### PR TITLE
docs: clarify performance stance in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,3 +41,12 @@ All work is tracked via GitHub Issue → branch → Pull Request. No direct comm
 - Job HASH field names (`data`, `opts`, `progress`, `returnvalue`, `stacktrace`, etc.) follow BullMQ.
 - State transitions and Lua script responsibilities mirror BullMQ v5+ (see design doc Section 5).
 - Divergence from BullMQ is allowed only at the API surface (Go generics / goroutines / context), never at the Redis wire format.
+
+## Performance stance
+
+Compatibility defines the wire format; it does not cap client implementation.
+
+- Encouraged on the client side: goroutine-based concurrency, go-redis pipelining, allocation-lean JSON handling, `time.AfterFunc` for delayed-job wakeup.
+- Non-negotiable: Redis payload shape, Lua atomic semantics, and cross-language queue sharing.
+- Optimizations that assume mkq is the sole writer of a queue must opt-out when foreign workers are detected.
+- Extended Lua scripts are additive, never replacements for BullMQ-equivalent scripts.


### PR DESCRIPTION
## Summary
- Add a Performance stance section to CLAUDE.md.
- Document the "compat = wire, optimization = client" split as a first-class design principle, complementing the existing BullMQ compatibility rules.

## Key Changes
- `CLAUDE.md`: +9 lines, new section describing encouraged Go-native client optimizations, non-negotiable wire constraints, and ground rules for mkq-only vs. cross-language-worker scenarios.

## Testing
- Docs-only change; no code or tests affected.

## Related
- Closes #2
- Parent: #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)