### PR TITLE
feat: Worker happy-path (Process / moveToActive / moveToFinished)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/lua/loader.go
+++ b/internal/lua/loader.go
@@ -19,6 +19,10 @@ const (
 	AddStandardJob    ScriptName = "addStandardJob-9"
 	AddDelayedJob     ScriptName = "addDelayedJob-6"
 	AddPrioritizedJob ScriptName = "addPrioritizedJob-9"
+	MoveToActive      ScriptName = "moveToActive-11"
+	MoveToFinished    ScriptName = "moveToFinished-14"
+	ExtendLock        ScriptName = "extendLock-2"
+	ReleaseLock       ScriptName = "releaseLock-1"
 )
 
 // Scripter executes vendored Lua scripts via EVALSHA, with transparent
@@ -45,7 +49,10 @@ func NewScripter(ctx context.Context, client redis.Scripter) (*Scripter, error) 
 		client:  client,
 		scripts: make(map[ScriptName]*loadedScript),
 	}
-	for _, name := range []ScriptName{AddStandardJob, AddDelayedJob, AddPrioritizedJob} {
+	for _, name := range []ScriptName{
+		AddStandardJob, AddDelayedJob, AddPrioritizedJob,
+		MoveToActive, MoveToFinished, ExtendLock, ReleaseLock,
+	} {
 		if _, err := s.load(ctx, name); err != nil {
 			return nil, fmt.Errorf("preload %s: %w", name, err)
 		}

--- a/internal/lua/preprocess_test.go
+++ b/internal/lua/preprocess_test.go
@@ -13,6 +13,10 @@ func TestPreprocess_VendoredEntryPoints(t *testing.T) {
 		"addStandardJob-9",
 		"addDelayedJob-6",
 		"addPrioritizedJob-9",
+		"moveToActive-11",
+		"moveToFinished-14",
+		"extendLock-2",
+		"releaseLock-1",
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/lua/scripts/UPSTREAM.md
+++ b/internal/lua/scripts/UPSTREAM.md
@@ -9,11 +9,18 @@ Lua scripts in this directory are vendored verbatim from BullMQ.
 
 ## Files vendored
 
+Entry points:
+
 - `addStandardJob-9.lua`
 - `addDelayedJob-6.lua`
 - `addPrioritizedJob-9.lua`
-- `includes/` — every script transitively reachable from the three entry
-  points above via `--- @include "..."` directives.
+- `moveToActive-11.lua`
+- `moveToFinished-14.lua`
+- `extendLock-2.lua`
+- `releaseLock-1.lua`
+
+`includes/` — every script transitively reachable from the entry points
+above via `--- @include "..."` directives.
 
 The `-N` suffix on entry-point scripts is the BullMQ convention for the
 expected `KEYS` count and is preserved verbatim.

--- a/internal/lua/scripts/extendLock-2.lua
+++ b/internal/lua/scripts/extendLock-2.lua
@@ -1,0 +1,23 @@
+--[[
+  Extend lock and removes the job from the stalled set.
+
+  Input:
+    KEYS[1] 'lock',
+    KEYS[2] 'stalled'
+
+    ARGV[1]  token
+    ARGV[2]  lock duration in milliseconds
+    ARGV[3]  jobid
+
+  Output:
+    "1" if lock extented succesfully.
+]]
+local rcall = redis.call
+if rcall("GET", KEYS[1]) == ARGV[1] then
+  --   if rcall("SET", KEYS[1], ARGV[1], "PX", ARGV[2], "XX") then
+  if rcall("SET", KEYS[1], ARGV[1], "PX", ARGV[2]) then
+    rcall("SREM", KEYS[2], ARGV[3])
+    return 1
+  end
+end
+return 0

--- a/internal/lua/scripts/includes/batches.lua
+++ b/internal/lua/scripts/includes/batches.lua
@@ -1,0 +1,18 @@
+--[[
+  Function to loop in batches.
+  Just a bit of warning, some commands as ZREM
+  could receive a maximum of 7000 parameters per call.
+]]
+
+local function batches(n, batchSize)
+  local i = 0
+
+  return function()
+    local from = i * batchSize + 1
+    i = i + 1
+    if (from <= n) then
+      local to = math.min(from + batchSize - 1, n)
+      return from, to
+    end
+  end
+end

--- a/internal/lua/scripts/includes/collectMetrics.lua
+++ b/internal/lua/scripts/includes/collectMetrics.lua
@@ -1,0 +1,46 @@
+--[[
+  Functions to collect metrics based on a current and previous count of jobs.
+  Granualarity is fixed at 1 minute.
+]]
+--- @include "batches"
+local function collectMetrics(metaKey, dataPointsList, maxDataPoints,
+                                 timestamp)
+    -- Increment current count
+    local count = rcall("HINCRBY", metaKey, "count", 1) - 1
+
+    -- Compute how many data points we need to add to the list, N.
+    local prevTS = rcall("HGET", metaKey, "prevTS")
+
+    if not prevTS then
+        -- If prevTS is nil, set it to the current timestamp
+        rcall("HSET", metaKey, "prevTS", timestamp, "prevCount", 0)
+        return
+    end
+
+    local N = math.min(math.floor(timestamp / 60000) - math.floor(prevTS / 60000), tonumber(maxDataPoints))
+
+    if N > 0 then
+        local delta = count - rcall("HGET", metaKey, "prevCount")
+        -- If N > 1, add N-1 zeros to the list
+        if N > 1 then
+            local points = {}
+            points[1] = delta
+            for i = 2, N do
+                points[i] = 0
+            end
+
+            for from, to in batches(#points, 7000) do
+                rcall("LPUSH", dataPointsList, unpack(points, from, to))
+            end
+        else
+            -- LPUSH delta to the list
+            rcall("LPUSH", dataPointsList, delta)
+        end
+
+        -- LTRIM to keep list to its max size
+        rcall("LTRIM", dataPointsList, 0, maxDataPoints - 1)
+
+        -- update prev count with current count
+        rcall("HSET", metaKey, "prevCount", count, "prevTS", timestamp)
+    end
+end

--- a/internal/lua/scripts/includes/destructureJobKey.lua
+++ b/internal/lua/scripts/includes/destructureJobKey.lua
@@ -1,0 +1,12 @@
+--[[
+  Functions to destructure job key.
+  Just a bit of warning, these functions may be a bit slow and affect performance significantly.
+]]
+
+local getJobIdFromKey = function (jobKey)
+  return string.match(jobKey, ".*:(.*)")
+end
+
+local getJobKeyPrefix = function (jobKey, jobId)
+  return string.sub(jobKey, 0, #jobKey - #jobId)
+end

--- a/internal/lua/scripts/includes/fetchNextJob.lua
+++ b/internal/lua/scripts/includes/fetchNextJob.lua
@@ -1,0 +1,95 @@
+--[[
+  Function to fetch the next job to process.
+  Tries to get the next job to avoid an extra roundtrip if the queue is
+  not closing and not rate limited.
+
+  Input:
+    waitKey - wait list key
+    activeKey - active list key
+    prioritizedKey - prioritized sorted set key
+    eventStreamKey - event stream key
+    rateLimiterKey - rate limiter key
+    delayedKey - delayed sorted set key
+    pausedKey - paused list key
+    metaKey - meta hash key
+    pcKey - priority counter key
+    markerKey - marker key
+    prefix - keys prefix
+    timestamp - current timestamp
+    opts - options table:
+      token (required) - lock token used when locking jobs
+      lockDuration (required) - lock duration for acquired jobs
+      limiter (optional) - rate limiter options table (e.g. { max = number })
+]]
+
+-- Includes
+--- @include "getNextDelayedTimestamp"
+--- @include "getRateLimitTTL"
+--- @include "getTargetQueueList"
+--- @include "moveJobFromPrioritizedToActive"
+--- @include "prepareJobForProcessing"
+--- @include "promoteDelayedJobs"
+
+local function fetchNextJob(waitKey, activeKey, prioritizedKey, eventStreamKey,
+    rateLimiterKey, delayedKey, pausedKey, metaKey, pcKey, markerKey, prefix,
+    timestamp, opts)
+
+    local target, isPausedOrMaxed, rateLimitMax, rateLimitDuration =
+        getTargetQueueList(metaKey, activeKey, waitKey, pausedKey)
+
+    -- Check if there are delayed jobs that can be promoted
+    promoteDelayedJobs(delayedKey, markerKey, target, prioritizedKey,
+        eventStreamKey, prefix, timestamp, pcKey, isPausedOrMaxed)
+
+    local maxJobs = tonumber(rateLimitMax or (opts['limiter'] and opts['limiter']['max']))
+    -- Check if we are rate limited first.
+    local expireTime = getRateLimitTTL(maxJobs, rateLimiterKey)
+
+    if expireTime > 0 then
+        return {0, 0, expireTime, 0}
+    end
+
+    -- paused or maxed queue
+    if isPausedOrMaxed then
+        return {0, 0, 0, 0}
+    end
+
+    local limiterDuration = (opts['limiter'] and opts['limiter']['duration']) or rateLimitDuration
+
+    local jobId = rcall("RPOPLPUSH", waitKey, activeKey)
+
+    if jobId then
+        -- Markers in waitlist DEPRECATED in v5: Remove in v6.
+        if string.sub(jobId, 1, 2) == "0:" then
+            rcall("LREM", activeKey, 1, jobId)
+
+            -- If jobId is special ID 0:delay (delay greater than 0), then there is no job to process
+            -- but if ID is 0:0, then there is at least 1 prioritized job to process
+            if jobId == "0:0" then
+                jobId = moveJobFromPrioritizedToActive(prioritizedKey, activeKey, pcKey)
+                return prepareJobForProcessing(prefix, rateLimiterKey,
+                    eventStreamKey, jobId, timestamp, maxJobs,
+                    limiterDuration, markerKey, opts)
+            end
+        else
+            return prepareJobForProcessing(prefix, rateLimiterKey,
+                eventStreamKey, jobId, timestamp, maxJobs,
+                limiterDuration, markerKey, opts)
+        end
+    else
+        jobId = moveJobFromPrioritizedToActive(prioritizedKey, activeKey, pcKey)
+        if jobId then
+            return prepareJobForProcessing(prefix, rateLimiterKey,
+                eventStreamKey, jobId, timestamp, maxJobs,
+                limiterDuration, markerKey, opts)
+        end
+    end
+
+    -- Return the timestamp for the next delayed job if any.
+    local nextTimestamp = getNextDelayedTimestamp(delayedKey)
+    if nextTimestamp ~= nil then
+        -- The result is guaranteed to be positive, since the
+        -- ZRANGEBYSCORE command would have return a job otherwise.
+        return {0, 0, 0, nextTimestamp}
+    end
+end

--- a/internal/lua/scripts/includes/getRateLimitTTL.lua
+++ b/internal/lua/scripts/includes/getRateLimitTTL.lua
@@ -1,0 +1,17 @@
+--[[
+  Function to get current rate limit ttl.
+]]
+local function getRateLimitTTL(maxJobs, rateLimiterKey)
+  if maxJobs and maxJobs <= tonumber(rcall("GET", rateLimiterKey) or 0) then
+    local pttl = rcall("PTTL", rateLimiterKey)
+
+    if pttl == 0 then
+      rcall("DEL", rateLimiterKey)
+    end
+
+    if pttl > 0 then
+      return pttl
+    end
+  end
+  return 0
+end

--- a/internal/lua/scripts/includes/moveChildFromDependenciesIfNeeded.lua
+++ b/internal/lua/scripts/includes/moveChildFromDependenciesIfNeeded.lua
@@ -1,0 +1,70 @@
+--[[
+  Function to recursively move from waitingChildren to failed.
+]]
+
+-- Includes
+--- @include "moveParentToWaitIfNoPendingDependencies"
+--- @include "moveParentToWaitIfNeeded"
+--- @include "moveParentToWait"
+
+local handleChildFailureAndMoveParentToWait = function (parentQueueKey, parentKey, parentId, jobIdKey, timestamp)
+  if rcall("EXISTS", parentKey) == 1 then
+    local parentWaitingChildrenKey = parentQueueKey .. ":waiting-children"
+    local parentDelayedKey = parentQueueKey .. ":delayed"
+    local parentWaitingChildrenOrDelayedKey
+    if rcall("ZSCORE", parentWaitingChildrenKey, parentId) then
+      parentWaitingChildrenOrDelayedKey = parentWaitingChildrenKey
+    elseif rcall("ZSCORE", parentDelayedKey, parentId) then
+      parentWaitingChildrenOrDelayedKey = parentDelayedKey
+      rcall("HSET", parentKey, "delay", 0)
+    end
+
+    if parentWaitingChildrenOrDelayedKey then
+      rcall("ZREM", parentWaitingChildrenOrDelayedKey, parentId)
+      local deferredFailure = "child " .. jobIdKey .. " failed"
+      rcall("HSET", parentKey, "defa", deferredFailure)
+      moveParentToWait(parentQueueKey, parentKey, parentId, timestamp)
+    else
+      if not rcall("ZSCORE", parentQueueKey .. ":failed", parentId) then
+        local deferredFailure = "child " .. jobIdKey .. " failed"
+        rcall("HSET", parentKey, "defa", deferredFailure)
+      end
+    end
+  end
+end
+
+local moveChildFromDependenciesIfNeeded = function (rawParentData, childKey, failedReason, timestamp)
+  if rawParentData then
+    local parentData = cjson.decode(rawParentData)
+    local parentKey = parentData['queueKey'] .. ':' .. parentData['id']
+    local parentDependenciesChildrenKey = parentKey .. ":dependencies"
+    if parentData['fpof'] then
+      if rcall("SREM", parentDependenciesChildrenKey, childKey) == 1 then
+        local parentUnsuccessfulChildrenKey = parentKey .. ":unsuccessful"
+        rcall("ZADD", parentUnsuccessfulChildrenKey, timestamp, childKey)
+        handleChildFailureAndMoveParentToWait(
+          parentData['queueKey'],
+          parentKey,
+          parentData['id'],
+          childKey,
+          timestamp
+        )
+      end
+    elseif parentData['cpof'] then
+      if rcall("SREM", parentDependenciesChildrenKey, childKey) == 1 then
+        local parentFailedChildrenKey = parentKey .. ":failed"
+        rcall("HSET", parentFailedChildrenKey, childKey, failedReason)
+        moveParentToWaitIfNeeded(parentData['queueKey'], parentKey, parentData['id'], timestamp)
+      end
+    elseif parentData['idof'] or parentData['rdof'] then
+      if rcall("SREM", parentDependenciesChildrenKey, childKey) == 1 then
+        moveParentToWaitIfNoPendingDependencies(parentData['queueKey'], parentDependenciesChildrenKey,
+          parentKey, parentData['id'], timestamp)
+        if parentData['idof'] then
+          local parentFailedChildrenKey = parentKey .. ":failed"
+          rcall("HSET", parentFailedChildrenKey, childKey, failedReason)
+        end
+      end
+    end
+  end
+end

--- a/internal/lua/scripts/includes/moveJobFromPrioritizedToActive.lua
+++ b/internal/lua/scripts/includes/moveJobFromPrioritizedToActive.lua
@@ -1,0 +1,13 @@
+--[[
+  Function to move job from prioritized state to active.
+]]
+
+local function moveJobFromPrioritizedToActive(priorityKey, activeKey, priorityCounterKey)
+  local prioritizedJob = rcall("ZPOPMIN", priorityKey)
+  if #prioritizedJob > 0 then
+    rcall("LPUSH", activeKey, prioritizedJob[1])
+    return prioritizedJob[1]
+  else
+    rcall("DEL", priorityCounterKey)
+  end
+end

--- a/internal/lua/scripts/includes/prepareJobForProcessing.lua
+++ b/internal/lua/scripts/includes/prepareJobForProcessing.lua
@@ -1,0 +1,49 @@
+--[[
+  Function to move job from wait state to active.
+  Input:
+    opts - token - lock token
+    opts - lockDuration
+    opts - limiter
+]]
+
+-- Includes
+--- @include "addBaseMarkerIfNeeded"
+
+local function prepareJobForProcessing(keyPrefix, rateLimiterKey, eventStreamKey,
+    jobId, processedOn, maxJobs, limiterDuration, markerKey, opts)
+  local jobKey = keyPrefix .. jobId
+
+  -- Check if we need to perform rate limiting.
+  if maxJobs then
+    local jobCounter = tonumber(rcall("INCR", rateLimiterKey))
+
+    if jobCounter == 1 then
+      local integerDuration = math.floor(math.abs(limiterDuration))
+      rcall("PEXPIRE", rateLimiterKey, integerDuration)
+    end
+  end
+
+  -- get a lock
+  if opts['token'] ~= "0" then
+    local lockKey = jobKey .. ':lock'
+    rcall("SET", lockKey, opts['token'], "PX", opts['lockDuration'])
+  end
+
+  local optionalValues = {}
+
+  if opts['name'] then
+    -- Set "processedBy" field to the worker name
+    table.insert(optionalValues, "pb")
+    table.insert(optionalValues, opts['name'])
+  end
+
+  rcall("XADD", eventStreamKey, "*", "event", "active", "jobId", jobId, "prev", "waiting")
+  rcall("HMSET", jobKey, "processedOn", processedOn, unpack(optionalValues))
+  rcall("HINCRBY", jobKey, "ats", 1)
+
+  addBaseMarkerIfNeeded(markerKey, false)
+
+  -- rate limit delay must be 0 in this case to prevent adding more delay
+  -- when job that is moved to active needs to be processed
+  return {rcall("HGETALL", jobKey), jobId, 0, 0} -- get job data
+end

--- a/internal/lua/scripts/includes/promoteDelayedJobs.lua
+++ b/internal/lua/scripts/includes/promoteDelayedJobs.lua
@@ -1,0 +1,44 @@
+--[[
+  Updates the delay set, by moving delayed jobs that should
+  be processed now to "wait".
+
+     Events:
+      'waiting'
+]]
+
+-- Includes
+--- @include "addBaseMarkerIfNeeded"
+--- @include "addJobInTargetList"
+--- @include "addJobWithPriority"
+--- @include "getPriorityScore"
+
+-- Try to get as much as 1000 jobs at once
+local function promoteDelayedJobs(delayedKey, markerKey, targetKey, prioritizedKey,
+                                  eventStreamKey, prefix, timestamp, priorityCounterKey, isPaused)
+    local jobs = rcall("ZRANGEBYSCORE", delayedKey, 0, (timestamp + 1) * 0x1000 - 1, "LIMIT", 0, 1000)
+
+    if (#jobs > 0) then
+        rcall("ZREM", delayedKey, unpack(jobs))
+
+        for _, jobId in ipairs(jobs) do
+            local jobKey = prefix .. jobId
+            local priority =
+                tonumber(rcall("HGET", jobKey, "priority")) or 0
+
+            if priority == 0 then
+                -- LIFO or FIFO
+                rcall("LPUSH", targetKey, jobId)
+            else
+                local score = getPriorityScore(priority, priorityCounterKey)
+                rcall("ZADD", prioritizedKey, score, jobId)
+            end
+
+            -- Emit waiting event
+            rcall("XADD", eventStreamKey, "*", "event", "waiting", "jobId",
+                  jobId, "prev", "delayed")
+            rcall("HSET", jobKey, "delay", 0)
+        end
+
+        addBaseMarkerIfNeeded(markerKey, isPaused)
+    end
+end

--- a/internal/lua/scripts/includes/removeDeduplicationKeyIfNeededOnFinalization.lua
+++ b/internal/lua/scripts/includes/removeDeduplicationKeyIfNeededOnFinalization.lua
@@ -1,0 +1,23 @@
+--[[
+  Function to remove deduplication key if needed
+  when a job is moved to completed or failed states.
+]]
+
+local function removeDeduplicationKeyIfNeededOnFinalization(prefixKey,
+  deduplicationId, jobId)
+  if deduplicationId then
+    local deduplicationKey = prefixKey .. "de:" .. deduplicationId
+    local pttl = rcall("PTTL", deduplicationKey)
+
+    if pttl == 0 then
+      return rcall("DEL", deduplicationKey)
+    end
+
+    if pttl == -1 then
+      local currentJobId = rcall('GET', deduplicationKey)
+      if currentJobId and currentJobId == jobId then
+        return rcall("DEL", deduplicationKey)
+      end
+    end
+  end
+end

--- a/internal/lua/scripts/includes/removeDeduplicationKeyIfNeededOnRemoval.lua
+++ b/internal/lua/scripts/includes/removeDeduplicationKeyIfNeededOnRemoval.lua
@@ -1,0 +1,18 @@
+--[[
+  Function to remove deduplication key if needed
+  when a job is being removed.
+]]
+
+local function removeDeduplicationKeyIfNeededOnRemoval(prefixKey,
+  jobId, deduplicationId)
+  if deduplicationId then
+    local deduplicationKey = prefixKey .. "de:" .. deduplicationId
+    local currentJobId = rcall('GET', deduplicationKey)
+    if currentJobId and currentJobId == jobId then
+      rcall("DEL", deduplicationKey)
+      -- Also clean up any pending dedup-next data for this dedup ID
+      rcall("DEL", prefixKey .. "dn:" .. deduplicationId)
+      return 1
+    end
+  end
+end

--- a/internal/lua/scripts/includes/removeJob.lua
+++ b/internal/lua/scripts/includes/removeJob.lua
@@ -1,0 +1,18 @@
+--[[
+  Function to remove job.
+]]
+
+-- Includes
+--- @include "removeDeduplicationKeyIfNeededOnRemoval"
+--- @include "removeJobKeys"
+--- @include "removeParentDependencyKey"
+
+local function removeJob(jobId, hard, baseKey, shouldRemoveDeduplicationKey)
+  local jobKey = baseKey .. jobId
+  removeParentDependencyKey(jobKey, hard, nil, baseKey)
+  if shouldRemoveDeduplicationKey then
+    local deduplicationId = rcall("HGET", jobKey, "deid")
+    removeDeduplicationKeyIfNeededOnRemoval(baseKey, jobId, deduplicationId)
+  end
+  removeJobKeys(jobKey)
+end

--- a/internal/lua/scripts/includes/removeJobsByMaxAge.lua
+++ b/internal/lua/scripts/includes/removeJobsByMaxAge.lua
@@ -1,0 +1,24 @@
+--[[
+  Functions to remove jobs by max age.
+]]
+
+-- Includes
+--- @include "batches"
+--- @include "removeJob"
+
+local function removeJobsByMaxAge(timestamp, maxAge, targetSet, prefix, maxLimit)
+  local start = timestamp - maxAge * 1000
+  local jobIds = rcall("ZREVRANGEBYSCORE", targetSet, start, "-inf", "LIMIT", 0, maxLimit)
+  for i, jobId in ipairs(jobIds) do
+    removeJob(jobId, false, prefix, false --[[remove debounce key]])
+  end
+  if #jobIds > 0 then
+    if #jobIds < maxLimit then
+      rcall("ZREMRANGEBYSCORE", targetSet, "-inf", start)
+    else
+      for from, to in batches(#jobIds, 7000) do
+        rcall("ZREM", targetSet, unpack(jobIds, from, to))
+      end
+    end
+  end
+end

--- a/internal/lua/scripts/includes/removeJobsByMaxCount.lua
+++ b/internal/lua/scripts/includes/removeJobsByMaxCount.lua
@@ -1,0 +1,15 @@
+--[[
+  Functions to remove jobs by max count.
+]]
+
+-- Includes
+--- @include "removeJob"
+
+local function removeJobsByMaxCount(maxCount, targetSet, prefix)
+  local start = maxCount
+  local jobIds = rcall("ZREVRANGE", targetSet, start, -1)
+  for i, jobId in ipairs(jobIds) do
+    removeJob(jobId, false, prefix, false --[[remove debounce key]])
+  end
+  rcall("ZREMRANGEBYRANK", targetSet, 0, -(maxCount + 1))
+end

--- a/internal/lua/scripts/includes/removeLock.lua
+++ b/internal/lua/scripts/includes/removeLock.lua
@@ -1,0 +1,19 @@
+local function removeLock(jobKey, stalledKey, token, jobId)
+  if token ~= "0" then
+    local lockKey = jobKey .. ':lock'
+    local lockToken = rcall("GET", lockKey)
+    if lockToken == token then
+      rcall("DEL", lockKey)
+      rcall("SREM", stalledKey, jobId)
+    else
+      if lockToken then
+        -- Lock exists but token does not match
+        return -6
+      else
+        -- Lock is missing completely
+        return -2
+      end
+    end
+  end
+  return 0
+end

--- a/internal/lua/scripts/includes/removeParentDependencyKey.lua
+++ b/internal/lua/scripts/includes/removeParentDependencyKey.lua
@@ -1,0 +1,90 @@
+--[[
+  Check if this job has a parent. If so we will just remove it from
+  the parent child list, but if it is the last child we should move the parent to "wait/paused"
+  which requires code from "moveToFinished"
+]]
+
+-- Includes
+--- @include "addJobInTargetList"
+--- @include "destructureJobKey"
+--- @include "getTargetQueueList"
+--- @include "removeJobKeys"
+
+local function _moveParentToWait(parentPrefix, parentId, emitEvent)
+  local parentTarget, isPausedOrMaxed = getTargetQueueList(parentPrefix .. "meta", parentPrefix .. "active",
+    parentPrefix .. "wait", parentPrefix .. "paused")
+  addJobInTargetList(parentTarget, parentPrefix .. "marker", "RPUSH", isPausedOrMaxed, parentId)
+
+  if emitEvent then
+    local parentEventStream = parentPrefix .. "events"
+    rcall("XADD", parentEventStream, "*", "event", "waiting", "jobId", parentId, "prev", "waiting-children")
+  end
+end
+
+local function removeParentDependencyKey(jobKey, hard, parentKey, baseKey, debounceId)
+  if parentKey then
+    local parentDependenciesKey = parentKey .. ":dependencies"
+    local result = rcall("SREM", parentDependenciesKey, jobKey)
+    if result > 0 then
+      local pendingDependencies = rcall("SCARD", parentDependenciesKey)
+      if pendingDependencies == 0 then
+        local parentId = getJobIdFromKey(parentKey)
+        local parentPrefix = getJobKeyPrefix(parentKey, parentId)
+
+        local numRemovedElements = rcall("ZREM", parentPrefix .. "waiting-children", parentId)
+
+        if numRemovedElements == 1 then
+          if hard then -- remove parent in same queue
+            if parentPrefix == baseKey then
+              removeParentDependencyKey(parentKey, hard, nil, baseKey, nil)
+              removeJobKeys(parentKey)
+              if debounceId then
+                rcall("DEL", parentPrefix .. "de:" .. debounceId)
+              end
+            else
+              _moveParentToWait(parentPrefix, parentId)
+            end
+          else
+            _moveParentToWait(parentPrefix, parentId, true)
+          end
+        end
+      end
+      return true
+    end
+  else
+    local parentAttributes = rcall("HMGET", jobKey, "parentKey", "deid")
+    local missedParentKey = parentAttributes[1]
+    if( (type(missedParentKey) == "string") and missedParentKey ~= ""
+      and (rcall("EXISTS", missedParentKey) == 1)) then
+      local parentDependenciesKey = missedParentKey .. ":dependencies"
+      local result = rcall("SREM", parentDependenciesKey, jobKey)
+      if result > 0 then
+        local pendingDependencies = rcall("SCARD", parentDependenciesKey)
+        if pendingDependencies == 0 then
+          local parentId = getJobIdFromKey(missedParentKey)
+          local parentPrefix = getJobKeyPrefix(missedParentKey, parentId)
+
+          local numRemovedElements = rcall("ZREM", parentPrefix .. "waiting-children", parentId)
+
+          if numRemovedElements == 1 then
+            if hard then
+              if parentPrefix == baseKey then
+                removeParentDependencyKey(missedParentKey, hard, nil, baseKey, nil)
+                removeJobKeys(missedParentKey)
+                if parentAttributes[2] then
+                  rcall("DEL", parentPrefix .. "de:" .. parentAttributes[2])
+                end
+              else
+                _moveParentToWait(parentPrefix, parentId)
+              end
+            else
+              _moveParentToWait(parentPrefix, parentId, true)
+            end
+          end
+        end
+        return true
+      end
+    end
+  end
+  return false
+end

--- a/internal/lua/scripts/includes/requeueDeduplicatedJob.lua
+++ b/internal/lua/scripts/includes/requeueDeduplicatedJob.lua
@@ -1,0 +1,57 @@
+--[[
+  Function to create a new job from stored dedup-next data
+  when a deduplicated job with keepLastIfActive finishes.
+  At most one next job is created per deduplication ID.
+  Multiple triggers while active overwrite the dedup-next data,
+  so only the latest data is used.
+]]
+
+-- Includes
+--- @include "getOrSetMaxEvents"
+--- @include "setDeduplicationKey"
+--- @include "storeAndEnqueueJob"
+
+local function requeueDeduplicatedJob(prefix, deduplicationId, eventStreamKey,
+    metaKey, activeKey, waitKey, pausedKey, markerKey, prioritizedKey,
+    priorityCounterKey, delayedKey, timestamp)
+  local deduplicationNextKey = prefix .. "dn:" .. deduplicationId
+  if rcall("EXISTS", deduplicationNextKey) == 1 then
+    local nextData = rcall("HMGET", deduplicationNextKey,
+        "name", "data", "opts", "pk", "pd", "pdk", "rjk")
+
+    local newJobId = rcall("INCR", prefix .. "id") .. ""
+    local newJobIdKey = prefix .. newJobId
+    local newOpts = cjson.decode(nextData[3])
+    local deduplicationKey = prefix .. "de:" .. deduplicationId
+
+    local parentKey = nextData[4] or nil
+    local parentData = nextData[5] or nil
+    local parentDependenciesKey = nextData[6] or nil
+    local repeatJobKey = nextData[7] or nil
+
+    -- Set dedup key for the new job (without TTL when keepLastIfActive,
+    -- so the key outlives the job's active duration)
+    local deOpts = newOpts['de']
+    if deOpts and deOpts['keepLastIfActive'] then
+      rcall('SET', deduplicationKey, newJobId)
+    else
+      setDeduplicationKey(deduplicationKey, newJobId, deOpts)
+    end
+
+    -- Store and enqueue using the shared helper (handles priority/lifo/delayed)
+    local maxEvents = getOrSetMaxEvents(metaKey)
+    storeAndEnqueueJob(eventStreamKey, newJobIdKey, newJobId, nextData[1], nextData[2],
+        newOpts, timestamp, parentKey, parentData, repeatJobKey, maxEvents,
+        waitKey, pausedKey, activeKey, metaKey, prioritizedKey,
+        priorityCounterKey, delayedKey, markerKey)
+
+    -- Register as child dependency if the job has a parent
+    if parentDependenciesKey then
+      rcall("SADD", parentDependenciesKey, newJobIdKey)
+    end
+
+    -- Only delete the dedup-next hash after the job is fully created,
+    -- so that if any step above errors, the data is not permanently lost.
+    rcall("DEL", deduplicationNextKey)
+  end
+end

--- a/internal/lua/scripts/includes/storeAndEnqueueJob.lua
+++ b/internal/lua/scripts/includes/storeAndEnqueueJob.lua
@@ -1,0 +1,42 @@
+--[[
+  Shared helper to store a job and enqueue it into the appropriate list/set.
+  Handles delayed, prioritized, and standard (LIFO/FIFO) jobs.
+  Emits the appropriate event after enqueuing ("delayed" or "waiting").
+
+  Returns delay, priority from storeJob.
+]]
+
+-- Includes
+--- @include "addDelayedJob"
+--- @include "addJobInTargetList"
+--- @include "addJobWithPriority"
+--- @include "getTargetQueueList"
+--- @include "storeJob"
+
+local function storeAndEnqueueJob(eventsKey, jobIdKey, jobId, name, data, opts,
+    timestamp, parentKey, parentData, repeatJobKey, maxEvents,
+    waitKey, pausedKey, activeKey, metaKey, prioritizedKey,
+    priorityCounterKey, delayedKey, markerKey)
+
+  local delay, priority = storeJob(eventsKey, jobIdKey, jobId, name, data,
+      opts, timestamp, parentKey, parentData, repeatJobKey)
+
+  if delay ~= 0 and delayedKey then
+    addDelayedJob(jobId, delayedKey, eventsKey, timestamp, maxEvents, markerKey, delay)
+  else
+    local target, isPausedOrMaxed = getTargetQueueList(metaKey, activeKey, waitKey, pausedKey)
+
+    if priority > 0 then
+      addJobWithPriority(markerKey, prioritizedKey, priority, jobId,
+          priorityCounterKey, isPausedOrMaxed)
+    else
+      local pushCmd = opts['lifo'] and 'RPUSH' or 'LPUSH'
+      addJobInTargetList(target, markerKey, pushCmd, isPausedOrMaxed, jobId)
+    end
+
+    rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event", "waiting",
+        "jobId", jobId)
+  end
+
+  return delay, priority
+end

--- a/internal/lua/scripts/includes/trimEvents.lua
+++ b/internal/lua/scripts/includes/trimEvents.lua
@@ -1,0 +1,15 @@
+--[[
+  Function to trim events, default 10000.
+]]
+
+-- Includes
+--- @include "getOrSetMaxEvents"
+
+local function trimEvents(metaKey, eventStreamKey)
+  local maxEvents = getOrSetMaxEvents(metaKey)
+  if maxEvents then
+    rcall("XTRIM", eventStreamKey, "MAXLEN", "~", maxEvents)
+  else
+    rcall("XTRIM", eventStreamKey, "MAXLEN", "~", 10000)
+  end
+end

--- a/internal/lua/scripts/includes/updateJobFields.lua
+++ b/internal/lua/scripts/includes/updateJobFields.lua
@@ -1,0 +1,11 @@
+--[[
+  Function to update a bunch of fields in a job.
+]]
+local function updateJobFields(jobKey, msgpackedFields)
+  if msgpackedFields and #msgpackedFields > 0 then
+    local fieldsToUpdate = cmsgpack.unpack(msgpackedFields)
+    if fieldsToUpdate then
+      rcall("HMSET", jobKey, unpack(fieldsToUpdate))
+    end
+  end
+end

--- a/internal/lua/scripts/moveToActive-11.lua
+++ b/internal/lua/scripts/moveToActive-11.lua
@@ -1,0 +1,97 @@
+--[[
+  Move next job to be processed to active, lock it and fetch its data. The job
+  may be delayed, in that case we need to move it to the delayed set instead.
+
+  This operation guarantees that the worker owns the job during the lock
+  expiration time. The worker is responsible of keeping the lock fresh
+  so that no other worker picks this job again.
+
+  Input:
+    KEYS[1] wait key
+    KEYS[2] active key
+    KEYS[3] prioritized key
+    KEYS[4] stream events key
+    KEYS[5] stalled key
+
+    -- Rate limiting
+    KEYS[6] rate limiter key
+    KEYS[7] delayed key
+
+    -- Delayed jobs
+    KEYS[8] paused key
+    KEYS[9] meta key
+    KEYS[10] pc priority counter
+
+    -- Marker
+    KEYS[11] marker key
+
+    -- Arguments
+    ARGV[1] key prefix
+    ARGV[2] timestamp
+    ARGV[3] opts
+
+    opts - token - lock token
+    opts - lockDuration
+    opts - limiter
+    opts - name - worker name
+]]
+local rcall = redis.call
+local waitKey = KEYS[1]
+local activeKey = KEYS[2]
+local eventStreamKey = KEYS[4]
+local rateLimiterKey = KEYS[6]
+local delayedKey = KEYS[7]
+local opts = cmsgpack.unpack(ARGV[3])
+
+-- Includes
+--- @include "includes/getNextDelayedTimestamp"
+--- @include "includes/getRateLimitTTL"
+--- @include "includes/getTargetQueueList"
+--- @include "includes/moveJobFromPrioritizedToActive"
+--- @include "includes/prepareJobForProcessing"
+--- @include "includes/promoteDelayedJobs"
+
+local target, isPausedOrMaxed, rateLimitMax, rateLimitDuration = getTargetQueueList(KEYS[9],
+    activeKey, waitKey, KEYS[8])
+
+-- Check if there are delayed jobs that we can move to wait.
+local markerKey = KEYS[11]
+promoteDelayedJobs(delayedKey, markerKey, target, KEYS[3], eventStreamKey, ARGV[1],
+                   ARGV[2], KEYS[10], isPausedOrMaxed)
+
+local maxJobs = tonumber(rateLimitMax or (opts['limiter'] and opts['limiter']['max']))
+local expireTime = getRateLimitTTL(maxJobs, rateLimiterKey)
+
+-- Check if we are rate limited first.
+if expireTime > 0 then return {0, 0, expireTime, 0} end
+
+-- paused or maxed queue
+if isPausedOrMaxed then return {0, 0, 0, 0} end
+
+local limiterDuration = (opts['limiter'] and opts['limiter']['duration']) or rateLimitDuration
+
+-- no job ID, try non-blocking move from wait to active
+local jobId = rcall("RPOPLPUSH", waitKey, activeKey)
+
+-- Markers in waitlist DEPRECATED in v5: Will be completely removed in v6.
+if jobId and string.sub(jobId, 1, 2) == "0:" then
+    rcall("LREM", activeKey, 1, jobId)
+    jobId = rcall("RPOPLPUSH", waitKey, activeKey)
+end
+
+if jobId then
+    return prepareJobForProcessing(ARGV[1], rateLimiterKey, eventStreamKey, jobId, ARGV[2],
+                                   maxJobs, limiterDuration, markerKey, opts)
+else
+    jobId = moveJobFromPrioritizedToActive(KEYS[3], activeKey, KEYS[10])
+    if jobId then
+        return prepareJobForProcessing(ARGV[1], rateLimiterKey, eventStreamKey, jobId, ARGV[2],
+                                       maxJobs, limiterDuration, markerKey, opts)
+    end
+end
+
+-- Return the timestamp for the next delayed job if any.
+local nextTimestamp = getNextDelayedTimestamp(delayedKey)
+if nextTimestamp ~= nil then return {0, 0, 0, nextTimestamp} end
+
+return {0, 0, 0, 0}

--- a/internal/lua/scripts/moveToFinished-14.lua
+++ b/internal/lua/scripts/moveToFinished-14.lua
@@ -1,0 +1,239 @@
+--[[
+  Move job from active to a finished status (completed o failed)
+  A job can only be moved to completed if it was active.
+  The job must be locked before it can be moved to a finished status,
+  and the lock must be released in this script.
+
+    Input:
+      KEYS[1] wait key
+      KEYS[2] active key
+      KEYS[3] prioritized key
+      KEYS[4] event stream key
+      KEYS[5] stalled key
+
+      -- Rate limiting
+      KEYS[6] rate limiter key
+      KEYS[7] delayed key
+
+      KEYS[8] paused key
+      KEYS[9] meta key
+      KEYS[10] pc priority counter
+
+      KEYS[11] completed/failed key
+      KEYS[12] jobId key
+      KEYS[13] metrics key
+      KEYS[14] marker key
+
+      ARGV[1]  jobId
+      ARGV[2]  timestamp
+      ARGV[3]  msg property returnvalue / failedReason
+      ARGV[4]  return value / failed reason
+      ARGV[5]  target (completed/failed)
+      ARGV[6]  fetch next?
+      ARGV[7]  keys prefix
+      ARGV[8]  opts
+      ARGV[9]  job fields to update
+
+      opts - token - lock token
+      opts - keepJobs
+      opts - lockDuration - lock duration in milliseconds
+      opts - attempts max attempts
+      opts - maxMetricsSize
+      opts - fpof - fail parent on fail
+      opts - cpof - continue parent on fail
+      opts - idof - ignore dependency on fail
+      opts - rdof - remove dependency on fail
+      opts - name - worker name
+
+    Output:
+      0 OK
+      -1 Missing key.
+      -2 Missing lock.
+      -3 Job not in active set
+      -4 Job has pending children
+      -6 Lock is not owned by this client
+      -9 Job has failed children
+
+    Events:
+      'completed/failed'
+]]
+local rcall = redis.call
+
+--- Includes
+--- @include "includes/collectMetrics"
+--- @include "includes/fetchNextJob"
+--- @include "includes/moveChildFromDependenciesIfNeeded"
+--- @include "includes/removeDeduplicationKeyIfNeededOnFinalization"
+--- @include "includes/removeJobKeys"
+--- @include "includes/removeJobsByMaxAge"
+--- @include "includes/removeJobsByMaxCount"
+--- @include "includes/removeLock"
+--- @include "includes/removeParentDependencyKey"
+--- @include "includes/requeueDeduplicatedJob"
+--- @include "includes/trimEvents"
+--- @include "includes/updateParentDepsIfNeeded"
+--- @include "includes/updateJobFields"
+
+local jobIdKey = KEYS[12]
+if rcall("EXISTS", jobIdKey) == 1 then -- Make sure job exists
+    -- Make sure it does not have pending dependencies
+    -- It must happen before removing lock
+    if ARGV[5] == "completed" then
+        if rcall("SCARD", jobIdKey .. ":dependencies") ~= 0 then
+            return -4
+        end
+
+        if rcall("ZCARD", jobIdKey .. ":unsuccessful") ~= 0 then
+            return -9
+        end
+    end
+
+    local opts = cmsgpack.unpack(ARGV[8])
+
+    local token = opts['token']
+
+    local errorCode = removeLock(jobIdKey, KEYS[5], token, ARGV[1])
+    if errorCode < 0 then
+        return errorCode
+    end
+
+    updateJobFields(jobIdKey, ARGV[9]);
+
+    local attempts = opts['attempts']
+    local maxMetricsSize = opts['maxMetricsSize']
+    local maxCount = opts['keepJobs']['count']
+    local maxAge = opts['keepJobs']['age']
+    local maxLimit = opts['keepJobs']['limit'] or 1000
+
+    local jobAttributes = rcall("HMGET", jobIdKey, "parentKey", "parent", "deid")
+    local parentKey = jobAttributes[1] or ""
+    local parentId = ""
+    local parentQueueKey = ""
+    if jobAttributes[2] then -- TODO: need to revisit this logic if it's still needed
+        local jsonDecodedParent = cjson.decode(jobAttributes[2])
+        parentId = jsonDecodedParent['id']
+        parentQueueKey = jsonDecodedParent['queueKey']
+    end
+
+    local jobId = ARGV[1]
+    local timestamp = ARGV[2]
+
+    -- Remove from active list (if not active we shall return error)
+    local numRemovedElements = rcall("LREM", KEYS[2], -1, jobId)
+
+    if (numRemovedElements < 1) then
+        return -3
+    end
+
+    local eventStreamKey = KEYS[4]
+    local metaKey = KEYS[9]
+    -- Trim events before emiting them to avoid trimming events emitted in this script
+    trimEvents(metaKey, eventStreamKey)
+
+    local prefix = ARGV[7]
+
+    removeDeduplicationKeyIfNeededOnFinalization(prefix, jobAttributes[3], jobId)
+
+    -- Check if there is requeue data for this dedup ID (keepLastIfActive mode)
+    if jobAttributes[3] then
+      requeueDeduplicatedJob(prefix, jobAttributes[3], eventStreamKey,
+          metaKey, KEYS[2], KEYS[1], KEYS[8], KEYS[14], KEYS[3], KEYS[10],
+          KEYS[7], timestamp)
+    end
+
+    -- If job has a parent we need to
+    -- 1) remove this job id from parents dependencies
+    -- 2) move the job Id to parent "processed" set
+    -- 3) push the results into parent "results" list
+    -- 4) if parent's dependencies is empty, then move parent to "wait/paused". Note it may be a different queue!.
+    if parentId == "" and parentKey ~= "" then
+        parentId = getJobIdFromKey(parentKey)
+        parentQueueKey = getJobKeyPrefix(parentKey, ":" .. parentId)
+    end
+
+    if parentId ~= "" then
+        if ARGV[5] == "completed" then
+            local dependenciesSet = parentKey .. ":dependencies"
+            if rcall("SREM", dependenciesSet, jobIdKey) == 1 then
+                updateParentDepsIfNeeded(parentKey, parentQueueKey, dependenciesSet, parentId, jobIdKey, ARGV[4],
+                    timestamp)
+            end
+        else
+            moveChildFromDependenciesIfNeeded(jobAttributes[2], jobIdKey, ARGV[4], timestamp)
+        end
+    end
+
+    local attemptsMade = rcall("HINCRBY", jobIdKey, "atm", 1)
+
+    -- Remove job?
+    if maxCount ~= 0 then
+        local targetSet = KEYS[11]
+        -- Add to complete/failed set
+        rcall("ZADD", targetSet, timestamp, jobId)
+        rcall("HSET", jobIdKey, ARGV[3], ARGV[4], "finishedOn", timestamp)
+        -- "returnvalue" / "failedReason" and "finishedOn"
+
+        if ARGV[5] == "failed" then
+            rcall("HDEL", jobIdKey, "defa")
+        end
+
+        -- Remove old jobs?
+        if maxAge ~= nil then
+            removeJobsByMaxAge(timestamp, maxAge, targetSet, prefix, maxLimit)
+        end
+
+        if maxCount ~= nil and maxCount > 0 then
+            removeJobsByMaxCount(maxCount, targetSet, prefix)
+        end
+    else
+        removeJobKeys(jobIdKey)
+        if parentKey ~= "" then
+            -- TODO: when a child is removed when finished, result or failure in parent
+            -- must not be deleted, those value references should be deleted when the parent
+            -- is deleted
+            removeParentDependencyKey(jobIdKey, false, parentKey, jobAttributes[3])
+        end
+    end
+
+    rcall("XADD", eventStreamKey, "*", "event", ARGV[5], "jobId", jobId, ARGV[3], ARGV[4], "prev", "active")
+
+    if ARGV[5] == "failed" then
+        if tonumber(attemptsMade) >= tonumber(attempts) then
+            rcall("XADD", eventStreamKey, "*", "event", "retries-exhausted", "jobId", jobId, "attemptsMade",
+                attemptsMade)
+        end
+    end
+
+    -- Collect metrics
+    if maxMetricsSize ~= "" then
+        collectMetrics(KEYS[13], KEYS[13] .. ':data', maxMetricsSize, timestamp)
+    end
+
+    -- Try to get next job to avoid an extra roundtrip if the queue is not closing,
+    -- and not rate limited.
+    if (ARGV[6] == "1") then
+        local result = fetchNextJob(KEYS[1], KEYS[2], KEYS[3], eventStreamKey,
+            KEYS[6], KEYS[7], KEYS[8], metaKey, KEYS[10], KEYS[14], prefix,
+            timestamp, opts)
+        if result then
+            return result
+        end
+    end
+
+    local waitLen = rcall("LLEN", KEYS[1])
+    if waitLen == 0 then
+        local activeLen = rcall("LLEN", KEYS[2])
+
+        if activeLen == 0 then
+            local prioritizedLen = rcall("ZCARD", KEYS[3])
+
+            if prioritizedLen == 0 then
+                rcall("XADD", eventStreamKey, "*", "event", "drained")
+            end
+        end
+    end
+
+    return 0
+else
+    return -1
+end

--- a/internal/lua/scripts/releaseLock-1.lua
+++ b/internal/lua/scripts/releaseLock-1.lua
@@ -1,0 +1,19 @@
+--[[
+  Release lock
+
+    Input:
+      KEYS[1] 'lock',
+    
+      ARGV[1]  token
+      ARGV[2]  lock duration in milliseconds
+      
+    Output:
+      "OK" if lock extented succesfully.
+]]
+local rcall = redis.call
+
+if rcall("GET", KEYS[1]) == ARGV[1] then
+  return rcall("DEL", KEYS[1])
+else
+  return 0
+end

--- a/internal/proto/finish_args.go
+++ b/internal/proto/finish_args.go
@@ -1,0 +1,86 @@
+package proto
+
+import (
+	"errors"
+
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// MoveToFinishedOpts is the BullMQ "opts" map consumed by
+// moveToFinished-14.lua via cmsgpack.unpack of ARGV[8].
+//
+// The Lua reads opts['token'] / opts['lockDuration'] for ownership
+// validation, opts['attempts'] for retry decisions, opts['keepJobs']
+// for retention trimming, and opts['name'] for attribution. Worker
+// fields the basic happy-path doesn't expose (fpof, cpof, idof, rdof,
+// maxMetricsSize) stay omitted.
+type MoveToFinishedOpts struct {
+	Token        string
+	LockDuration int64
+	// Attempts mirrors the user-facing WithAttempts. Lua uses it to
+	// decide whether a failure should be retried; mkq's first worker
+	// PR does not implement retry so this is informational only.
+	Attempts int
+	// KeepJobs configures retention for the completed/failed ZSET.
+	// Nil means BullMQ's default retention (keep all).
+	KeepJobs *KeepJobs
+	Name     string
+}
+
+// KeepJobs mirrors BullMQ's keepJobs option. Either Count or Age can
+// be set; both forms supported by storeAndEnqueueJob etc.
+type KeepJobs struct {
+	// Count keeps at most N completed/failed jobs.
+	Count int
+	// Age (seconds) drops jobs older than this from the set.
+	Age int
+}
+
+// EncodeMoveToFinishedOpts returns the msgpack-encoded ARGV[8] payload.
+//
+// keepJobs is always emitted (as an empty map when unset) because the
+// vendored moveToFinished Lua dereferences `opts['keepJobs']['count']`
+// without a nil guard; sending nil would surface as a runtime "attempt
+// to index a nil value" error from Redis.
+func EncodeMoveToFinishedOpts(o MoveToFinishedOpts) ([]byte, error) {
+	keep := map[string]any{}
+	if o.KeepJobs != nil {
+		if o.KeepJobs.Count > 0 {
+			keep["count"] = o.KeepJobs.Count
+		}
+		if o.KeepJobs.Age > 0 {
+			keep["age"] = o.KeepJobs.Age
+		}
+	}
+	m := map[string]any{
+		"token":        o.Token,
+		"lockDuration": o.LockDuration,
+		"attempts":     o.Attempts,
+		"keepJobs":     keep,
+	}
+	if o.Name != "" {
+		m["name"] = o.Name
+	}
+	return msgpack.Marshal(m)
+}
+
+// EncodeJobFields packs ARGV[9] of moveToFinished — extra HASH fields
+// to write atomically along with the state transition. Each call site
+// passes whichever of `processedOn` / `finishedOn` / `returnvalue` /
+// `failedReason` it owns as alternating key/value pairs.
+//
+// The wire format is a msgpack-encoded flat array `[k1, v1, k2, v2,
+// ...]` because the vendored includes/updateJobFields.lua does
+// `cmsgpack.unpack(msgpackedFields)` and forwards the result to HMSET
+// via `unpack(...)`.
+func EncodeJobFields(pairs ...any) ([]byte, error) {
+	if len(pairs)%2 != 0 {
+		return nil, errOddJobFields
+	}
+	if len(pairs) == 0 {
+		return nil, nil
+	}
+	return msgpack.Marshal(pairs)
+}
+
+var errOddJobFields = errors.New("proto: EncodeJobFields requires an even number of arguments")

--- a/internal/proto/finish_args.go
+++ b/internal/proto/finish_args.go
@@ -38,10 +38,16 @@ type KeepJobs struct {
 
 // EncodeMoveToFinishedOpts returns the msgpack-encoded ARGV[8] payload.
 //
-// keepJobs is always emitted (as an empty map when unset) because the
-// vendored moveToFinished Lua dereferences `opts['keepJobs']['count']`
-// without a nil guard; sending nil would surface as a runtime "attempt
-// to index a nil value" error from Redis.
+// Two fields are always emitted regardless of caller input because the
+// vendored Lua dereferences them without nil guards:
+//
+//   - keepJobs: opts['keepJobs']['count'] is read directly. nil would
+//     produce "attempt to index a nil value".
+//   - maxMetricsSize: collectMetrics() does
+//     `tonumber(maxDataPoints)` which crashes with "bad argument" if
+//     maxDataPoints is nil but the outer guard `if maxMetricsSize ~=
+//     ""` permitted entry. BullMQ TypeScript sends "" when metrics
+//     are disabled; mkq mirrors that.
 func EncodeMoveToFinishedOpts(o MoveToFinishedOpts) ([]byte, error) {
 	keep := map[string]any{}
 	if o.KeepJobs != nil {
@@ -53,10 +59,11 @@ func EncodeMoveToFinishedOpts(o MoveToFinishedOpts) ([]byte, error) {
 		}
 	}
 	m := map[string]any{
-		"token":        o.Token,
-		"lockDuration": o.LockDuration,
-		"attempts":     o.Attempts,
-		"keepJobs":     keep,
+		"token":          o.Token,
+		"lockDuration":   o.LockDuration,
+		"attempts":       o.Attempts,
+		"keepJobs":       keep,
+		"maxMetricsSize": "",
 	}
 	if o.Name != "" {
 		m["name"] = o.Name

--- a/internal/proto/finish_args.go
+++ b/internal/proto/finish_args.go
@@ -51,9 +51,10 @@ type KeepJobs struct {
 func EncodeMoveToFinishedOpts(o MoveToFinishedOpts) ([]byte, error) {
 	keep := map[string]any{}
 	if o.KeepJobs != nil {
-		if o.KeepJobs.Count > 0 {
-			keep["count"] = o.KeepJobs.Count
-		}
+		// 0 is meaningful for Count: BullMQの「即時削除」セマンティクス
+		// に対応するため、Count==0 でも emit する。一方 Age はBullMQが
+		// 0 を「制限なし」(=未設定) として扱うので omit でよい。
+		keep["count"] = o.KeepJobs.Count
 		if o.KeepJobs.Age > 0 {
 			keep["age"] = o.KeepJobs.Age
 		}

--- a/internal/proto/worker_args.go
+++ b/internal/proto/worker_args.go
@@ -1,0 +1,36 @@
+package proto
+
+import (
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// MoveToActiveOpts is the BullMQ "opts" map consumed by
+// moveToActive-11.lua via cmsgpack.unpack of ARGV[3].
+//
+// The Lua reads opts['token'], opts['lockDuration'], opts['name'], and
+// optionally opts['limiter']{'max','duration'}; only token+lockDuration
+// are required. Limiter is omitted in the basic worker path and stays
+// here as a future hook.
+type MoveToActiveOpts struct {
+	// Token is the per-job lock token the worker writes to
+	// {jobKey}:lock. The worker is then expected to extend it via
+	// extendLock until the handler finishes.
+	Token string
+	// LockDuration is the lock TTL in milliseconds.
+	LockDuration int64
+	// Name is the worker name; Lua mirrors it into the HASH `pb`
+	// (processedBy) field for stalled-recovery attribution.
+	Name string
+}
+
+// EncodeMoveToActiveOpts returns the msgpack-encoded ARGV[3] payload.
+func EncodeMoveToActiveOpts(o MoveToActiveOpts) ([]byte, error) {
+	m := map[string]any{
+		"token":        o.Token,
+		"lockDuration": o.LockDuration,
+	}
+	if o.Name != "" {
+		m["name"] = o.Name
+	}
+	return msgpack.Marshal(m)
+}

--- a/internal/proto/worker_args_test.go
+++ b/internal/proto/worker_args_test.go
@@ -1,0 +1,114 @@
+package proto
+
+import (
+	"testing"
+
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+func TestEncodeMoveToActiveOpts_Roundtrip(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := EncodeMoveToActiveOpts(MoveToActiveOpts{
+		Token:        "tok",
+		LockDuration: 30000,
+		Name:         "worker-1",
+	})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	var m map[string]any
+	if err := msgpack.Unmarshal(encoded, &m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if m["token"] != "tok" {
+		t.Errorf("token: got %v", m["token"])
+	}
+	if got, ok := toInt64(m["lockDuration"]); !ok || got != 30000 {
+		t.Errorf("lockDuration: got %v", m["lockDuration"])
+	}
+	if m["name"] != "worker-1" {
+		t.Errorf("name: got %v", m["name"])
+	}
+}
+
+func TestEncodeMoveToActiveOpts_OmitsEmptyName(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := EncodeMoveToActiveOpts(MoveToActiveOpts{
+		Token:        "tok",
+		LockDuration: 1000,
+	})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	var m map[string]any
+	if err := msgpack.Unmarshal(encoded, &m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, present := m["name"]; present {
+		t.Errorf("empty Name should be omitted, got %v", m["name"])
+	}
+}
+
+func TestEncodeMoveToFinishedOpts_AlwaysIncludesKeepJobs(t *testing.T) {
+	t.Parallel()
+
+	// Lua does opts['keepJobs']['count'] without nil-guarding the
+	// outer table, so omitting keepJobs surfaces as a runtime error
+	// from Redis. The encoder must always emit at least an empty map.
+	encoded, err := EncodeMoveToFinishedOpts(MoveToFinishedOpts{
+		Token:        "t",
+		LockDuration: 1000,
+	})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	var m map[string]any
+	if err := msgpack.Unmarshal(encoded, &m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := m["keepJobs"]; !ok {
+		t.Fatal("keepJobs must always be present in the encoded opts map")
+	}
+}
+
+func TestEncodeJobFields(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := EncodeJobFields("finishedOn", int64(1714000000000))
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	var arr []any
+	if err := msgpack.Unmarshal(encoded, &arr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(arr) != 2 {
+		t.Fatalf("expected flat [k,v] of length 2, got %d", len(arr))
+	}
+	if arr[0] != "finishedOn" {
+		t.Errorf("key: got %v", arr[0])
+	}
+	if got, ok := toInt64(arr[1]); !ok || got != 1714000000000 {
+		t.Errorf("value: got %v", arr[1])
+	}
+}
+
+func TestEncodeJobFields_RejectsOdd(t *testing.T) {
+	t.Parallel()
+	if _, err := EncodeJobFields("k1", "v1", "k2"); err == nil {
+		t.Fatal("expected error for odd argument count, got nil")
+	}
+}
+
+func TestEncodeJobFields_EmptyReturnsNil(t *testing.T) {
+	t.Parallel()
+	got, err := EncodeJobFields()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("empty input should produce nil bytes, got %v", got)
+	}
+}

--- a/internal/proto/worker_args_test.go
+++ b/internal/proto/worker_args_test.go
@@ -51,12 +51,13 @@ func TestEncodeMoveToActiveOpts_OmitsEmptyName(t *testing.T) {
 	}
 }
 
-func TestEncodeMoveToFinishedOpts_AlwaysIncludesKeepJobs(t *testing.T) {
+func TestEncodeMoveToFinishedOpts_AlwaysIncludesNilSafeFields(t *testing.T) {
 	t.Parallel()
 
-	// Lua does opts['keepJobs']['count'] without nil-guarding the
-	// outer table, so omitting keepJobs surfaces as a runtime error
-	// from Redis. The encoder must always emit at least an empty map.
+	// Two fields the vendored Lua dereferences without nil guards:
+	//   - opts['keepJobs']['count'] (moveToFinished-14.lua:104)
+	//   - opts['maxMetricsSize'] in collectMetrics → tonumber(nil)
+	//     crashes on the second invocation.
 	encoded, err := EncodeMoveToFinishedOpts(MoveToFinishedOpts{
 		Token:        "t",
 		LockDuration: 1000,
@@ -69,7 +70,13 @@ func TestEncodeMoveToFinishedOpts_AlwaysIncludesKeepJobs(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 	if _, ok := m["keepJobs"]; !ok {
-		t.Fatal("keepJobs must always be present in the encoded opts map")
+		t.Error("keepJobs must always be present in the encoded opts map")
+	}
+	v, ok := m["maxMetricsSize"]
+	if !ok {
+		t.Error("maxMetricsSize must always be present in the encoded opts map")
+	} else if v != "" {
+		t.Errorf("maxMetricsSize default should be empty string, got %v", v)
 	}
 }
 

--- a/internal/proto/worker_args_test.go
+++ b/internal/proto/worker_args_test.go
@@ -51,6 +51,34 @@ func TestEncodeMoveToActiveOpts_OmitsEmptyName(t *testing.T) {
 	}
 }
 
+func TestEncodeMoveToFinishedOpts_KeepJobsCountZeroPreserved(t *testing.T) {
+	t.Parallel()
+
+	// Count==0 means "remove completed/failed immediately" in BullMQ.
+	// Dropping the key would make Lua read nil and fall through to the
+	// "keep all" branch — silently inverting the caller's intent.
+	encoded, err := EncodeMoveToFinishedOpts(MoveToFinishedOpts{
+		Token:        "t",
+		LockDuration: 1000,
+		KeepJobs:     &KeepJobs{Count: 0},
+	})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	var m map[string]any
+	if err := msgpack.Unmarshal(encoded, &m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	keep, ok := m["keepJobs"].(map[string]any)
+	if !ok {
+		t.Fatalf("keepJobs missing or not a map: %v", m["keepJobs"])
+	}
+	got, ok := toInt64(keep["count"])
+	if !ok || got != 0 {
+		t.Errorf("keepJobs.count: expected 0, got %v (%T)", keep["count"], keep["count"])
+	}
+}
+
 func TestEncodeMoveToFinishedOpts_AlwaysIncludesNilSafeFields(t *testing.T) {
 	t.Parallel()
 

--- a/worker.go
+++ b/worker.go
@@ -32,16 +32,15 @@ type Worker struct {
 	scripts *lua.Scripter
 
 	// runCtx is cancelled by Stop to break dispatch goroutines out of
-	// the dequeue loop.
+	// the dequeue loop. Each in-flight handler derives its job ctx
+	// from runCtx, so cancellation propagates automatically.
 	runCtx    context.Context
 	runCancel context.CancelFunc
 
-	// run waits for dispatch goroutines.
+	// run tracks every dispatch goroutine. Because dispatchLoop runs
+	// the handler synchronously (one in-flight job per loop), this
+	// also covers handler completion — no separate WaitGroup needed.
 	run sync.WaitGroup
-	// jobs waits for in-flight handler goroutines (a subset of the
-	// dispatch goroutines' work, but tracked separately so Stop can
-	// distinguish "loop exited" from "handler still running").
-	jobs sync.WaitGroup
 }
 
 // queueKeys is a snapshot of the per-queue Redis keys consumed by
@@ -107,7 +106,6 @@ func (w *Worker) Stop(ctx context.Context) error {
 	loopDone := make(chan struct{})
 	go func() {
 		w.run.Wait()
-		w.jobs.Wait()
 		close(loopDone)
 	}()
 	select {
@@ -187,42 +185,28 @@ func (w *Worker) tryOnce(handlerAny any) (bool, error) {
 		return false, nil
 	}
 
-	w.jobs.Add(1)
-	go w.processJob(handlerAny, token, jobID, jobMap)
+	w.processJob(handlerAny, token, jobID, jobMap)
 	return true, nil
 }
 
 // processJob runs the handler for one acquired job, manages the lock
 // heartbeat, and writes the terminal state via moveToFinished.
+//
+// The per-job ctx is derived from runCtx so worker shutdown propagates
+// without a separate bridge goroutine. Heartbeat owns its own goroutine
+// because the BullMQ extendLock semantics require periodic ticks
+// independent of handler progress.
 func (w *Worker) processJob(handlerAny any, token, jobID string, jobMap map[string]string) {
-	defer w.jobs.Done()
-
-	// Per-job context: cancelled when worker stops or when the lock
-	// heartbeat fails.
-	jobCtx, cancelJob := context.WithCancel(context.Background())
+	jobCtx, cancelJob := context.WithCancel(w.runCtx)
 	defer cancelJob()
 
-	// Stop heartbeat must run before moveToFinished so the lock token
-	// is still valid when Lua re-validates ownership.
 	hbDone := make(chan struct{})
 	go w.heartbeat(jobCtx, hbDone, token, jobID, cancelJob)
-	defer func() {
-		<-hbDone
-	}()
-
-	// Bridge worker shutdown into the per-job ctx.
-	go func() {
-		select {
-		case <-w.runCtx.Done():
-			cancelJob()
-		case <-jobCtx.Done():
-		}
-	}()
 
 	target, msgProperty, msgValue := w.runHandler(jobCtx, handlerAny, jobID, jobMap)
 
-	// jobCtx is cancelled by defer; heartbeat exits before we try the
-	// finish call so the lock is still ours.
+	// Heartbeat must finish before moveToFinished so its extendLock
+	// won't race with moveToFinished's lock-token validation.
 	cancelJob()
 	<-hbDone
 

--- a/worker.go
+++ b/worker.go
@@ -225,21 +225,27 @@ func (w *Worker) processJob(handlerAny any, token, jobID string, jobMap map[stri
 
 // runHandler invokes the user handler with panic recovery and returns
 // the wire-level finish parameters: target ("completed" or "failed"),
-// the BullMQ msg field name ("returnvalue" or "failedReason"), and the
-// JSON-encoded value.
+// the BullMQ msg field name, and the value to write.
+//
+// BullMQ's wire format is asymmetric:
+//   - returnvalue is JSON.stringify-d (the user's return is opaque).
+//   - failedReason is the raw err.message string (no JSON quoting).
+//
+// Mirroring that asymmetry is required for bull-board and other
+// foreign readers to render error messages without spurious quotes.
 func (w *Worker) runHandler(ctx context.Context, handlerAny any, jobID string, jobMap map[string]string) (target, msgProperty, msgValue string) {
 	defer func() {
 		if r := recover(); r != nil {
 			target = "failed"
 			msgProperty = "failedReason"
 			stack := string(debug.Stack())
-			msgValue = mustJSONString(fmt.Sprintf("panic: %v\n%s", r, stack))
+			msgValue = fmt.Sprintf("panic: %v\n%s", r, stack)
 		}
 	}()
 
 	ret, err := invokeHandler(ctx, handlerAny, jobID, jobMap)
 	if err != nil {
-		return "failed", "failedReason", mustJSONString(err.Error())
+		return "failed", "failedReason", err.Error()
 	}
 	return "completed", "returnvalue", mustJSONString(ret)
 }

--- a/worker.go
+++ b/worker.go
@@ -1,0 +1,496 @@
+package mkq
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"runtime/debug"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/shiroha-a/mkq/internal/lua"
+	"github.com/shiroha-a/mkq/internal/proto"
+)
+
+// Handler is the user function invoked once per dequeued job. The
+// returned value (any) is JSON-encoded and stored in the BullMQ
+// `returnvalue` HASH field on success. A non-nil error transitions the
+// job to failed; mkq's first worker PR does not yet retry, regardless
+// of WithAttempts.
+type Handler[T any] func(ctx context.Context, job *Job[T]) (any, error)
+
+// Worker is the lifecycle handle returned by Process. It owns its
+// goroutine pool and the per-job lock heartbeats.
+type Worker struct {
+	cfg     workerConfig
+	keys    queueKeys
+	scripts *lua.Scripter
+
+	// runCtx is cancelled by Stop to break dispatch goroutines out of
+	// the dequeue loop.
+	runCtx    context.Context
+	runCancel context.CancelFunc
+
+	// run waits for dispatch goroutines.
+	run sync.WaitGroup
+	// jobs waits for in-flight handler goroutines (a subset of the
+	// dispatch goroutines' work, but tracked separately so Stop can
+	// distinguish "loop exited" from "handler still running").
+	jobs sync.WaitGroup
+}
+
+// queueKeys is a snapshot of the per-queue Redis keys consumed by
+// moveToActive / moveToFinished / extendLock / releaseLock. We capture
+// it at Process time so the worker can run without holding a *Queue.
+type queueKeys struct {
+	wait, active, prioritized, events, stalled string
+	limiter, delayed, paused, meta, pc, marker string
+	completed, failed                          string
+	prefix                                     string
+}
+
+// Process starts a worker that pulls jobs from q and runs h on each.
+// Process returns once the worker goroutines are up; call Worker.Stop
+// to drain.
+func Process[T any](q *Queue[T], h Handler[T], opts ...WorkerOption) (*Worker, error) {
+	if q == nil {
+		return nil, errors.New("mkq: Process requires a non-nil queue")
+	}
+	if h == nil {
+		return nil, errors.New("mkq: Process requires a non-nil handler")
+	}
+
+	cfg := workerConfig{
+		concurrency:      defaultConcurrency,
+		lockDuration:     defaultLockDuration,
+		idlePollInterval: defaultIdlePollInterval,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if cfg.concurrency < 1 {
+		cfg.concurrency = 1
+	}
+	if cfg.workerName == "" {
+		cfg.workerName = defaultWorkerName()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w := &Worker{
+		cfg:       cfg,
+		keys:      newQueueKeys(q),
+		scripts:   q.client.scripts,
+		runCtx:    ctx,
+		runCancel: cancel,
+	}
+
+	shim := newHandlerShim(h)
+	for i := 0; i < cfg.concurrency; i++ {
+		w.run.Add(1)
+		go w.dispatchLoop(shim)
+	}
+	return w, nil
+}
+
+// Stop signals the worker to stop dequeueing and waits for in-flight
+// jobs to finish. If ctx is cancelled before the in-flight jobs
+// complete, Stop returns ctx.Err(); the still-running handlers see
+// their own ctx cancelled and any subsequent moveToFinished call may
+// fail with a lock-mismatch error (logged, not surfaced).
+func (w *Worker) Stop(ctx context.Context) error {
+	w.runCancel()
+	loopDone := make(chan struct{})
+	go func() {
+		w.run.Wait()
+		w.jobs.Wait()
+		close(loopDone)
+	}()
+	select {
+	case <-loopDone:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// dispatchLoop is one slot of the goroutine pool. It repeatedly tries
+// to dequeue a job and process it, sleeping IdlePollInterval between
+// empty pulls and exiting when runCtx is cancelled.
+func (w *Worker) dispatchLoop(handlerAny any) {
+	defer w.run.Done()
+	for {
+		if w.runCtx.Err() != nil {
+			return
+		}
+		processed, err := w.tryOnce(handlerAny)
+		if err != nil {
+			// 取得や lua 失敗はログ的扱い (worker は止めない)。
+			// 本格的なエラー報告チャネルは observability PR で導入。
+			select {
+			case <-time.After(w.cfg.idlePollInterval):
+			case <-w.runCtx.Done():
+				return
+			}
+			continue
+		}
+		if processed {
+			continue
+		}
+		select {
+		case <-time.After(w.cfg.idlePollInterval):
+		case <-w.runCtx.Done():
+			return
+		}
+	}
+}
+
+// tryOnce performs one dequeue attempt and, if successful, runs the
+// handler and finalises the job. Returns (processed, err).
+func (w *Worker) tryOnce(handlerAny any) (bool, error) {
+	token := uuid.NewString()
+	now := time.Now().UnixMilli()
+
+	optsBytes, err := proto.EncodeMoveToActiveOpts(proto.MoveToActiveOpts{
+		Token:        token,
+		LockDuration: w.cfg.lockDuration.Milliseconds(),
+		Name:         w.cfg.workerName,
+	})
+	if err != nil {
+		return false, fmt.Errorf("encode moveToActive opts: %w", err)
+	}
+
+	res, err := w.scripts.Run(
+		w.runCtx,
+		lua.MoveToActive,
+		w.keys.moveToActiveKeys(),
+		w.keys.prefix,
+		now,
+		optsBytes,
+	)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return false, nil
+		}
+		return false, fmt.Errorf("moveToActive: %w", err)
+	}
+
+	jobMap, jobID, ok, err := parseMoveToActiveResult(res)
+	if err != nil {
+		return false, fmt.Errorf("parse moveToActive: %w", err)
+	}
+	if !ok {
+		return false, nil
+	}
+
+	w.jobs.Add(1)
+	go w.processJob(handlerAny, token, jobID, jobMap)
+	return true, nil
+}
+
+// processJob runs the handler for one acquired job, manages the lock
+// heartbeat, and writes the terminal state via moveToFinished.
+func (w *Worker) processJob(handlerAny any, token, jobID string, jobMap map[string]string) {
+	defer w.jobs.Done()
+
+	// Per-job context: cancelled when worker stops or when the lock
+	// heartbeat fails.
+	jobCtx, cancelJob := context.WithCancel(context.Background())
+	defer cancelJob()
+
+	// Stop heartbeat must run before moveToFinished so the lock token
+	// is still valid when Lua re-validates ownership.
+	hbDone := make(chan struct{})
+	go w.heartbeat(jobCtx, hbDone, token, jobID, cancelJob)
+	defer func() {
+		<-hbDone
+	}()
+
+	// Bridge worker shutdown into the per-job ctx.
+	go func() {
+		select {
+		case <-w.runCtx.Done():
+			cancelJob()
+		case <-jobCtx.Done():
+		}
+	}()
+
+	target, msgProperty, msgValue := w.runHandler(jobCtx, handlerAny, jobID, jobMap)
+
+	// jobCtx is cancelled by defer; heartbeat exits before we try the
+	// finish call so the lock is still ours.
+	cancelJob()
+	<-hbDone
+
+	if err := w.finish(jobID, token, target, msgProperty, msgValue); err != nil {
+		// Best-effort lock cleanup so a failed moveToFinished doesn't
+		// strand the lock for the full TTL.
+		_, _ = w.scripts.Run(
+			context.Background(),
+			lua.ReleaseLock,
+			[]string{w.keys.jobLock(jobID)},
+			token,
+			w.cfg.lockDuration.Milliseconds(),
+		)
+	}
+}
+
+// runHandler invokes the user handler with panic recovery and returns
+// the wire-level finish parameters: target ("completed" or "failed"),
+// the BullMQ msg field name ("returnvalue" or "failedReason"), and the
+// JSON-encoded value.
+func (w *Worker) runHandler(ctx context.Context, handlerAny any, jobID string, jobMap map[string]string) (target, msgProperty, msgValue string) {
+	defer func() {
+		if r := recover(); r != nil {
+			target = "failed"
+			msgProperty = "failedReason"
+			stack := string(debug.Stack())
+			msgValue = mustJSONString(fmt.Sprintf("panic: %v\n%s", r, stack))
+		}
+	}()
+
+	ret, err := invokeHandler(ctx, handlerAny, jobID, jobMap)
+	if err != nil {
+		return "failed", "failedReason", mustJSONString(err.Error())
+	}
+	return "completed", "returnvalue", mustJSONString(ret)
+}
+
+// heartbeat extends the job's lock at lockDuration/2 intervals until
+// the per-job ctx is cancelled or the extend call fails. A failed
+// extend cancels the job ctx (cancelJob) so the handler observes a
+// cancellation and finishes promptly.
+func (w *Worker) heartbeat(ctx context.Context, done chan<- struct{}, token, jobID string, cancelJob context.CancelFunc) {
+	defer close(done)
+	tick := max(w.cfg.lockDuration/2, time.Second)
+	t := time.NewTicker(tick)
+	defer t.Stop()
+	keys := []string{w.keys.jobLock(jobID), w.keys.stalled}
+	lockMs := w.cfg.lockDuration.Milliseconds()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			res, err := w.scripts.Run(context.Background(), lua.ExtendLock, keys, token, lockMs, jobID)
+			if err != nil {
+				cancelJob()
+				return
+			}
+			if n, ok := res.(int64); ok && n == 0 {
+				// Lock no longer ours (stolen via stalled detection or
+				// flushed). Cancel the handler so it doesn't keep
+				// running off-lock.
+				cancelJob()
+				return
+			}
+		}
+	}
+}
+
+// finish runs moveToFinished for the given target + payload.
+func (w *Worker) finish(jobID, token, target, msgProperty, msgValue string) error {
+	now := time.Now().UnixMilli()
+
+	optsBytes, err := proto.EncodeMoveToFinishedOpts(proto.MoveToFinishedOpts{
+		Token:        token,
+		LockDuration: w.cfg.lockDuration.Milliseconds(),
+		Name:         w.cfg.workerName,
+	})
+	if err != nil {
+		return fmt.Errorf("encode finish opts: %w", err)
+	}
+
+	jobFields, err := proto.EncodeJobFields("finishedOn", now)
+	if err != nil {
+		return fmt.Errorf("encode job fields: %w", err)
+	}
+
+	keys := w.keys.moveToFinishedKeys(jobID, target)
+	res, err := w.scripts.Run(
+		context.Background(),
+		lua.MoveToFinished,
+		keys,
+		jobID,
+		now,
+		msgProperty,
+		msgValue,
+		target,
+		"", // fetchNext=false: empty string is BullMQ's "do not fetch" sentinel
+		w.keys.prefix,
+		optsBytes,
+		jobFields,
+	)
+	if err != nil {
+		return fmt.Errorf("moveToFinished(%s): %w", target, err)
+	}
+	if code, ok := res.(int64); ok && code < 0 {
+		return fmt.Errorf("moveToFinished(%s) returned error code %d", target, code)
+	}
+	return nil
+}
+
+// invokeHandler dispatches to the typed Handler[T] via the closure
+// captured at Process time. We pay one type assertion per job to keep
+// Worker / Queue independent of T.
+func invokeHandler(ctx context.Context, handlerAny any, jobID string, jobMap map[string]string) (any, error) {
+	invoke, ok := handlerAny.(func(ctx context.Context, jobID string, jobMap map[string]string) (any, error))
+	if !ok {
+		return nil, fmt.Errorf("mkq: handler shim has unexpected type %T", handlerAny)
+	}
+	return invoke(ctx, jobID, jobMap)
+}
+
+// newHandlerShim wraps a typed Handler[T] in the type-erased adapter
+// the Worker invokes. Lives here so worker.go owns the only place that
+// reaches into Job[T] reconstruction.
+func newHandlerShim[T any](h Handler[T]) any {
+	return func(ctx context.Context, jobID string, jobMap map[string]string) (any, error) {
+		job, err := buildJob[T](jobID, jobMap)
+		if err != nil {
+			return nil, fmt.Errorf("mkq: rebuild job %s: %w", jobID, err)
+		}
+		return h(ctx, job)
+	}
+}
+
+func buildJob[T any](jobID string, jobMap map[string]string) (*Job[T], error) {
+	var data T
+	if raw, ok := jobMap["data"]; ok && raw != "" {
+		if err := json.Unmarshal([]byte(raw), &data); err != nil {
+			return nil, fmt.Errorf("unmarshal data: %w", err)
+		}
+	}
+	tsMs, _ := strconv.ParseInt(jobMap["timestamp"], 10, 64)
+	return &Job[T]{
+		ID:        jobID,
+		Name:      jobMap["name"],
+		Data:      data,
+		Timestamp: time.UnixMilli(tsMs),
+	}, nil
+}
+
+// parseMoveToActiveResult interprets the polymorphic EVALSHA response.
+// Lua returns one of:
+//   - {HGETALL_array, jobId, 0, 0} on success
+//   - {0, 0, expireTime, 0} when rate-limited (treated as no job)
+//   - {0, 0, 0, nextDelayedTs} when waiting on a delayed job
+//   - {0, 0, 0, 0} when paused / maxed / empty
+func parseMoveToActiveResult(res any) (jobMap map[string]string, jobID string, ok bool, err error) {
+	arr, isArr := res.([]any)
+	if !isArr || len(arr) < 2 {
+		return nil, "", false, nil
+	}
+	jobData, isJobData := arr[0].([]any)
+	if !isJobData {
+		// arr[0] が integer (=0) のとき = job 無し。
+		return nil, "", false, nil
+	}
+	id, idOK := arr[1].(string)
+	if !idOK || id == "" {
+		return nil, "", false, nil
+	}
+	m, err := flatHashToMap(jobData)
+	if err != nil {
+		return nil, "", false, err
+	}
+	return m, id, true, nil
+}
+
+// flatHashToMap turns Redis HGETALL output `[k1, v1, k2, v2, ...]` into
+// a map. go-redis surfaces strings here.
+func flatHashToMap(arr []any) (map[string]string, error) {
+	if len(arr)%2 != 0 {
+		return nil, fmt.Errorf("HGETALL flat array has odd length %d", len(arr))
+	}
+	m := make(map[string]string, len(arr)/2)
+	for i := 0; i < len(arr); i += 2 {
+		k, kok := arr[i].(string)
+		v, vok := arr[i+1].(string)
+		if !kok || !vok {
+			return nil, fmt.Errorf("HGETALL element %d/%d not a string", i, i+1)
+		}
+		m[k] = v
+	}
+	return m, nil
+}
+
+// mustJSONString JSON-encodes v; on failure (which would only happen
+// for genuinely non-marshalable values) it falls back to a string so
+// the failed/completed transition still surfaces *something*.
+func mustJSONString(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		fallback, _ := json.Marshal(fmt.Sprintf("mkq: failed to marshal value: %v", err))
+		return string(fallback)
+	}
+	return string(b)
+}
+
+// defaultWorkerName matches BullMQ's "host:pid:uuid" convention loosely.
+func defaultWorkerName() string {
+	host, err := os.Hostname()
+	if err != nil {
+		host = "unknown"
+	}
+	return fmt.Sprintf("%s-%d-%s", host, os.Getpid(), uuid.NewString()[:8])
+}
+
+// newQueueKeys snapshots the per-queue Redis key set used by all four
+// worker scripts.
+func newQueueKeys[T any](q *Queue[T]) queueKeys {
+	b := q.keys
+	return queueKeys{
+		wait:        b.Wait(),
+		active:      b.Active(),
+		prioritized: b.Prioritized(),
+		events:      b.Events(),
+		stalled:     b.Stalled(),
+		limiter:     b.Limiter(),
+		delayed:     b.Delayed(),
+		paused:      b.Paused(),
+		meta:        b.Meta(),
+		pc:          b.PriorityCounter(),
+		marker:      b.Marker(),
+		completed:   b.Completed(),
+		failed:      b.Failed(),
+		prefix:      b.Base(),
+	}
+}
+
+func (k queueKeys) jobLock(jobID string) string {
+	return k.prefix + jobID + ":lock"
+}
+
+func (k queueKeys) job(jobID string) string {
+	return k.prefix + jobID
+}
+
+// moveToActiveKeys assembles KEYS[1..11] for moveToActive-11.lua.
+func (k queueKeys) moveToActiveKeys() []string {
+	return []string{
+		k.wait, k.active, k.prioritized, k.events, k.stalled,
+		k.limiter, k.delayed, k.paused, k.meta, k.pc,
+		k.marker,
+	}
+}
+
+// moveToFinishedKeys assembles KEYS[1..14] for moveToFinished-14.lua.
+// KEYS[11] toggles between completed and failed depending on target;
+// KEYS[13] (metrics key) is intentionally empty until observability
+// lands.
+func (k queueKeys) moveToFinishedKeys(jobID, target string) []string {
+	resultSet := k.completed
+	if target == "failed" {
+		resultSet = k.failed
+	}
+	return []string{
+		k.wait, k.active, k.prioritized, k.events, k.stalled,
+		k.limiter, k.delayed, k.paused, k.meta, k.pc,
+		resultSet, k.job(jobID), "", k.marker,
+	}
+}

--- a/worker_options.go
+++ b/worker_options.go
@@ -1,0 +1,49 @@
+package mkq
+
+import "time"
+
+// WorkerOption customises a Worker created by Process.
+type WorkerOption func(*workerConfig)
+
+type workerConfig struct {
+	concurrency      int
+	lockDuration     time.Duration
+	workerName       string
+	idlePollInterval time.Duration
+}
+
+// Defaults mirror BullMQ where applicable.
+const (
+	defaultConcurrency      = 1
+	defaultLockDuration     = 30 * time.Second
+	defaultIdlePollInterval = 100 * time.Millisecond
+)
+
+// WithConcurrency sets the number of in-flight jobs the worker will
+// process concurrently. Each slot runs in its own goroutine.
+func WithConcurrency(n int) WorkerOption {
+	return func(c *workerConfig) { c.concurrency = n }
+}
+
+// WithLockDuration sets the lock TTL written to {jobKey}:lock. The
+// worker refreshes the lock at half this interval; a missed heartbeat
+// past the TTL lets stalled-detection (future PR) reclaim the job.
+func WithLockDuration(d time.Duration) WorkerOption {
+	return func(c *workerConfig) { c.lockDuration = d }
+}
+
+// WithWorkerName sets the BullMQ "name" attached to dequeued jobs (the
+// HASH `pb` / processedBy field). When empty mkq generates one from
+// hostname-pid-uuid at Worker startup.
+func WithWorkerName(name string) WorkerOption {
+	return func(c *workerConfig) { c.workerName = name }
+}
+
+// WithIdlePollInterval controls how long the worker sleeps between
+// moveToActive calls when no job is available. A shorter value reduces
+// dequeue latency at the cost of Redis load. The marker-based blocking
+// dequeue (BullMQ's preferred path) is not yet implemented; this knob
+// is the temporary substitute.
+func WithIdlePollInterval(d time.Duration) WorkerOption {
+	return func(c *workerConfig) { c.idlePollInterval = d }
+}

--- a/worker_test.go
+++ b/worker_test.go
@@ -193,6 +193,53 @@ func TestWorker_Process_Concurrency(t *testing.T) {
 	assert.EqualValues(t, N, done.Load(), "every handler must have run")
 }
 
+// TestWorker_Process_SerialJobsOnSingleSlot regression-tests two
+// behaviours that PR #9's first round broke:
+//
+//  1. Without WithConcurrency(1) gating, a single dispatch loop must
+//     still process N jobs sequentially without skipping any. Earlier
+//     code spawned per-job goroutines, which masked correctness bugs
+//     by parallelising around them.
+//
+//  2. moveToFinished's vendored Lua needs maxMetricsSize="" or it
+//     crashes via collectMetrics on the *second* job (tonumber(nil)
+//     in math.min). Running multiple jobs through one slot exercises
+//     this path.
+func TestWorker_Process_SerialJobsOnSingleSlot(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const N = 5
+	for i := range N {
+		_, err := queue.Add(ctx, testPayload{Inbox: strconv.Itoa(i)})
+		require.NoError(t, err)
+	}
+
+	var seen atomic.Int64
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		seen.Add(1)
+		return nil, nil
+	},
+		mkq.WithConcurrency(1),
+		mkq.WithIdlePollInterval(20*time.Millisecond),
+	)
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		n, _ := rdb.ZCard(ctx, base+"completed").Result()
+		return n == int64(N)
+	})
+	assert.EqualValues(t, N, seen.Load())
+}
+
 func TestWorker_Process_PriorityOrderingWithinPrioritized(t *testing.T) {
 	t.Parallel()
 	prefix := uniquePrefix(t)

--- a/worker_test.go
+++ b/worker_test.go
@@ -1,0 +1,302 @@
+package mkq_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// waitFor polls cond every step until it returns true or ctx is done.
+// Integration tests against Redis are inherently asynchronous; pinning a
+// fixed sleep gives flaky CI.
+func waitFor(t *testing.T, ctx context.Context, step time.Duration, cond func() bool) {
+	t.Helper()
+	for {
+		if cond() {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("waitFor: timed out: %v", ctx.Err())
+		case <-time.After(step):
+		}
+	}
+}
+
+func TestWorker_Process_Success(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	addedJob, err := queue.Add(ctx, testPayload{Inbox: "https://x", Body: "ok"})
+	require.NoError(t, err)
+
+	type observed struct {
+		jobID string
+		data  testPayload
+	}
+	var got atomic.Value
+	worker, err := mkq.Process(queue, func(_ context.Context, j *mkq.Job[testPayload]) (any, error) {
+		got.Store(observed{jobID: j.ID, data: j.Data})
+		return map[string]any{"ok": true}, nil
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		assert.NoError(t, worker.Stop(stopCtx))
+	}()
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"completed", addedJob.ID).Result()
+		return v > 0
+	})
+
+	o, _ := got.Load().(observed)
+	assert.Equal(t, addedJob.ID, o.jobID)
+	assert.Equal(t, "https://x", o.data.Inbox)
+
+	h, err := rdb.HGetAll(ctx, base+addedJob.ID).Result()
+	require.NoError(t, err)
+	assert.NotEmpty(t, h["processedOn"], "processedOn must be set")
+	assert.NotEmpty(t, h["finishedOn"], "finishedOn must be set")
+	require.NotEmpty(t, h["returnvalue"])
+	var ret map[string]any
+	require.NoError(t, json.Unmarshal([]byte(h["returnvalue"]), &ret))
+	assert.Equal(t, true, ret["ok"])
+
+	// The lock key must be released by moveToFinished.
+	exists, err := rdb.Exists(ctx, base+addedJob.ID+":lock").Result()
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, exists, "lock key must be released after finish")
+}
+
+func TestWorker_Process_HandlerError(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	addedJob, err := queue.Add(ctx, testPayload{})
+	require.NoError(t, err)
+
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		return nil, errors.New("boom")
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"failed", addedJob.ID).Result()
+		return v > 0
+	})
+
+	h, err := rdb.HGetAll(ctx, base+addedJob.ID).Result()
+	require.NoError(t, err)
+	require.NotEmpty(t, h["failedReason"])
+	var reason string
+	require.NoError(t, json.Unmarshal([]byte(h["failedReason"]), &reason))
+	assert.Equal(t, "boom", reason)
+}
+
+func TestWorker_Process_Panic(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	addedJob, err := queue.Add(ctx, testPayload{})
+	require.NoError(t, err)
+
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		panic("kaboom")
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"failed", addedJob.ID).Result()
+		return v > 0
+	})
+
+	h, err := rdb.HGetAll(ctx, base+addedJob.ID).Result()
+	require.NoError(t, err)
+	var reason string
+	require.NoError(t, json.Unmarshal([]byte(h["failedReason"]), &reason))
+	assert.Contains(t, reason, "panic: kaboom")
+	assert.Contains(t, reason, "goroutine ", "stack trace must be captured")
+}
+
+func TestWorker_Process_Concurrency(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const N = 8
+	for i := range N {
+		_, err := queue.Add(ctx, testPayload{Inbox: strconv.Itoa(i)})
+		require.NoError(t, err)
+	}
+
+	var done atomic.Int64
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		// 並行性を観測しやすくするため軽い擬似処理を入れる。
+		time.Sleep(50 * time.Millisecond)
+		done.Add(1)
+		return nil, nil
+	},
+		mkq.WithConcurrency(N),
+		mkq.WithIdlePollInterval(20*time.Millisecond),
+	)
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		n, _ := rdb.ZCard(ctx, base+"completed").Result()
+		return n == int64(N)
+	})
+	assert.EqualValues(t, N, done.Load(), "every handler must have run")
+}
+
+func TestWorker_Process_PriorityOrderingWithinPrioritized(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// BullMQ's vendored moveToActive drains the wait list before the
+	// prioritized ZSET, so a "priority job vs standard job" race is
+	// not the right ordering test (standard jobs always win when wait
+	// is non-empty). The real priority semantic — that smaller numeric
+	// priority runs first — applies *within* the prioritized bucket.
+	low, err := queue.Add(ctx, testPayload{Inbox: "low"}, mkq.WithPriority(10))
+	require.NoError(t, err)
+	high, err := queue.Add(ctx, testPayload{Inbox: "high"}, mkq.WithPriority(1))
+	require.NoError(t, err)
+
+	order := make(chan string, 2)
+	worker, err := mkq.Process(queue, func(_ context.Context, j *mkq.Job[testPayload]) (any, error) {
+		order <- j.ID
+		return nil, nil
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	first := receiveOrFail(t, ctx, order)
+	second := receiveOrFail(t, ctx, order)
+
+	assert.Equal(t, high.ID, first, "priority=1 should run before priority=10")
+	assert.Equal(t, low.ID, second)
+}
+
+func TestWorker_Stop_DrainsInflight(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, testPayload{})
+	require.NoError(t, err)
+
+	started := make(chan struct{})
+	finished := make(chan struct{})
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		close(started)
+		// Stop が呼ばれた後でも処理を完走させる。
+		time.Sleep(300 * time.Millisecond)
+		close(finished)
+		return "done", nil
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+
+	receiveOrFail(t, ctx, started)
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	require.NoError(t, worker.Stop(stopCtx))
+
+	// 完走したことを確認 (Stop が in-flight を待ったか)。
+	select {
+	case <-finished:
+	default:
+		t.Fatal("Stop returned before in-flight handler finished")
+	}
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	v, err := rdb.ZScore(ctx, base+"completed", job.ID).Result()
+	require.NoError(t, err)
+	assert.Greater(t, v, float64(0))
+}
+
+func receiveOrFail[T any](t *testing.T, ctx context.Context, ch <-chan T) T {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-ctx.Done():
+		t.Fatalf("expected channel send, got ctx done: %v", ctx.Err())
+		var zero T
+		return zero
+	}
+}
+
+// Sanity: assert that the dispatch path is entered only via Process —
+// callers should not be tempted to peek at unexported fields.
+func TestWorker_Process_RejectsNilQueue(t *testing.T) {
+	t.Parallel()
+	_, err := mkq.Process(nil, func(context.Context, *mkq.Job[testPayload]) (any, error) {
+		return nil, nil
+	})
+	require.Error(t, err)
+}
+
+func TestWorker_Process_RejectsNilHandler(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+	_, err := mkq.Process(queue, mkq.Handler[testPayload](nil))
+	require.Error(t, err)
+}

--- a/worker_test.go
+++ b/worker_test.go
@@ -115,10 +115,9 @@ func TestWorker_Process_HandlerError(t *testing.T) {
 
 	h, err := rdb.HGetAll(ctx, base+addedJob.ID).Result()
 	require.NoError(t, err)
-	require.NotEmpty(t, h["failedReason"])
-	var reason string
-	require.NoError(t, json.Unmarshal([]byte(h["failedReason"]), &reason))
-	assert.Equal(t, "boom", reason)
+	// BullMQ stores failedReason as a plain string (matching err.message
+	// in the TS client), not JSON-encoded.
+	assert.Equal(t, "boom", h["failedReason"])
 }
 
 func TestWorker_Process_Panic(t *testing.T) {
@@ -149,8 +148,7 @@ func TestWorker_Process_Panic(t *testing.T) {
 
 	h, err := rdb.HGetAll(ctx, base+addedJob.ID).Result()
 	require.NoError(t, err)
-	var reason string
-	require.NoError(t, json.Unmarshal([]byte(h["failedReason"]), &reason))
+	reason := h["failedReason"]
 	assert.Contains(t, reason, "panic: kaboom")
 	assert.Contains(t, reason, "goroutine ", "stack trace must be captured")
 }


### PR DESCRIPTION
Resolves #8. Advances #1 (Phase 3 alpha — second slice).

## Summary

Worker complement to PR #5: jobs queued by \`Queue.Add\` now run end-to-end through a typed \`Process\` API backed by BullMQ \`moveToActive\` / \`moveToFinished\` / \`extendLock\` / \`releaseLock\` Lua.

## Key Changes

### Public API (root package)

\`\`\`go
type Handler[T any] func(ctx context.Context, job *Job[T]) (any, error)

func Process[T any](q *Queue[T], h Handler[T], opts ...WorkerOption) (*Worker, error)
func (w *Worker) Stop(ctx context.Context) error
\`\`\`

\`WorkerOption\`: \`WithConcurrency\` / \`WithLockDuration\` / \`WithWorkerName\` / \`WithIdlePollInterval\`.

Handler return -> JSON-encoded into BullMQ \`returnvalue\` HASH field. Non-nil error -> failed + \`failedReason\`. Panic -> recovered, captured stack trace stored in \`failedReason\`.

### Wire compatibility (BullMQ verbatim)

- 4 new entry-point Lua scripts vendored verbatim from \`taskforcesh/bullmq @ 0866f39\`: \`moveToActive-11\`, \`moveToFinished-14\`, \`extendLock-2\`, \`releaseLock-1\`. Transitive includes resolved by the existing preprocessor; 16 new includes added.
- \`internal/proto\` adds \`MoveToActiveOpts\` (ARGV[3]), \`MoveToFinishedOpts\` (ARGV[8]), and \`EncodeJobFields\` (ARGV[9], msgpack flat array consumed by \`includes/updateJobFields.lua\`).
- KEYS slice ordering for both move scripts cross-checked against the script header comments inline.

### Worker engine

- Per-concurrency-slot goroutine calls \`moveToActive\` in a loop, sleeping \`IdlePollInterval\` (default 100ms) between empty pulls. Marker-based blocking dequeue is deferred (#follow-up).
- Per-job context cancelled by either \`Worker.Stop\` or a failed lock heartbeat.
- Heartbeat goroutine extends the lock at \`lockDuration/2\` (clamped >= 1s); cancels the per-job ctx if \`extendLock\` returns 0 (lock stolen) so the handler stops doing wasted work.
- \`moveToFinished\` writes \`processedOn\` / \`finishedOn\` / \`returnvalue\` (or \`failedReason\`) atomically with the state transition.
- Best-effort \`releaseLock\` is invoked if \`moveToFinished\` fails so a dropped finish doesn't strand the lock for the full TTL.
- \`Stop\` signals the dispatch loops and waits for in-flight handlers via a separate waitgroup; ctx cancellation lets callers bound the drain.

### Notable behaviour discovered while wiring up

- \`moveToFinished\`'s vendored Lua dereferences \`opts['keepJobs']['count']\` without nil-guarding the outer table, so \`EncodeMoveToFinishedOpts\` always emits \`keepJobs\` (as an empty map when none configured). Comment in code + dedicated test enforce this.
- \`moveToActive\` drains the \`wait\` LIST before the \`prioritized\` ZSET — BullMQ priority orders jobs only *within* the prioritized bucket. \`TestWorker_Process_PriorityOrderingWithinPrioritized\` reflects that semantic with a comment so future readers don't waste time chasing an apparent priority bug.

## Testing

\`\`\`
go vet ./...
gofmt -l .
go build ./...
go test ./... -race -count=1
\`\`\`

- Unit: moveToActive / moveToFinished opts encoders (incl. mandatory \`keepJobs\` presence), \`EncodeJobFields\` odd-arity rejection. Existing preprocessor test extended to cover the four new entry points.
- Integration (real Redis 7):
  - success path (returnvalue / processedOn / finishedOn / lock release)
  - handler error -> failed + failedReason
  - panic -> failed + stack trace in failedReason
  - WithConcurrency(8) processes 8 jobs concurrently
  - priority ordering within prioritized bucket
  - graceful Stop drains in-flight job to completion

5 sequential \`go test ./... -race -count=1\` runs all green; priority ordering test additionally looped 20x clean.

CI runs the same suite on every push and on PRs against \`develop\` / \`main\` with a \`redis:7-alpine\` service container on Go 1.25.

## Out of scope (deferred)

- \`retryJob\` execution — failures still go straight to failed regardless of \`WithAttempts\`
- Stalled detection (\`moveStalledToWait\`)
- Marker-based blocking dequeue
- Progress reporting / returnvalue read API
- Rate limiter / pause / resume
- Delayed-job promotion
- Observability (otel / metrics / slog adapter)

## New Dependency

- \`github.com/google/uuid\` v1.6.0 (lock token + worker name generation)

## Related Issue

- Sub-issue: #8
- Tracking: #1 (Phase 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
