### PR TITLE
feat: retry / backoff (retryJob + moveToDelayed)

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -1,6 +1,9 @@
 package mkq
 
-import "time"
+import (
+	"math"
+	"time"
+)
 
 // BackoffStrategy describes a BullMQ-compatible backoff. The on-Redis
 // JSON shape is {"type": "...", "delay": <ms>}; mkq mirrors it
@@ -25,4 +28,39 @@ func FixedBackoff(d time.Duration) BackoffStrategy {
 // ceiling will need a custom strategy in a follow-up release.
 func ExponentialBackoff(d time.Duration) BackoffStrategy {
 	return BackoffStrategy{Type: "exponential", Delay: d}
+}
+
+// computeBackoffDelay mirrors BullMQ's Backoffs.calculate worker-side
+// computation: the chosen delay is passed to Lua as a plain integer
+// so the wire-level retry script (retryJob / moveToDelayed) does not
+// know about strategy types.
+//
+// attemptsMade is the post-bump count (i.e. "this is attempt N");
+// BullMQ's exponential formula is `delay * 2^(attemptsMade-1)`.
+//
+// Returns 0 for an unset / nil strategy. Overflow is clamped to
+// math.MaxInt64 nanoseconds so a misconfigured exponential never
+// wraps negative.
+func computeBackoffDelay(b *BackoffStrategy, attemptsMade int) time.Duration {
+	if b == nil || attemptsMade < 1 {
+		return 0
+	}
+	switch b.Type {
+	case "fixed":
+		return b.Delay
+	case "exponential":
+		shift := uint(attemptsMade - 1)
+		// 上限を 62 bit に抑える: 1<<63 は signed int64 で overflow。
+		if shift >= 63 {
+			return time.Duration(math.MaxInt64)
+		}
+		mult := time.Duration(1) << shift
+		// b.Delay * mult が int64 を overflow しないかを乗算前にチェック。
+		if mult != 0 && b.Delay > time.Duration(math.MaxInt64)/mult {
+			return time.Duration(math.MaxInt64)
+		}
+		return b.Delay * mult
+	default:
+		return 0
+	}
 }

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -1,0 +1,78 @@
+package mkq
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestComputeBackoffDelay_Nil(t *testing.T) {
+	t.Parallel()
+	if got := computeBackoffDelay(nil, 1); got != 0 {
+		t.Errorf("nil strategy: expected 0, got %v", got)
+	}
+}
+
+func TestComputeBackoffDelay_Fixed(t *testing.T) {
+	t.Parallel()
+	b := FixedBackoff(150 * time.Millisecond)
+	for _, n := range []int{1, 2, 5, 100} {
+		if got := computeBackoffDelay(&b, n); got != 150*time.Millisecond {
+			t.Errorf("fixed attempt=%d: expected 150ms, got %v", n, got)
+		}
+	}
+}
+
+func TestComputeBackoffDelay_Exponential(t *testing.T) {
+	t.Parallel()
+	b := ExponentialBackoff(20 * time.Millisecond)
+	cases := []struct {
+		attemptsMade int
+		want         time.Duration
+	}{
+		{1, 20 * time.Millisecond},     // 20 * 2^0
+		{2, 40 * time.Millisecond},     // 20 * 2^1
+		{3, 80 * time.Millisecond},     // 20 * 2^2
+		{4, 160 * time.Millisecond},    // 20 * 2^3
+		{10, 10240 * time.Millisecond}, // 20 * 2^9
+	}
+	for _, c := range cases {
+		if got := computeBackoffDelay(&b, c.attemptsMade); got != c.want {
+			t.Errorf("exp attempt=%d: expected %v, got %v", c.attemptsMade, c.want, got)
+		}
+	}
+}
+
+func TestComputeBackoffDelay_ExponentialOverflow(t *testing.T) {
+	t.Parallel()
+	// 1 second base, attempt=70: 1s * 2^69 ≈ 5.9e20 ns, way past int64.
+	b := ExponentialBackoff(1 * time.Second)
+	got := computeBackoffDelay(&b, 70)
+	if got != time.Duration(math.MaxInt64) {
+		t.Errorf("expected clamped MaxInt64, got %v", got)
+	}
+
+	// Boundary: shift==63 should clamp without underflow.
+	if got := computeBackoffDelay(&b, 64); got != time.Duration(math.MaxInt64) {
+		t.Errorf("attempt=64 should clamp, got %v", got)
+	}
+}
+
+func TestComputeBackoffDelay_UnknownType(t *testing.T) {
+	t.Parallel()
+	b := BackoffStrategy{Type: "polynomial", Delay: time.Second}
+	if got := computeBackoffDelay(&b, 3); got != 0 {
+		t.Errorf("unknown type should return 0, got %v", got)
+	}
+}
+
+func TestComputeBackoffDelay_AttemptsZeroOrNegative(t *testing.T) {
+	t.Parallel()
+	b := ExponentialBackoff(time.Second)
+	if got := computeBackoffDelay(&b, 0); got != 0 {
+		t.Errorf("attempt=0 should return 0, got %v", got)
+	}
+	if got := computeBackoffDelay(&b, -1); got != 0 {
+		t.Errorf("attempt=-1 should return 0, got %v", got)
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -10,3 +10,15 @@ import "errors"
 // A future PR may add a combined dispatch (delayed + prioritized) that
 // removes this restriction.
 var ErrPriorityWithDelay = errors.New("mkq: WithPriority cannot be combined with WithDelay")
+
+// ErrUnrecoverable, when wrapped into a handler's returned error,
+// instructs the worker to skip the retry path even if WithAttempts
+// would otherwise allow another attempt. The job transitions straight
+// to failed.
+//
+// This mirrors BullMQ's UnrecoverableError class for foreign-language
+// workers: bull-board reports the same final-failed shape regardless
+// of whether the rejection came from a JS Worker or mkq.
+//
+//	return fmt.Errorf("invalid input: %w", mkq.ErrUnrecoverable)
+var ErrUnrecoverable = errors.New("mkq: unrecoverable error (skip retry)")

--- a/internal/lua/loader.go
+++ b/internal/lua/loader.go
@@ -23,6 +23,8 @@ const (
 	MoveToFinished    ScriptName = "moveToFinished-14"
 	ExtendLock        ScriptName = "extendLock-2"
 	ReleaseLock       ScriptName = "releaseLock-1"
+	RetryJob          ScriptName = "retryJob-11"
+	MoveToDelayed     ScriptName = "moveToDelayed-12"
 )
 
 // Scripter executes vendored Lua scripts via EVALSHA, with transparent
@@ -52,6 +54,7 @@ func NewScripter(ctx context.Context, client redis.Scripter) (*Scripter, error) 
 	for _, name := range []ScriptName{
 		AddStandardJob, AddDelayedJob, AddPrioritizedJob,
 		MoveToActive, MoveToFinished, ExtendLock, ReleaseLock,
+		RetryJob, MoveToDelayed,
 	} {
 		if _, err := s.load(ctx, name); err != nil {
 			return nil, fmt.Errorf("preload %s: %w", name, err)

--- a/internal/lua/preprocess_test.go
+++ b/internal/lua/preprocess_test.go
@@ -17,6 +17,8 @@ func TestPreprocess_VendoredEntryPoints(t *testing.T) {
 		"moveToFinished-14",
 		"extendLock-2",
 		"releaseLock-1",
+		"retryJob-11",
+		"moveToDelayed-12",
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/lua/scripts/UPSTREAM.md
+++ b/internal/lua/scripts/UPSTREAM.md
@@ -18,6 +18,8 @@ Entry points:
 - `moveToFinished-14.lua`
 - `extendLock-2.lua`
 - `releaseLock-1.lua`
+- `retryJob-11.lua`
+- `moveToDelayed-12.lua`
 
 `includes/` — every script transitively reachable from the entry points
 above via `--- @include "..."` directives.

--- a/internal/lua/scripts/moveToDelayed-12.lua
+++ b/internal/lua/scripts/moveToDelayed-12.lua
@@ -1,0 +1,97 @@
+--[[
+  Moves job from active to delayed set.
+
+  Input:
+    KEYS[1] marker key
+    KEYS[2] active key
+    KEYS[3] prioritized key
+    KEYS[4] delayed key
+    KEYS[5] job key
+    KEYS[6] events stream
+    KEYS[7] meta key
+    KEYS[8] stalled key
+    KEYS[9] wait key
+    KEYS[10] rate limiter key
+    KEYS[11] paused key
+    KEYS[12] pc priority counter
+
+    ARGV[1] key prefix
+    ARGV[2] timestamp
+    ARGV[3] the id of the job
+    ARGV[4] queue token
+    ARGV[5] delay value
+    ARGV[6] skip attempt
+    ARGV[7] optional job fields to update
+    ARGV[8] fetch next?
+    ARGV[9] opts
+
+  Output:
+    0 - OK
+   -1 - Missing job.
+   -3 - Job not in active set.
+
+  Events:
+    - delayed key.
+]]
+local rcall = redis.call
+
+-- Includes
+--- @include "includes/addDelayMarkerIfNeeded"
+--- @include "includes/fetchNextJob"
+--- @include "includes/getDelayedScore"
+--- @include "includes/getOrSetMaxEvents"
+--- @include "includes/removeLock"
+--- @include "includes/updateJobFields"
+
+local jobKey = KEYS[5]
+local markerKey = KEYS[1]
+local metaKey = KEYS[7]
+local token = ARGV[4] 
+if rcall("EXISTS", jobKey) == 1 then
+    local errorCode = removeLock(jobKey, KEYS[8], token, ARGV[3])
+    if errorCode < 0 then
+        return errorCode
+    end
+
+    updateJobFields(jobKey, ARGV[7])
+    
+    local delayedKey = KEYS[4]
+    local jobId = ARGV[3]
+    local delay = tonumber(ARGV[5])
+
+    local numRemovedElements = rcall("LREM", KEYS[2], -1, jobId)
+    if numRemovedElements < 1 then return -3 end
+
+    local score, delayedTimestamp = getDelayedScore(delayedKey, ARGV[2], delay)
+
+    if ARGV[6] == "0" then
+        rcall("HINCRBY", jobKey, "atm", 1)
+    end
+
+    rcall("HSET", jobKey, "delay", ARGV[5])
+
+    local maxEvents = getOrSetMaxEvents(metaKey)
+
+    rcall("ZADD", delayedKey, score, jobId)
+    rcall("XADD", KEYS[6], "MAXLEN", "~", maxEvents, "*", "event", "delayed",
+          "jobId", jobId, "delay", delayedTimestamp)
+
+    -- Try to get next job to avoid an extra roundtrip if the queue is not closing,
+    -- and not rate limited.
+    if (ARGV[8] == "1") then
+        local opts = cmsgpack.unpack(ARGV[9])
+        local result = fetchNextJob(KEYS[9], KEYS[2], KEYS[3], KEYS[6],
+            KEYS[10], KEYS[4], KEYS[11], metaKey, KEYS[12], markerKey,
+            ARGV[1], ARGV[2], opts)
+        if result and type(result[1]) == "table" then
+            return result
+        end
+    end
+
+    -- Check if we need to push a marker job to wake up sleeping workers.
+    addDelayMarkerIfNeeded(markerKey, delayedKey)
+
+    return 0
+else
+    return -1
+end

--- a/internal/lua/scripts/retryJob-11.lua
+++ b/internal/lua/scripts/retryJob-11.lua
@@ -1,0 +1,88 @@
+--[[
+  Retries a failed job by moving it back to the wait queue.
+
+    Input:
+      KEYS[1]  'active',
+      KEYS[2]  'wait'
+      KEYS[3]  'paused'
+      KEYS[4]  job key
+      KEYS[5]  'meta'
+      KEYS[6]  events stream
+      KEYS[7]  delayed key
+      KEYS[8]  prioritized key
+      KEYS[9]  'pc' priority counter
+      KEYS[10] 'marker'
+      KEYS[11] 'stalled'
+
+      ARGV[1]  key prefix
+      ARGV[2]  timestamp
+      ARGV[3]  pushCmd
+      ARGV[4]  jobId
+      ARGV[5]  token
+      ARGV[6]  optional job fields to update
+
+    Events:
+      'waiting'
+
+    Output:
+     0  - OK
+     -1 - Missing key
+     -2 - Missing lock
+     -3 - Job not in active set
+]]
+local rcall = redis.call
+
+-- Includes
+--- @include "includes/addJobInTargetList"
+--- @include "includes/addJobWithPriority"
+--- @include "includes/getOrSetMaxEvents"
+--- @include "includes/getTargetQueueList"
+--- @include "includes/isQueuePausedOrMaxed"
+--- @include "includes/promoteDelayedJobs"
+--- @include "includes/removeLock"
+--- @include "includes/updateJobFields"
+
+local target, isPausedOrMaxed = getTargetQueueList(KEYS[5], KEYS[1], KEYS[2], KEYS[3])
+local markerKey = KEYS[10]
+
+-- Check if there are delayed jobs that we can move to wait.
+-- test example: when there are delayed jobs between retries
+promoteDelayedJobs(KEYS[7], markerKey, target, KEYS[8], KEYS[6], ARGV[1], ARGV[2], KEYS[9], isPausedOrMaxed)
+
+local jobKey = KEYS[4]
+
+if rcall("EXISTS", jobKey) == 1 then
+  local errorCode = removeLock(jobKey, KEYS[11], ARGV[5], ARGV[4]) 
+  if errorCode < 0 then
+    return errorCode
+  end
+
+  updateJobFields(jobKey, ARGV[6])
+
+  local numRemovedElements = rcall("LREM", KEYS[1], -1, ARGV[4])
+  if (numRemovedElements < 1) then return -3 end
+
+  local priority = tonumber(rcall("HGET", jobKey, "priority")) or 0
+
+  --need to re-evaluate after removing job from active
+  isPausedOrMaxed = isQueuePausedOrMaxed(KEYS[5], KEYS[1])
+
+  -- Standard or priority add
+  if priority == 0 then
+    addJobInTargetList(target, markerKey, ARGV[3], isPausedOrMaxed, ARGV[4])
+  else
+    addJobWithPriority(markerKey, KEYS[8], priority, ARGV[4], KEYS[9], isPausedOrMaxed)
+  end
+
+  rcall("HINCRBY", jobKey, "atm", 1)
+
+  local maxEvents = getOrSetMaxEvents(KEYS[5])
+
+  -- Emit waiting event
+  rcall("XADD", KEYS[6], "MAXLEN", "~", maxEvents, "*", "event", "waiting",
+    "jobId", ARGV[4], "prev", "active")
+
+  return 0
+else
+  return -1
+end

--- a/internal/proto/finish_args.go
+++ b/internal/proto/finish_args.go
@@ -17,9 +17,12 @@ import (
 type MoveToFinishedOpts struct {
 	Token        string
 	LockDuration int64
-	// Attempts mirrors the user-facing WithAttempts. Lua uses it to
-	// decide whether a failure should be retried; mkq's first worker
-	// PR does not implement retry so this is informational only.
+	// Attempts mirrors the user-facing WithAttempts. The vendored Lua
+	// gates the `retries-exhausted` event on
+	// `attemptsMade >= attempts`, so callers that go straight to
+	// failed (e.g. ErrUnrecoverable) must still pass the job's
+	// configured attempts to avoid emitting a spurious exhaustion
+	// event into the wire-format events stream.
 	Attempts int
 	// KeepJobs configures retention for the completed/failed ZSET.
 	// Nil means BullMQ's default retention (keep all).

--- a/worker.go
+++ b/worker.go
@@ -25,6 +25,19 @@ import (
 // the job's WithAttempts / WithBackoff configuration. Wrapping the
 // returned error with ErrUnrecoverable forces the failed transition
 // regardless of remaining attempts.
+//
+// Notes mirroring BullMQ behaviour:
+//   - Panics inside the handler are recovered, recorded in the
+//     stacktrace HASH field, and treated as a regular error — they
+//     are eligible for retry under WithAttempts. Use
+//     ErrUnrecoverable inside an explicit recover() if you need
+//     panics to be terminal.
+//   - The `retries-exhausted` event in the BullMQ events stream
+//     fires whenever a job lands in `failed` and `attemptsMade`
+//     reached the configured `attempts`. With the default (no
+//     WithAttempts), `attempts` is 0 and any failure satisfies the
+//     gate, so the event fires immediately. This matches BullMQ TS
+//     wire-format behaviour.
 type Handler[T any] func(ctx context.Context, job *Job[T]) (any, error)
 
 // Worker is the lifecycle handle returned by Process. It owns its
@@ -374,9 +387,11 @@ func (w *Worker) runMoveToFinished(jobID, token string, attempts int, target, ms
 		return fmt.Errorf("encode finish opts: %w", err)
 	}
 
-	fields := []any{"finishedOn", now}
-	fields = append(fields, extraFields...)
-	jobFields, err := proto.EncodeJobFields(fields...)
+	// `finishedOn` を ARGV[9] に積まない: moveToFinished-14.lua が
+	// 末尾で HSET timestamp 同値を書き込むため重複になる。空 / extra
+	// だけを渡すことで余計な HMSET ペアを削減し、BullMQ TS の
+	// updateData 設計と揃える。
+	jobFields, err := proto.EncodeJobFields(extraFields...)
 	if err != nil {
 		return fmt.Errorf("encode job fields: %w", err)
 	}

--- a/worker.go
+++ b/worker.go
@@ -190,7 +190,8 @@ func (w *Worker) tryOnce(handlerAny any) (bool, error) {
 }
 
 // processJob runs the handler for one acquired job, manages the lock
-// heartbeat, and writes the terminal state via moveToFinished.
+// heartbeat, and writes the terminal state via the appropriate
+// BullMQ Lua script (moveToFinished / retryJob / moveToDelayed).
 //
 // The per-job ctx is derived from runCtx so worker shutdown propagates
 // without a separate bridge goroutine. Heartbeat owns its own goroutine
@@ -203,15 +204,15 @@ func (w *Worker) processJob(handlerAny any, token, jobID string, jobMap map[stri
 	hbDone := make(chan struct{})
 	go w.heartbeat(jobCtx, hbDone, token, jobID, cancelJob)
 
-	target, msgProperty, msgValue := w.runHandler(jobCtx, handlerAny, jobID, jobMap)
+	outcome := w.runHandler(jobCtx, handlerAny, jobID, jobMap)
 
-	// Heartbeat must finish before moveToFinished so its extendLock
-	// won't race with moveToFinished's lock-token validation.
+	// Heartbeat must finish before any finalisation Lua call so its
+	// extendLock won't race with the script's lock-token validation.
 	cancelJob()
 	<-hbDone
 
-	if err := w.finish(jobID, token, target, msgProperty, msgValue); err != nil {
-		// Best-effort lock cleanup so a failed moveToFinished doesn't
+	if err := w.finalise(jobID, token, jobMap, outcome); err != nil {
+		// Best-effort lock cleanup so a failed terminal call doesn't
 		// strand the lock for the full TTL.
 		_, _ = w.scripts.Run(
 			context.Background(),
@@ -223,31 +224,55 @@ func (w *Worker) processJob(handlerAny any, token, jobID string, jobMap map[stri
 	}
 }
 
-// runHandler invokes the user handler with panic recovery and returns
-// the wire-level finish parameters: target ("completed" or "failed"),
-// the BullMQ msg field name, and the value to write.
+// handlerOutcome captures the result of invoking a handler. Exactly
+// one of returnValue / errReason is populated. stacktrace mirrors
+// BullMQ's HASH `stacktrace` JSON-array shape and is set on every
+// failure (panics include the captured Go stack; plain errors carry
+// the message itself).
+type handlerOutcome struct {
+	success     bool
+	returnValue string // JSON-encoded user return, success=true only
+	err         error  // raw error from the handler, success=false only
+	errReason   string // BullMQ failedReason (plain string)
+	stacktrace  string // BullMQ stacktrace (JSON array string)
+}
+
+// runHandler invokes the user handler under panic recovery and returns
+// the BullMQ-shaped wire fields. BullMQ's wire format is asymmetric:
 //
-// BullMQ's wire format is asymmetric:
-//   - returnvalue is JSON.stringify-d (the user's return is opaque).
+//   - returnvalue is JSON.stringify-d (opaque user return).
 //   - failedReason is the raw err.message string (no JSON quoting).
+//   - stacktrace is JSON.stringify of an array of strings.
 //
 // Mirroring that asymmetry is required for bull-board and other
-// foreign readers to render error messages without spurious quotes.
-func (w *Worker) runHandler(ctx context.Context, handlerAny any, jobID string, jobMap map[string]string) (target, msgProperty, msgValue string) {
+// foreign readers to render values without spurious quotes.
+func (w *Worker) runHandler(ctx context.Context, handlerAny any, jobID string, jobMap map[string]string) (out handlerOutcome) {
 	defer func() {
 		if r := recover(); r != nil {
-			target = "failed"
-			msgProperty = "failedReason"
 			stack := string(debug.Stack())
-			msgValue = fmt.Sprintf("panic: %v\n%s", r, stack)
+			reason := fmt.Sprintf("panic: %v\n%s", r, stack)
+			out = handlerOutcome{
+				success:    false,
+				err:        fmt.Errorf("mkq: handler panic: %v", r),
+				errReason:  reason,
+				stacktrace: mustJSONString([]string{reason}),
+			}
 		}
 	}()
 
 	ret, err := invokeHandler(ctx, handlerAny, jobID, jobMap)
 	if err != nil {
-		return "failed", "failedReason", err.Error()
+		return handlerOutcome{
+			success:    false,
+			err:        err,
+			errReason:  err.Error(),
+			stacktrace: mustJSONString([]string{err.Error()}),
+		}
 	}
-	return "completed", "returnvalue", mustJSONString(ret)
+	return handlerOutcome{
+		success:     true,
+		returnValue: mustJSONString(ret),
+	}
 }
 
 // heartbeat extends the job's lock at lockDuration/2 intervals until
@@ -282,8 +307,54 @@ func (w *Worker) heartbeat(ctx context.Context, done chan<- struct{}, token, job
 	}
 }
 
-// finish runs moveToFinished for the given target + payload.
-func (w *Worker) finish(jobID, token, target, msgProperty, msgValue string) error {
+// finalise dispatches the terminal-state Lua call for a job. On
+// success it always calls moveToFinished("completed"). On failure it
+// consults retry policy and may instead call retryJob (immediate
+// re-enqueue) or moveToDelayed (backoff-delayed re-enqueue), bumping
+// the BullMQ HASH `atm` (attempts made) counter atomically inside
+// the script.
+func (w *Worker) finalise(jobID, token string, jobMap map[string]string, out handlerOutcome) error {
+	if out.success {
+		return w.finishCompleted(jobID, token, out.returnValue)
+	}
+
+	// Decide retry. Reading from the in-memory jobMap snapshot is fine
+	// for attempts/backoff (immutable), but `atm` lives in Redis and
+	// may have been bumped by a prior retry on a different worker —
+	// we re-read it (via jobMap, which is the HGETALL captured at
+	// moveToActive). For BullMQ-correctness this is sufficient because
+	// stalled-recovery — the only way `atm` advances without us
+	// observing it — is not yet implemented.
+	jobOpts := parseJobOpts(jobMap["opts"])
+	atm := parseInt(jobMap["atm"])
+
+	if !w.shouldRetry(jobOpts, atm, out.err) {
+		return w.finishFailed(jobID, token, out.errReason, out.stacktrace)
+	}
+
+	delay := computeBackoffDelay(jobOpts.backoff, atm+1)
+	if delay > 0 {
+		return w.retryDelayed(jobID, token, delay, out.errReason, out.stacktrace)
+	}
+	return w.retryImmediate(jobID, token, jobOpts.lifo, out.errReason, out.stacktrace)
+}
+
+// finishCompleted writes the BullMQ completed-state transition.
+func (w *Worker) finishCompleted(jobID, token, returnValue string) error {
+	return w.runMoveToFinished(jobID, token, "completed", "returnvalue", returnValue, nil)
+}
+
+// finishFailed writes the BullMQ failed-state transition with the
+// failedReason + stacktrace HASH fields.
+func (w *Worker) finishFailed(jobID, token, reason, stacktrace string) error {
+	return w.runMoveToFinished(jobID, token, "failed", "failedReason", reason,
+		[]any{"stacktrace", stacktrace})
+}
+
+// runMoveToFinished is the shared moveToFinished invocation. extraFields
+// piggybacks on ARGV[9] for the failed path to write stacktrace
+// alongside the state change.
+func (w *Worker) runMoveToFinished(jobID, token, target, msgProperty, msgValue string, extraFields []any) error {
 	now := time.Now().UnixMilli()
 
 	optsBytes, err := proto.EncodeMoveToFinishedOpts(proto.MoveToFinishedOpts{
@@ -295,7 +366,9 @@ func (w *Worker) finish(jobID, token, target, msgProperty, msgValue string) erro
 		return fmt.Errorf("encode finish opts: %w", err)
 	}
 
-	jobFields, err := proto.EncodeJobFields("finishedOn", now)
+	fields := []any{"finishedOn", now}
+	fields = append(fields, extraFields...)
+	jobFields, err := proto.EncodeJobFields(fields...)
 	if err != nil {
 		return fmt.Errorf("encode job fields: %w", err)
 	}
@@ -322,6 +395,143 @@ func (w *Worker) finish(jobID, token, target, msgProperty, msgValue string) erro
 		return fmt.Errorf("moveToFinished(%s) returned error code %d", target, code)
 	}
 	return nil
+}
+
+// retryImmediate re-enqueues a failed job via retryJob-11.lua. The Lua
+// bumps `atm` (HINCRBY) atomically and writes failedReason/stacktrace
+// via ARGV[6] (jobFieldsToUpdate, msgpack flat array).
+func (w *Worker) retryImmediate(jobID, token string, lifo bool, reason, stacktrace string) error {
+	now := time.Now().UnixMilli()
+	pushCmd := "LPUSH"
+	if lifo {
+		pushCmd = "RPUSH"
+	}
+
+	jobFields, err := proto.EncodeJobFields("failedReason", reason, "stacktrace", stacktrace)
+	if err != nil {
+		return fmt.Errorf("encode retry job fields: %w", err)
+	}
+
+	keys := w.keys.retryJobKeys(jobID)
+	res, err := w.scripts.Run(
+		context.Background(),
+		lua.RetryJob,
+		keys,
+		w.keys.prefix,
+		now,
+		pushCmd,
+		jobID,
+		token,
+		jobFields,
+	)
+	if err != nil {
+		return fmt.Errorf("retryJob: %w", err)
+	}
+	if code, ok := res.(int64); ok && code < 0 {
+		return fmt.Errorf("retryJob returned error code %d", code)
+	}
+	return nil
+}
+
+// retryDelayed re-enqueues with a delay via moveToDelayed-12.lua,
+// honouring exponential / fixed backoff computed Go-side.
+func (w *Worker) retryDelayed(jobID, token string, delay time.Duration, reason, stacktrace string) error {
+	now := time.Now().UnixMilli()
+	// 防御: computeBackoffDelay は >0 のはずだが、誤って 0 を渡すと
+	// Lua が delayedTimestamp = timestamp + 0 で即時 promote 候補に
+	// なる。1 ms 床値で「delayed」状態を確実にする。
+	delayMs := max(delay.Milliseconds(), 1)
+
+	jobFields, err := proto.EncodeJobFields("failedReason", reason, "stacktrace", stacktrace)
+	if err != nil {
+		return fmt.Errorf("encode retry job fields: %w", err)
+	}
+
+	keys := w.keys.moveToDelayedKeys(jobID)
+	res, err := w.scripts.Run(
+		context.Background(),
+		lua.MoveToDelayed,
+		keys,
+		w.keys.prefix,
+		now,
+		jobID,
+		token,
+		delayMs,
+		"0", // skip attempt = false: bump atm on this retry
+		jobFields,
+		"", // fetchNext=false
+		"", // opts: BullMQ accepts empty for the basic retry case
+	)
+	if err != nil {
+		return fmt.Errorf("moveToDelayed: %w", err)
+	}
+	if code, ok := res.(int64); ok && code < 0 {
+		return fmt.Errorf("moveToDelayed returned error code %d", code)
+	}
+	return nil
+}
+
+// jobOpts is the subset of the per-job opts JSON that the worker
+// needs after dequeue. The on-Redis HASH `opts` field is the JSON
+// shape produced by Job.optsAsJSON in BullMQ TS.
+type jobOpts struct {
+	attempts int
+	backoff  *BackoffStrategy
+	lifo     bool
+}
+
+// parseJobOpts deserialises the BullMQ HASH `opts` JSON into the
+// fields the retry path needs. Missing or malformed input falls back
+// to zero values (no retry / no backoff / FIFO push).
+func parseJobOpts(raw string) jobOpts {
+	var out jobOpts
+	if raw == "" || raw == "{}" {
+		return out
+	}
+	var m struct {
+		Attempts int  `json:"attempts"`
+		Lifo     bool `json:"lifo"`
+		Backoff  *struct {
+			Type  string `json:"type"`
+			Delay int64  `json:"delay"`
+		} `json:"backoff"`
+	}
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return out
+	}
+	out.attempts = m.Attempts
+	out.lifo = m.Lifo
+	if m.Backoff != nil {
+		out.backoff = &BackoffStrategy{
+			Type:  m.Backoff.Type,
+			Delay: time.Duration(m.Backoff.Delay) * time.Millisecond,
+		}
+	}
+	return out
+}
+
+// shouldRetry encodes BullMQ's worker-side retry decision. attemptsMade
+// is the count BEFORE this failure (the value stored in HASH `atm`);
+// the +1 mirrors BullMQ's `attemptsMade + 1 < opts.attempts` check.
+func (w *Worker) shouldRetry(o jobOpts, attemptsMade int, err error) bool {
+	if errors.Is(err, ErrUnrecoverable) {
+		return false
+	}
+	if o.attempts <= 0 {
+		return false
+	}
+	return attemptsMade+1 < o.attempts
+}
+
+func parseInt(s string) int {
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 // invokeHandler dispatches to the typed Handler[T] via the closure
@@ -482,5 +692,32 @@ func (k queueKeys) moveToFinishedKeys(jobID, target string) []string {
 		k.wait, k.active, k.prioritized, k.events, k.stalled,
 		k.limiter, k.delayed, k.paused, k.meta, k.pc,
 		resultSet, k.job(jobID), "", k.marker,
+	}
+}
+
+// retryJobKeys assembles KEYS[1..11] for retryJob-11.lua.
+//
+//	KEYS[1]  active     KEYS[2]  wait        KEYS[3]  paused
+//	KEYS[4]  job key    KEYS[5]  meta        KEYS[6]  events
+//	KEYS[7]  delayed    KEYS[8]  prioritized KEYS[9]  pc
+//	KEYS[10] marker     KEYS[11] stalled
+func (k queueKeys) retryJobKeys(jobID string) []string {
+	return []string{
+		k.active, k.wait, k.paused, k.job(jobID), k.meta, k.events,
+		k.delayed, k.prioritized, k.pc, k.marker, k.stalled,
+	}
+}
+
+// moveToDelayedKeys assembles KEYS[1..12] for moveToDelayed-12.lua.
+//
+//	KEYS[1]  marker     KEYS[2]  active      KEYS[3]  prioritized
+//	KEYS[4]  delayed    KEYS[5]  job key     KEYS[6]  events
+//	KEYS[7]  meta       KEYS[8]  stalled     KEYS[9]  wait
+//	KEYS[10] limiter    KEYS[11] paused      KEYS[12] pc
+func (k queueKeys) moveToDelayedKeys(jobID string) []string {
+	return []string{
+		k.marker, k.active, k.prioritized, k.delayed, k.job(jobID),
+		k.events, k.meta, k.stalled, k.wait, k.limiter,
+		k.paused, k.pc,
 	}
 }

--- a/worker.go
+++ b/worker.go
@@ -19,9 +19,12 @@ import (
 
 // Handler is the user function invoked once per dequeued job. The
 // returned value (any) is JSON-encoded and stored in the BullMQ
-// `returnvalue` HASH field on success. A non-nil error transitions the
-// job to failed; mkq's first worker PR does not yet retry, regardless
-// of WithAttempts.
+// `returnvalue` HASH field on success.
+//
+// A non-nil error transitions the job to retry or failed depending on
+// the job's WithAttempts / WithBackoff configuration. Wrapping the
+// returned error with ErrUnrecoverable forces the failed transition
+// regardless of remaining attempts.
 type Handler[T any] func(ctx context.Context, job *Job[T]) (any, error)
 
 // Worker is the lifecycle handle returned by Process. It owns its
@@ -314,8 +317,10 @@ func (w *Worker) heartbeat(ctx context.Context, done chan<- struct{}, token, job
 // the BullMQ HASH `atm` (attempts made) counter atomically inside
 // the script.
 func (w *Worker) finalise(jobID, token string, jobMap map[string]string, out handlerOutcome) error {
+	jobOpts := parseJobOpts(jobMap["opts"])
+
 	if out.success {
-		return w.finishCompleted(jobID, token, out.returnValue)
+		return w.finishCompleted(jobID, token, jobOpts.attempts, out.returnValue)
 	}
 
 	// Decide retry. Reading from the in-memory jobMap snapshot is fine
@@ -325,11 +330,10 @@ func (w *Worker) finalise(jobID, token string, jobMap map[string]string, out han
 	// moveToActive). For BullMQ-correctness this is sufficient because
 	// stalled-recovery — the only way `atm` advances without us
 	// observing it — is not yet implemented.
-	jobOpts := parseJobOpts(jobMap["opts"])
 	atm := parseInt(jobMap["atm"])
 
 	if !w.shouldRetry(jobOpts, atm, out.err) {
-		return w.finishFailed(jobID, token, out.errReason, out.stacktrace)
+		return w.finishFailed(jobID, token, jobOpts.attempts, out.errReason, out.stacktrace)
 	}
 
 	delay := computeBackoffDelay(jobOpts.backoff, atm+1)
@@ -340,26 +344,30 @@ func (w *Worker) finalise(jobID, token string, jobMap map[string]string, out han
 }
 
 // finishCompleted writes the BullMQ completed-state transition.
-func (w *Worker) finishCompleted(jobID, token, returnValue string) error {
-	return w.runMoveToFinished(jobID, token, "completed", "returnvalue", returnValue, nil)
+func (w *Worker) finishCompleted(jobID, token string, attempts int, returnValue string) error {
+	return w.runMoveToFinished(jobID, token, attempts, "completed", "returnvalue", returnValue, nil)
 }
 
 // finishFailed writes the BullMQ failed-state transition with the
-// failedReason + stacktrace HASH fields.
-func (w *Worker) finishFailed(jobID, token, reason, stacktrace string) error {
-	return w.runMoveToFinished(jobID, token, "failed", "failedReason", reason,
+// failedReason + stacktrace HASH fields. attempts is forwarded so the
+// vendored Lua only emits `retries-exhausted` when retries are
+// genuinely exhausted (matching BullMQ TS behaviour for foreign
+// readers of the events stream).
+func (w *Worker) finishFailed(jobID, token string, attempts int, reason, stacktrace string) error {
+	return w.runMoveToFinished(jobID, token, attempts, "failed", "failedReason", reason,
 		[]any{"stacktrace", stacktrace})
 }
 
 // runMoveToFinished is the shared moveToFinished invocation. extraFields
 // piggybacks on ARGV[9] for the failed path to write stacktrace
 // alongside the state change.
-func (w *Worker) runMoveToFinished(jobID, token, target, msgProperty, msgValue string, extraFields []any) error {
+func (w *Worker) runMoveToFinished(jobID, token string, attempts int, target, msgProperty, msgValue string, extraFields []any) error {
 	now := time.Now().UnixMilli()
 
 	optsBytes, err := proto.EncodeMoveToFinishedOpts(proto.MoveToFinishedOpts{
 		Token:        token,
 		LockDuration: w.cfg.lockDuration.Milliseconds(),
+		Attempts:     attempts,
 		Name:         w.cfg.workerName,
 	})
 	if err != nil {

--- a/worker_retry_test.go
+++ b/worker_retry_test.go
@@ -173,6 +173,53 @@ func TestWorker_Retry_UnrecoverableSkipsRetry(t *testing.T) {
 	assert.Contains(t, h["failedReason"], "hard fail")
 }
 
+// TestWorker_Retry_UnrecoverableSuppressesRetriesExhaustedEvent pins
+// a BullMQ wire-format detail: when WithAttempts(N) is configured but
+// the handler short-circuits via ErrUnrecoverable on the first run,
+// the events stream must NOT carry a `retries-exhausted` entry.
+//
+// BullMQ TS gates the event on `attemptsMade >= attempts`; if the
+// worker omits the `attempts` opt forwarded into moveToFinished's
+// Lua, the gate degrades to `1 >= 0` and emits spuriously, breaking
+// bull-board / foreign QueueEvents consumers.
+func TestWorker_Retry_UnrecoverableSuppressesRetriesExhaustedEvent(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, testPayload{},
+		mkq.WithAttempts(5),
+		mkq.WithBackoff(mkq.FixedBackoff(10*time.Millisecond)),
+	)
+	require.NoError(t, err)
+
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		return nil, fmt.Errorf("hard fail: %w", mkq.ErrUnrecoverable)
+	}, mkq.WithIdlePollInterval(10*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"failed", job.ID).Result()
+		return v > 0
+	})
+
+	// XRANGEで全eventを取り、retries-exhausted が無いことを確認。
+	entries, err := rdb.XRange(ctx, base+"events", "-", "+").Result()
+	require.NoError(t, err)
+	for _, e := range entries {
+		ev, _ := e.Values["event"].(string)
+		assert.NotEqual(t, "retries-exhausted", ev,
+			"retries-exhausted must not be emitted when WithAttempts(5) is unspent (event=%v jobId=%v)", e.Values["event"], e.Values["jobId"])
+	}
+}
+
 // TestWorker_Retry_StacktraceFieldShape pins the BullMQ wire-shape
 // for the stacktrace HASH field: a JSON array of strings.
 func TestWorker_Retry_StacktraceFieldShape(t *testing.T) {

--- a/worker_retry_test.go
+++ b/worker_retry_test.go
@@ -1,0 +1,209 @@
+package mkq_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestWorker_Retry_FixedBackoffExhausts pins the basic retry contract:
+// WithAttempts(N) + Fixed(d) makes the worker run the handler N times
+// (failing each time) before settling the job in failed.
+func TestWorker_Retry_FixedBackoffExhausts(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, testPayload{Inbox: "x"},
+		mkq.WithAttempts(3),
+		mkq.WithBackoff(mkq.FixedBackoff(20*time.Millisecond)),
+	)
+	require.NoError(t, err)
+
+	var attempts atomic.Int64
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		n := attempts.Add(1)
+		return nil, fmt.Errorf("attempt %d failed", n)
+	}, mkq.WithIdlePollInterval(10*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"failed", job.ID).Result()
+		return v > 0
+	})
+
+	assert.EqualValues(t, 3, attempts.Load(), "handler must run exactly attempts times")
+
+	h, err := rdb.HGetAll(ctx, base+job.ID).Result()
+	require.NoError(t, err)
+	assert.Equal(t, "3", h["atm"], "atm must be incremented to 3")
+	assert.Equal(t, "attempt 3 failed", h["failedReason"], "final failedReason persists")
+}
+
+// TestWorker_Retry_ExponentialBackoffSchedules verifies the second
+// retry happens after exponential backoff (delay * 2^(n-1)).
+func TestWorker_Retry_ExponentialBackoffSchedules(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, testPayload{},
+		mkq.WithAttempts(3),
+		mkq.WithBackoff(mkq.ExponentialBackoff(50*time.Millisecond)),
+	)
+	require.NoError(t, err)
+
+	var times []int64
+	var mu chan struct{} = make(chan struct{}, 1)
+	mu <- struct{}{}
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		<-mu
+		times = append(times, time.Now().UnixMilli())
+		mu <- struct{}{}
+		return nil, errors.New("nope")
+	}, mkq.WithIdlePollInterval(10*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"failed", job.ID).Result()
+		return v > 0
+	})
+
+	require.Len(t, times, 3, "expected 3 attempts")
+	gap1 := times[1] - times[0]
+	gap2 := times[2] - times[1]
+	// 1st retry: 50ms * 2^0 = 50ms; 2nd retry: 50ms * 2^1 = 100ms.
+	// 寛容な下限 (poll/scheduling 揺らぎを吸収) でassertする。
+	assert.GreaterOrEqual(t, gap1, int64(40), "first retry should wait ~50ms (got %dms)", gap1)
+	assert.GreaterOrEqual(t, gap2, int64(85), "second retry should wait ~100ms (got %dms)", gap2)
+	// 上限は緩く (CIタイマー揺らぎ吸収): doublingが効いていることだけ確認。
+	assert.Greater(t, gap2, gap1, "second gap should exceed first")
+}
+
+// TestWorker_Retry_NoAttemptsDefaultIsOneShot ensures the existing
+// no-WithAttempts behaviour (1 attempt -> failed) is preserved.
+func TestWorker_Retry_NoAttemptsDefaultIsOneShot(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, testPayload{}) // no WithAttempts
+	require.NoError(t, err)
+
+	var attempts atomic.Int64
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		attempts.Add(1)
+		return nil, errors.New("boom")
+	}, mkq.WithIdlePollInterval(10*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"failed", job.ID).Result()
+		return v > 0
+	})
+
+	assert.EqualValues(t, 1, attempts.Load(), "default (no WithAttempts) must run exactly once")
+}
+
+// TestWorker_Retry_UnrecoverableSkipsRetry verifies that wrapping
+// ErrUnrecoverable bypasses retry even when WithAttempts allows more.
+func TestWorker_Retry_UnrecoverableSkipsRetry(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, testPayload{},
+		mkq.WithAttempts(5),
+		mkq.WithBackoff(mkq.FixedBackoff(10*time.Millisecond)),
+	)
+	require.NoError(t, err)
+
+	var attempts atomic.Int64
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		attempts.Add(1)
+		return nil, fmt.Errorf("hard fail: %w", mkq.ErrUnrecoverable)
+	}, mkq.WithIdlePollInterval(10*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"failed", job.ID).Result()
+		return v > 0
+	})
+
+	assert.EqualValues(t, 1, attempts.Load(), "unrecoverable error must bypass retry")
+	h, err := rdb.HGetAll(ctx, base+job.ID).Result()
+	require.NoError(t, err)
+	assert.Contains(t, h["failedReason"], "hard fail")
+}
+
+// TestWorker_Retry_StacktraceFieldShape pins the BullMQ wire-shape
+// for the stacktrace HASH field: a JSON array of strings.
+func TestWorker_Retry_StacktraceFieldShape(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, testPayload{})
+	require.NoError(t, err)
+
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		return nil, errors.New("kaput")
+	}, mkq.WithIdlePollInterval(10*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"failed", job.ID).Result()
+		return v > 0
+	})
+
+	h, err := rdb.HGetAll(ctx, base+job.ID).Result()
+	require.NoError(t, err)
+	require.NotEmpty(t, h["stacktrace"], "stacktrace must be written on failure")
+	assert.True(t, h["stacktrace"][0] == '[' && h["stacktrace"][len(h["stacktrace"])-1] == ']',
+		"stacktrace should be a JSON array, got: %s", h["stacktrace"])
+	assert.Contains(t, h["stacktrace"], "kaput")
+}


### PR DESCRIPTION
Resolves #11. Advances #1 (Phase 3 alpha — third slice).

## Summary

Makes \`WithAttempts\` and \`WithBackoff\` actually drive the worker. Until this PR every handler error became a final \`failed\`; now the worker consults BullMQ-compatible retry policy and re-enqueues via either \`retryJob\` (immediate) or \`moveToDelayed\` (backoff-delayed) before falling through to \`moveToFinished\`.

## Key Changes

### Public API

- New: \`var ErrUnrecoverable = errors.New(\"mkq: unrecoverable error (skip retry)\")\` — BullMQ \`UnrecoverableError\` equivalent. Wrap with \`fmt.Errorf(\"...: %w\", mkq.ErrUnrecoverable)\` inside a handler to bypass retry regardless of \`WithAttempts\`.
- \`WithAttempts(N)\` and \`WithBackoff(...)\` were already public; they are now load-bearing instead of advisory.

### Wire compatibility (BullMQ verbatim)

- 2 new entry-point Lua scripts vendored from \`taskforcesh/bullmq @ 0866f39\`: \`retryJob-11\`, \`moveToDelayed-12\`. All transitive includes were already covered by PR #5 / PR #9 — 0 new include files.
- Backoff is computed Go-side (mirroring BullMQ TS \`Backoffs.calculate\`) and the resulting delay in ms is forwarded to \`moveToDelayed\` via ARGV[5]. Retry semantics — \`atm\` bump, \`failedReason\` / \`stacktrace\` HASH writes, marker push — stay entirely inside the vendored Lua.
- \`stacktrace\` HASH field is now written on every failure as a JSON array of strings, matching BullMQ wire shape:
  - plain error -> \`[\"<err.Error()>\"]\`
  - panic -> \`[\"panic: <r>\\n<debug.Stack()>\"]\`
- \`failedReason\` remains plain string per the PR #9 review fix.

### Worker engine

- \`finish()\` -> \`finalise()\`: single entry point that branches on outcome (success -> \`moveToFinished completed\`; error -> retry or \`moveToFinished failed\`).
- \`runHandler()\` returns a \`handlerOutcome\` capturing success / err / errReason / stacktrace, decoupling outcome capture from Redis dispatch.
- New helpers \`retryImmediate()\` / \`retryDelayed()\` invoke \`retryJob\` / \`moveToDelayed\` with the appropriate KEYS / ARGV layouts (cross-checked against the script header comments inline).
- \`parseJobOpts()\` decodes the BullMQ HASH \`opts\` JSON to recover the attempts / backoff / lifo fields the worker needs at retry time. Missing or malformed input yields zero values (no retry).
- \`shouldRetry()\` implements BullMQ's \`attemptsMade + 1 < opts.attempts\` rule with \`ErrUnrecoverable\` short-circuit.
- \`computeBackoffDelay()\` in \`backoff.go\`: fixed -> \`b.Delay\`; exponential -> \`b.Delay * 2^(attemptsMade-1)\` with overflow clamp to \`MaxInt64\`.

## Testing

\`\`\`
go vet ./...
gofmt -l .
go build ./...
go test ./... -race -count=1
\`\`\`

- \`backoff_test.go\` (unit): fixed / exponential progression / overflow clamp at \`shift>=63\` / unknown-type fallback / non-positive attempts.
- \`worker_retry_test.go\` (integration vs real Redis 7):
  - \`WithAttempts(3) + Fixed(20ms)\` -> exactly 3 handler invocations, final \`atm=3\`, persistent \`failedReason\`.
  - \`WithAttempts(3) + Exponential(50ms)\` -> \`gap1 ~50ms\`, \`gap2 ~100ms\` (assertion uses lower bounds with poll / scheduling tolerance).
  - No \`WithAttempts\` (default) -> exactly 1 invocation (regression pin for the previous one-shot behaviour).
  - \`ErrUnrecoverable\` bypasses retry under \`WithAttempts(5)\`.
  - \`stacktrace\` HASH field is a JSON array containing the err message.
- Existing \`TestWorker_Process_HandlerError\` / \`Panic\` still pass against the refactored \`finalise()\` path.

5 sequential \`go test ./... -race -count=1\` runs all green.

## Out of scope (deferred)

- Custom backoff strategies (BullMQ \"custom\" type with user function)
- Backoff jitter (\`WithJitter\` option)
- \`job.discard()\` API
- Stalled detection retry interaction
- Telemetry / metrics on retry

## Related Issue

- Sub-issue: #11
- Tracking: #1 (Phase 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
