### PR TITLE
feat: retention API + delayed pickup verification

### DIFF
--- a/internal/proto/opts.go
+++ b/internal/proto/opts.go
@@ -50,7 +50,7 @@ type Backoff struct {
 // The encoding uses a string-keyed map; missing fields are simply
 // omitted so Lua's `opts['x'] or default` idiom yields the right value.
 func EncodeAddOpts(o AddOpts) ([]byte, error) {
-	m := make(map[string]any, 6)
+	m := make(map[string]any, 8)
 	if o.Delay != 0 {
 		m["delay"] = o.Delay
 	}

--- a/internal/proto/opts.go
+++ b/internal/proto/opts.go
@@ -29,6 +29,12 @@ type AddOpts struct {
 	// Lifo flips the wait list push direction so newer jobs are
 	// processed first.
 	Lifo bool
+	// RemoveOnComplete / RemoveOnFail mirror BullMQ's per-job
+	// retention. nil means "not set" (BullMQ default = keep all).
+	// A non-nil value (including 0) is forwarded to Lua: 0 trims
+	// immediately, n>0 keeps the most recent n entries.
+	RemoveOnComplete *int
+	RemoveOnFail     *int
 }
 
 // Backoff matches BullMQ's BackoffOptions shape ({type, delay}).
@@ -62,6 +68,12 @@ func EncodeAddOpts(o AddOpts) ([]byte, error) {
 	}
 	if o.Lifo {
 		m["lifo"] = true
+	}
+	if o.RemoveOnComplete != nil {
+		m["removeOnComplete"] = *o.RemoveOnComplete
+	}
+	if o.RemoveOnFail != nil {
+		m["removeOnFail"] = *o.RemoveOnFail
 	}
 	return msgpack.Marshal(m)
 }

--- a/options.go
+++ b/options.go
@@ -13,12 +13,14 @@ type queueConfig struct {
 }
 
 type addConfig struct {
-	jobID    string
-	delay    time.Duration
-	attempts int
-	priority uint32
-	lifo     bool
-	backoff  *BackoffStrategy
+	jobID         string
+	delay         time.Duration
+	attempts      int
+	priority      uint32
+	lifo          bool
+	backoff       *BackoffStrategy
+	keepCompleted *int
+	keepFailed    *int
 }
 
 // WithJobID forces the job id instead of letting Redis INCR allocate
@@ -57,4 +59,19 @@ func WithLifo(lifo bool) AddOption {
 // WithBackoff sets the retry backoff strategy.
 func WithBackoff(b BackoffStrategy) AddOption {
 	return func(c *addConfig) { c.backoff = &b }
+}
+
+// WithKeepCompleted bounds the size of the completed ZSET. n==0 makes
+// each completed job removed immediately (BullMQ removeOnComplete=true);
+// n>0 keeps the most recent n entries via the vendored
+// removeJobsByMaxCount Lua. Not calling WithKeepCompleted preserves
+// BullMQ's default (keep all completed jobs).
+func WithKeepCompleted(n int) AddOption {
+	return func(c *addConfig) { c.keepCompleted = &n }
+}
+
+// WithKeepFailed bounds the size of the failed ZSET, mirroring
+// WithKeepCompleted's semantics for the failure path.
+func WithKeepFailed(n int) AddOption {
+	return func(c *addConfig) { c.keepFailed = &n }
 }

--- a/options.go
+++ b/options.go
@@ -66,12 +66,19 @@ func WithBackoff(b BackoffStrategy) AddOption {
 // n>0 keeps the most recent n entries via the vendored
 // removeJobsByMaxCount Lua. Not calling WithKeepCompleted preserves
 // BullMQ's default (keep all completed jobs).
+//
+// n must be >= 0. Negative values are forwarded as-is to the
+// vendored Lua, where BullMQ's `maxCount > 0` guard skips trimming —
+// the practical effect is identical to "keep all", but the value is
+// not normalised here so callers should treat negatives as
+// programmer error.
 func WithKeepCompleted(n int) AddOption {
 	return func(c *addConfig) { c.keepCompleted = &n }
 }
 
 // WithKeepFailed bounds the size of the failed ZSET, mirroring
-// WithKeepCompleted's semantics for the failure path.
+// WithKeepCompleted's semantics (and its n>=0 expectation) for the
+// failure path.
 func WithKeepFailed(n int) AddOption {
 	return func(c *addConfig) { c.keepFailed = &n }
 }

--- a/parse_jobopts_test.go
+++ b/parse_jobopts_test.go
@@ -1,0 +1,138 @@
+package mkq
+
+import (
+	"testing"
+	"time"
+)
+
+// These tests pin parseJobOpts against the polymorphic shapes BullMQ
+// TS persists into the per-job HASH `opts` JSON. The earlier strict
+// `*int` decoding silently zeroed out attempts/backoff/lifo whenever
+// a foreign worker stored e.g. `removeOnComplete: true` — a wire
+// compatibility bug spotted in PR #15 review.
+
+func TestParseJobOpts_RemoveOnComplete_BooleanTrue(t *testing.T) {
+	t.Parallel()
+	got := parseJobOpts(`{"attempts":3,"removeOnComplete":true}`)
+	if got.attempts != 3 {
+		t.Errorf("attempts must survive boolean removeOnComplete, got %d", got.attempts)
+	}
+	if got.removeOnComplete == nil || *got.removeOnComplete != 0 {
+		t.Errorf("removeOnComplete=true should map to *int(0), got %v", got.removeOnComplete)
+	}
+}
+
+func TestParseJobOpts_RemoveOnComplete_BooleanFalse(t *testing.T) {
+	t.Parallel()
+	got := parseJobOpts(`{"attempts":2,"removeOnComplete":false}`)
+	if got.attempts != 2 {
+		t.Errorf("attempts must survive boolean removeOnComplete, got %d", got.attempts)
+	}
+	if got.removeOnComplete != nil {
+		t.Errorf("removeOnComplete=false should map to nil, got %v", *got.removeOnComplete)
+	}
+}
+
+func TestParseJobOpts_RemoveOnComplete_Number(t *testing.T) {
+	t.Parallel()
+	got := parseJobOpts(`{"removeOnComplete":7}`)
+	if got.removeOnComplete == nil || *got.removeOnComplete != 7 {
+		t.Errorf("removeOnComplete=7 should map to *int(7), got %v", got.removeOnComplete)
+	}
+}
+
+func TestParseJobOpts_RemoveOnComplete_Object(t *testing.T) {
+	t.Parallel()
+	got := parseJobOpts(`{"removeOnComplete":{"count":42,"age":3600}}`)
+	if got.removeOnComplete == nil || *got.removeOnComplete != 42 {
+		t.Errorf("removeOnComplete={count:42} should map to *int(42), got %v", got.removeOnComplete)
+	}
+}
+
+func TestParseJobOpts_RemoveOnFail_BooleanForms(t *testing.T) {
+	t.Parallel()
+	if got := parseJobOpts(`{"removeOnFail":true}`); got.removeOnFail == nil || *got.removeOnFail != 0 {
+		t.Errorf("removeOnFail=true should map to *int(0), got %v", got.removeOnFail)
+	}
+	if got := parseJobOpts(`{"removeOnFail":false}`); got.removeOnFail != nil {
+		t.Errorf("removeOnFail=false should map to nil")
+	}
+}
+
+func TestParseJobOpts_Backoff_NumberShorthand(t *testing.T) {
+	t.Parallel()
+	got := parseJobOpts(`{"attempts":5,"backoff":2000}`)
+	if got.attempts != 5 {
+		t.Errorf("attempts must survive shorthand backoff, got %d", got.attempts)
+	}
+	if got.backoff == nil {
+		t.Fatal("backoff number shorthand must be parsed")
+	}
+	if got.backoff.Type != "fixed" {
+		t.Errorf("number-shorthand backoff should have Type=fixed, got %q", got.backoff.Type)
+	}
+	if got.backoff.Delay != 2*time.Second {
+		t.Errorf("number-shorthand backoff Delay should be 2s, got %v", got.backoff.Delay)
+	}
+}
+
+func TestParseJobOpts_Backoff_ObjectForm(t *testing.T) {
+	t.Parallel()
+	got := parseJobOpts(`{"backoff":{"type":"exponential","delay":500}}`)
+	if got.backoff == nil {
+		t.Fatal("object backoff must be parsed")
+	}
+	if got.backoff.Type != "exponential" || got.backoff.Delay != 500*time.Millisecond {
+		t.Errorf("object backoff parsed incorrectly: %+v", got.backoff)
+	}
+}
+
+func TestParseJobOpts_AllForeignFieldsTogether(t *testing.T) {
+	t.Parallel()
+	// Realistic foreign-worker shape: backoff as number, removeOn*
+	// as boolean, alongside attempts / lifo. The earlier strict
+	// decoder zeroed every field; the new code must preserve them.
+	raw := `{"attempts":4,"lifo":true,"backoff":1000,"removeOnComplete":true,"removeOnFail":10}`
+	got := parseJobOpts(raw)
+	if got.attempts != 4 {
+		t.Errorf("attempts: %d", got.attempts)
+	}
+	if !got.lifo {
+		t.Error("lifo must be true")
+	}
+	if got.backoff == nil || got.backoff.Type != "fixed" || got.backoff.Delay != time.Second {
+		t.Errorf("backoff: %+v", got.backoff)
+	}
+	if got.removeOnComplete == nil || *got.removeOnComplete != 0 {
+		t.Errorf("removeOnComplete: %v", got.removeOnComplete)
+	}
+	if got.removeOnFail == nil || *got.removeOnFail != 10 {
+		t.Errorf("removeOnFail: %v", got.removeOnFail)
+	}
+}
+
+func TestParseJobOpts_GarbageRemoveOpt(t *testing.T) {
+	t.Parallel()
+	// String / array / unrecognised should not poison sibling fields.
+	got := parseJobOpts(`{"attempts":2,"removeOnComplete":"weird","removeOnFail":[1,2]}`)
+	if got.attempts != 2 {
+		t.Errorf("attempts must survive garbage removeOn*, got %d", got.attempts)
+	}
+	if got.removeOnComplete != nil {
+		t.Errorf("garbage string should yield nil, got %v", *got.removeOnComplete)
+	}
+	if got.removeOnFail != nil {
+		t.Errorf("garbage array should yield nil, got %v", *got.removeOnFail)
+	}
+}
+
+func TestParseJobOpts_EmptyAndMalformed(t *testing.T) {
+	t.Parallel()
+	cases := []string{"", "{}", "not json"}
+	for _, raw := range cases {
+		got := parseJobOpts(raw)
+		if got.attempts != 0 || got.backoff != nil || got.lifo {
+			t.Errorf("%q should yield zero jobOpts, got %+v", raw, got)
+		}
+	}
+}

--- a/queue.go
+++ b/queue.go
@@ -158,10 +158,12 @@ func (q *Queue[T]) dispatch(delayMs int64, priority uint32) (lua.ScriptName, []s
 // to derive the absolute delayed target.
 func toProtoOpts(cfg addConfig, delayMs int64) proto.AddOpts {
 	o := proto.AddOpts{
-		Delay:    delayMs,
-		Priority: cfg.priority,
-		Attempts: cfg.attempts,
-		Lifo:     cfg.lifo,
+		Delay:            delayMs,
+		Priority:         cfg.priority,
+		Attempts:         cfg.attempts,
+		Lifo:             cfg.lifo,
+		RemoveOnComplete: cfg.keepCompleted,
+		RemoveOnFail:     cfg.keepFailed,
 	}
 	if cfg.backoff != nil {
 		o.Backoff = &proto.Backoff{

--- a/worker.go
+++ b/worker.go
@@ -333,7 +333,7 @@ func (w *Worker) finalise(jobID, token string, jobMap map[string]string, out han
 	jobOpts := parseJobOpts(jobMap["opts"])
 
 	if out.success {
-		return w.finishCompleted(jobID, token, jobOpts.attempts, out.returnValue)
+		return w.finishCompleted(jobID, token, jobOpts, out.returnValue)
 	}
 
 	// Decide retry. Reading from the in-memory jobMap snapshot is fine
@@ -342,11 +342,11 @@ func (w *Worker) finalise(jobID, token string, jobMap map[string]string, out han
 	// we re-read it (via jobMap, which is the HGETALL captured at
 	// moveToActive). For BullMQ-correctness this is sufficient because
 	// stalled-recovery — the only way `atm` advances without us
-	// observing it — is not yet implemented.
+	// observing it — is not yet implemented (tracked in #13).
 	atm := parseInt(jobMap["atm"])
 
 	if !w.shouldRetry(jobOpts, atm, out.err) {
-		return w.finishFailed(jobID, token, jobOpts.attempts, out.errReason, out.stacktrace)
+		return w.finishFailed(jobID, token, jobOpts, out.errReason, out.stacktrace)
 	}
 
 	delay := computeBackoffDelay(jobOpts.backoff, atm+1)
@@ -357,32 +357,41 @@ func (w *Worker) finalise(jobID, token string, jobMap map[string]string, out han
 }
 
 // finishCompleted writes the BullMQ completed-state transition.
-func (w *Worker) finishCompleted(jobID, token string, attempts int, returnValue string) error {
-	return w.runMoveToFinished(jobID, token, attempts, "completed", "returnvalue", returnValue, nil)
+// jobOpts.removeOnComplete is forwarded into MoveToFinishedOpts.KeepJobs
+// so the vendored Lua trims the completed ZSET per BullMQ semantics.
+func (w *Worker) finishCompleted(jobID, token string, opts jobOpts, returnValue string) error {
+	return w.runMoveToFinished(jobID, token, opts.attempts, opts.removeOnComplete,
+		"completed", "returnvalue", returnValue, nil)
 }
 
 // finishFailed writes the BullMQ failed-state transition with the
 // failedReason + stacktrace HASH fields. attempts is forwarded so the
 // vendored Lua only emits `retries-exhausted` when retries are
-// genuinely exhausted (matching BullMQ TS behaviour for foreign
-// readers of the events stream).
-func (w *Worker) finishFailed(jobID, token string, attempts int, reason, stacktrace string) error {
-	return w.runMoveToFinished(jobID, token, attempts, "failed", "failedReason", reason,
+// genuinely exhausted; jobOpts.removeOnFail drives failed ZSET
+// retention.
+func (w *Worker) finishFailed(jobID, token string, opts jobOpts, reason, stacktrace string) error {
+	return w.runMoveToFinished(jobID, token, opts.attempts, opts.removeOnFail,
+		"failed", "failedReason", reason,
 		[]any{"stacktrace", stacktrace})
 }
 
 // runMoveToFinished is the shared moveToFinished invocation. extraFields
 // piggybacks on ARGV[9] for the failed path to write stacktrace
-// alongside the state change.
-func (w *Worker) runMoveToFinished(jobID, token string, attempts int, target, msgProperty, msgValue string, extraFields []any) error {
+// alongside the state change. keepCount is the per-target retention
+// (nil = keep all, *0 = remove immediately, *n>0 = keep last n).
+func (w *Worker) runMoveToFinished(jobID, token string, attempts int, keepCount *int, target, msgProperty, msgValue string, extraFields []any) error {
 	now := time.Now().UnixMilli()
 
-	optsBytes, err := proto.EncodeMoveToFinishedOpts(proto.MoveToFinishedOpts{
+	optsArgs := proto.MoveToFinishedOpts{
 		Token:        token,
 		LockDuration: w.cfg.lockDuration.Milliseconds(),
 		Attempts:     attempts,
 		Name:         w.cfg.workerName,
-	})
+	}
+	if keepCount != nil {
+		optsArgs.KeepJobs = &proto.KeepJobs{Count: *keepCount}
+	}
+	optsBytes, err := proto.EncodeMoveToFinishedOpts(optsArgs)
 	if err != nil {
 		return fmt.Errorf("encode finish opts: %w", err)
 	}
@@ -498,14 +507,17 @@ func (w *Worker) retryDelayed(jobID, token string, delay time.Duration, reason, 
 // needs after dequeue. The on-Redis HASH `opts` field is the JSON
 // shape produced by Job.optsAsJSON in BullMQ TS.
 type jobOpts struct {
-	attempts int
-	backoff  *BackoffStrategy
-	lifo     bool
+	attempts         int
+	backoff          *BackoffStrategy
+	lifo             bool
+	removeOnComplete *int
+	removeOnFail     *int
 }
 
 // parseJobOpts deserialises the BullMQ HASH `opts` JSON into the
-// fields the retry path needs. Missing or malformed input falls back
-// to zero values (no retry / no backoff / FIFO push).
+// fields the retry / retention paths need. Missing or malformed input
+// falls back to zero values (no retry / no backoff / FIFO push /
+// keep all on completed+failed).
 func parseJobOpts(raw string) jobOpts {
 	var out jobOpts
 	if raw == "" || raw == "{}" {
@@ -518,6 +530,8 @@ func parseJobOpts(raw string) jobOpts {
 			Type  string `json:"type"`
 			Delay int64  `json:"delay"`
 		} `json:"backoff"`
+		RemoveOnComplete *int `json:"removeOnComplete"`
+		RemoveOnFail     *int `json:"removeOnFail"`
 	}
 	if err := json.Unmarshal([]byte(raw), &m); err != nil {
 		return out
@@ -530,6 +544,8 @@ func parseJobOpts(raw string) jobOpts {
 			Delay: time.Duration(m.Backoff.Delay) * time.Millisecond,
 		}
 	}
+	out.removeOnComplete = m.RemoveOnComplete
+	out.removeOnFail = m.RemoveOnFail
 	return out
 }
 

--- a/worker.go
+++ b/worker.go
@@ -515,38 +515,111 @@ type jobOpts struct {
 }
 
 // parseJobOpts deserialises the BullMQ HASH `opts` JSON into the
-// fields the retry / retention paths need. Missing or malformed input
-// falls back to zero values (no retry / no backoff / FIFO push /
-// keep all on completed+failed).
+// fields the retry / retention paths need.
+//
+// BullMQ TypeScript stores several option fields polymorphically:
+//
+//   - removeOnComplete / removeOnFail accept `boolean | number |
+//     {count, age}` and are persisted as-is.
+//   - backoff accepts `number | {type, delay}` and is persisted
+//     without normalisation (Backoffs.normalize runs at retry-time).
+//
+// Decoding these as concrete Go types would surface a
+// json.UnmarshalTypeError on the first foreign-style entry and
+// poison the entire opts struct, silently disabling retry for jobs
+// added by other-language workers. Instead we capture each
+// polymorphic field as json.RawMessage and convert per field below,
+// so a typing surprise only loses that one option.
+//
+// Missing or malformed top-level JSON falls back to zero values
+// (no retry / no backoff / FIFO push / keep all).
 func parseJobOpts(raw string) jobOpts {
 	var out jobOpts
 	if raw == "" || raw == "{}" {
 		return out
 	}
 	var m struct {
-		Attempts int  `json:"attempts"`
-		Lifo     bool `json:"lifo"`
-		Backoff  *struct {
-			Type  string `json:"type"`
-			Delay int64  `json:"delay"`
-		} `json:"backoff"`
-		RemoveOnComplete *int `json:"removeOnComplete"`
-		RemoveOnFail     *int `json:"removeOnFail"`
+		Attempts         int             `json:"attempts"`
+		Lifo             bool            `json:"lifo"`
+		Backoff          json.RawMessage `json:"backoff"`
+		RemoveOnComplete json.RawMessage `json:"removeOnComplete"`
+		RemoveOnFail     json.RawMessage `json:"removeOnFail"`
 	}
 	if err := json.Unmarshal([]byte(raw), &m); err != nil {
 		return out
 	}
 	out.attempts = m.Attempts
 	out.lifo = m.Lifo
-	if m.Backoff != nil {
-		out.backoff = &BackoffStrategy{
-			Type:  m.Backoff.Type,
-			Delay: time.Duration(m.Backoff.Delay) * time.Millisecond,
+	out.backoff = parseBackoffOpt(m.Backoff)
+	out.removeOnComplete = parseRemoveOpt(m.RemoveOnComplete)
+	out.removeOnFail = parseRemoveOpt(m.RemoveOnFail)
+	return out
+}
+
+// parseRemoveOpt converts a BullMQ removeOnComplete / removeOnFail
+// raw JSON value into the count form mkq cares about.
+//
+//	null / missing / false   -> nil  (BullMQ default: keep all)
+//	true                     -> *int(0)  (remove on completion)
+//	number N                 -> *int(N)
+//	{"count": N, ...}        -> *int(N)  (age / limit ignored for now)
+//
+// Anything else is treated as "not understood" and returns nil so
+// retry / retention default cleanly.
+func parseRemoveOpt(raw json.RawMessage) *int {
+	if len(raw) == 0 {
+		return nil
+	}
+	s := string(raw)
+	switch s {
+	case "null", "false":
+		return nil
+	case "true":
+		v := 0
+		return &v
+	}
+	var n int
+	if err := json.Unmarshal(raw, &n); err == nil {
+		return &n
+	}
+	var obj struct {
+		Count *int `json:"count"`
+	}
+	if err := json.Unmarshal(raw, &obj); err == nil && obj.Count != nil {
+		return obj.Count
+	}
+	return nil
+}
+
+// parseBackoffOpt accepts BullMQ's `number | {type, delay}` shape:
+//
+//	number N           -> &BackoffStrategy{Type:"fixed", Delay: N ms}
+//	{type, delay}      -> &BackoffStrategy{Type, Delay}
+//
+// Empty / null / unrecognised shapes return nil so callers fall back
+// to the no-backoff default.
+func parseBackoffOpt(raw json.RawMessage) *BackoffStrategy {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var ms int64
+	if err := json.Unmarshal(raw, &ms); err == nil {
+		return &BackoffStrategy{
+			Type:  "fixed",
+			Delay: time.Duration(ms) * time.Millisecond,
 		}
 	}
-	out.removeOnComplete = m.RemoveOnComplete
-	out.removeOnFail = m.RemoveOnFail
-	return out
+	var obj struct {
+		Type  string `json:"type"`
+		Delay int64  `json:"delay"`
+	}
+	if err := json.Unmarshal(raw, &obj); err == nil && obj.Type != "" {
+		return &BackoffStrategy{
+			Type:  obj.Type,
+			Delay: time.Duration(obj.Delay) * time.Millisecond,
+		}
+	}
+	return nil
 }
 
 // shouldRetry encodes BullMQ's worker-side retry decision. attemptsMade

--- a/worker_retention_test.go
+++ b/worker_retention_test.go
@@ -1,0 +1,180 @@
+package mkq_test
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestWorker_Retention_KeepCompletedTrims verifies that
+// WithKeepCompleted(N) bounds the completed ZSET to the most recent N
+// entries via BullMQ's removeJobsByMaxCount.
+func TestWorker_Retention_KeepCompletedTrims(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const total = 110
+	const keep = 100
+	for i := range total {
+		_, err := queue.Add(ctx, testPayload{Inbox: strconv.Itoa(i)},
+			mkq.WithKeepCompleted(keep),
+		)
+		require.NoError(t, err)
+	}
+
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		return nil, nil
+	},
+		mkq.WithConcurrency(4),
+		mkq.WithIdlePollInterval(10*time.Millisecond),
+	)
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+
+	// Wait for the wait list to drain and the trim to settle.
+	waitFor(t, ctx, 50*time.Millisecond, func() bool {
+		waitLen, _ := rdb.LLen(ctx, base+"wait").Result()
+		activeLen, _ := rdb.LLen(ctx, base+"active").Result()
+		completedLen, _ := rdb.ZCard(ctx, base+"completed").Result()
+		// 全部処理し終わって、completed が trim 後の値で安定したか。
+		return waitLen == 0 && activeLen == 0 && completedLen == int64(keep)
+	})
+
+	got, err := rdb.ZCard(ctx, base+"completed").Result()
+	require.NoError(t, err)
+	assert.EqualValues(t, keep, got, "completed ZSET must be trimmed to keep")
+}
+
+// TestWorker_Retention_KeepCompletedZeroRemovesJob verifies that
+// WithKeepCompleted(0) (BullMQ removeOnComplete=true) deletes the job
+// HASH outright instead of putting it into the completed ZSET.
+func TestWorker_Retention_KeepCompletedZeroRemovesJob(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, testPayload{}, mkq.WithKeepCompleted(0))
+	require.NoError(t, err)
+
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		return nil, nil
+	}, mkq.WithIdlePollInterval(10*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		waitLen, _ := rdb.LLen(ctx, base+"wait").Result()
+		activeLen, _ := rdb.LLen(ctx, base+"active").Result()
+		exists, _ := rdb.Exists(ctx, base+job.ID).Result()
+		// HASH が消滅し、queue keys も空になるまで待つ。
+		return waitLen == 0 && activeLen == 0 && exists == 0
+	})
+
+	completedLen, _ := rdb.ZCard(ctx, base+"completed").Result()
+	assert.Zero(t, completedLen, "completed ZSET must be empty when keep=0")
+	exists, _ := rdb.Exists(ctx, base+job.ID).Result()
+	assert.EqualValues(t, 0, exists, "job HASH must be removed when keep=0")
+}
+
+// TestWorker_Retention_DefaultKeepsAll regression-pins the BullMQ
+// default: when neither WithKeepCompleted nor WithKeepFailed is set,
+// finished jobs accumulate in their respective ZSET indefinitely.
+func TestWorker_Retention_DefaultKeepsAll(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const total = 5
+	for i := range total {
+		_, err := queue.Add(ctx, testPayload{Inbox: strconv.Itoa(i)})
+		require.NoError(t, err)
+	}
+
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		return nil, nil
+	}, mkq.WithIdlePollInterval(10*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		n, _ := rdb.ZCard(ctx, base+"completed").Result()
+		return n == int64(total)
+	})
+
+	got, err := rdb.ZCard(ctx, base+"completed").Result()
+	require.NoError(t, err)
+	assert.EqualValues(t, total, got, "default retention must keep all completed jobs")
+}
+
+// TestWorker_Retention_KeepFailedTrims is the failure-side analogue
+// of KeepCompletedTrims.
+func TestWorker_Retention_KeepFailedTrims(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const total = 5
+	const keep = 2
+	for i := range total {
+		_, err := queue.Add(ctx, testPayload{Inbox: strconv.Itoa(i)},
+			mkq.WithKeepFailed(keep),
+		)
+		require.NoError(t, err)
+	}
+
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		return nil, errors.New("boom")
+	},
+		mkq.WithConcurrency(2),
+		mkq.WithIdlePollInterval(10*time.Millisecond),
+	)
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+
+	waitFor(t, ctx, 50*time.Millisecond, func() bool {
+		waitLen, _ := rdb.LLen(ctx, base+"wait").Result()
+		activeLen, _ := rdb.LLen(ctx, base+"active").Result()
+		failedLen, _ := rdb.ZCard(ctx, base+"failed").Result()
+		return waitLen == 0 && activeLen == 0 && failedLen == int64(keep)
+	})
+
+	got, err := rdb.ZCard(ctx, base+"failed").Result()
+	require.NoError(t, err)
+	assert.EqualValues(t, keep, got, "failed ZSET must be trimmed to keep")
+}

--- a/worker_test.go
+++ b/worker_test.go
@@ -272,6 +272,49 @@ func TestWorker_Process_PriorityOrderingWithinPrioritized(t *testing.T) {
 	assert.Equal(t, low.ID, second)
 }
 
+// TestWorker_Process_DelayedJobRunsAfterDelay pins that delayed jobs
+// (added via WithDelay) get picked up by the worker once their delay
+// elapses. mkq doesn't run a separate scheduler — promotion is
+// performed inline by moveToActive-11.lua's promoteDelayedJobs call
+// every dequeue tick — so this test is the regression guarantee that
+// the polling loop + vendored Lua combination still works end-to-end.
+func TestWorker_Process_DelayedJobRunsAfterDelay(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const delay = 80 * time.Millisecond
+	addedAt := time.Now()
+	job, err := queue.Add(ctx, testPayload{Inbox: "delayed"},
+		mkq.WithDelay(delay),
+	)
+	require.NoError(t, err)
+
+	ranAt := make(chan time.Time, 1)
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		ranAt <- time.Now()
+		return nil, nil
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	got := receiveOrFail(t, ctx, ranAt)
+	elapsed := got.Sub(addedAt)
+	assert.GreaterOrEqual(t, elapsed, delay-10*time.Millisecond,
+		"handler must not run before the delay (got elapsed=%v)", elapsed)
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"completed", job.ID).Result()
+		return v > 0
+	})
+}
+
 func TestWorker_Stop_DrainsInflight(t *testing.T) {
 	t.Parallel()
 	prefix := uniquePrefix(t)


### PR DESCRIPTION
Resolves #14. Advances #1 (Phase 3 alpha — fourth slice).

## Summary

Two small Phase 3 leftovers bundled together:

1. **Retention public API** — wires up the \`KeepJobs{Count, Age}\` encoder shipped in PR #9 to a per-Add option (\`WithKeepCompleted\` / \`WithKeepFailed\`).
2. **Delayed pickup verification** — pins that delayed jobs are picked up end-to-end via \`moveToActive\`'s inline \`promoteDelayedJobs\` (no code change, regression test only).

## Key Changes

### Public API

\`\`\`go
func WithKeepCompleted(n int) AddOption  // 0 = remove on complete (HASH gone), n>0 = keep last n
func WithKeepFailed(n int) AddOption     // same for failed ZSET
\`\`\`

Semantics match BullMQ \`removeOnComplete\` / \`removeOnFail\`:

- Not calling = keep all (default).
- \`WithKeepCompleted(0)\` = delete the HASH on completion (BullMQ \`removeOnComplete: true\`).
- \`WithKeepCompleted(n>0)\` = keep most recent n entries via \`removeJobsByMaxCount\` Lua.

\`addConfig\` stores both as \`*int\` so "not set" stays distinct from "explicitly 0".

### Wire compatibility

- HASH \`opts\` JSON gains BullMQ's exact keys \`removeOnComplete\` / \`removeOnFail\` when supplied.
- \`MoveToFinishedOpts.KeepJobs.Count\` is constructed only when the corresponding pointer is non-nil; the PR #12 nil-safe defaults stay intact for legacy call sites.
- 0 new Lua scripts, 0 new dependencies.

### Worker engine

- \`jobOpts\` gains \`removeOnComplete\` / \`removeOnFail\`; \`parseJobOpts\` decodes them from the HASH \`opts\` JSON.
- \`finalise\` hands the full \`jobOpts\` to \`finishCompleted\` / \`finishFailed\` (instead of the bare \`attempts\` int) so each terminal path picks the right retention pointer.
- \`runMoveToFinished\` accepts an explicit \`keepCount *int\`.

### Delayed pickup

No code change. \`moveToActive-11.lua\` already calls \`promoteDelayedJobs\` on every dequeue, so the polling loop transparently picks up delayed jobs once their target timestamp passes.

## Testing

\`\`\`
go vet ./...
gofmt -l .
go build ./...
go test ./... -race -count=1
\`\`\`

- \`worker_retention_test.go\` (integration, real Redis 7):
  - \`KeepCompletedTrims\`: 110 jobs with \`WithKeepCompleted(100)\`, final completed ZSET has exactly 100 entries.
  - \`KeepCompletedZeroRemovesJob\`: \`WithKeepCompleted(0)\`, HASH is removed, completed ZSET stays empty.
  - \`DefaultKeepsAll\`: no \`With…Keep…\`, 5 finished jobs stay in completed indefinitely (regression pin).
  - \`KeepFailedTrims\`: failed-side analogue with \`WithKeepFailed(2)\`.
- \`worker_test.go\` adds \`TestWorker_Process_DelayedJobRunsAfterDelay\`.

5 sequential \`go test ./... -race -count=1\` runs all green. Existing PR #5 / #9 / #12 tests untouched and still pass.

## Out of scope (deferred)

- Age-based retention API (\`KeepJobs.Age\` type already shipped).
- BullMQ \`removeOn*\` boolean shorthand; \`WithKeepCompleted(0)\` covers \`removeOnComplete=true\`, "not setting" covers \`removeOnComplete=false\`.
- \`Queue.Promote()\` admin API.
- Queue-level default retention (\`Define\`-time options).

## Related Issue

- Sub-issue: #14
- Tracking: #1 (Phase 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
