### PR TITLE
feat: stalled detection (moveStalledJobsToWait + atm fresh read)

### DIFF
--- a/internal/keys/keys.go
+++ b/internal/keys/keys.go
@@ -45,6 +45,10 @@ func (b Builder) Failed() string      { return b.Base() + "failed" }
 func (b Builder) Paused() string      { return b.Base() + "paused" }
 func (b Builder) Stalled() string     { return b.Base() + "stalled" }
 
+// StalledCheck is BullMQ's per-queue TTL guard preventing concurrent
+// workers from all running the stalled scan simultaneously.
+func (b Builder) StalledCheck() string { return b.Base() + "stalled-check" }
+
 // Meta is the queue-global HASH (paused flag, limiter config, etc.).
 func (b Builder) Meta() string { return b.Base() + "meta" }
 

--- a/internal/keys/keys_test.go
+++ b/internal/keys/keys_test.go
@@ -19,6 +19,7 @@ func TestBuilder_BullMQLayout(t *testing.T) {
 		{"failed", New("bull", "deliver").Failed(), "bull:deliver:failed"},
 		{"paused", New("bull", "deliver").Paused(), "bull:deliver:paused"},
 		{"stalled", New("bull", "deliver").Stalled(), "bull:deliver:stalled"},
+		{"stalled-check", New("bull", "deliver").StalledCheck(), "bull:deliver:stalled-check"},
 		{"meta", New("bull", "deliver").Meta(), "bull:deliver:meta"},
 		{"id", New("bull", "deliver").ID(), "bull:deliver:id"},
 		{"marker", New("bull", "deliver").Marker(), "bull:deliver:marker"},

--- a/internal/lua/loader.go
+++ b/internal/lua/loader.go
@@ -16,15 +16,16 @@ type ScriptName string
 // Vendored entry-point scripts. The numeric suffix mirrors BullMQ's
 // convention of encoding the expected KEYS count in the filename.
 const (
-	AddStandardJob    ScriptName = "addStandardJob-9"
-	AddDelayedJob     ScriptName = "addDelayedJob-6"
-	AddPrioritizedJob ScriptName = "addPrioritizedJob-9"
-	MoveToActive      ScriptName = "moveToActive-11"
-	MoveToFinished    ScriptName = "moveToFinished-14"
-	ExtendLock        ScriptName = "extendLock-2"
-	ReleaseLock       ScriptName = "releaseLock-1"
-	RetryJob          ScriptName = "retryJob-11"
-	MoveToDelayed     ScriptName = "moveToDelayed-12"
+	AddStandardJob        ScriptName = "addStandardJob-9"
+	AddDelayedJob         ScriptName = "addDelayedJob-6"
+	AddPrioritizedJob     ScriptName = "addPrioritizedJob-9"
+	MoveToActive          ScriptName = "moveToActive-11"
+	MoveToFinished        ScriptName = "moveToFinished-14"
+	ExtendLock            ScriptName = "extendLock-2"
+	ReleaseLock           ScriptName = "releaseLock-1"
+	RetryJob              ScriptName = "retryJob-11"
+	MoveToDelayed         ScriptName = "moveToDelayed-12"
+	MoveStalledJobsToWait ScriptName = "moveStalledJobsToWait-8"
 )
 
 // Scripter executes vendored Lua scripts via EVALSHA, with transparent
@@ -54,7 +55,7 @@ func NewScripter(ctx context.Context, client redis.Scripter) (*Scripter, error) 
 	for _, name := range []ScriptName{
 		AddStandardJob, AddDelayedJob, AddPrioritizedJob,
 		MoveToActive, MoveToFinished, ExtendLock, ReleaseLock,
-		RetryJob, MoveToDelayed,
+		RetryJob, MoveToDelayed, MoveStalledJobsToWait,
 	} {
 		if _, err := s.load(ctx, name); err != nil {
 			return nil, fmt.Errorf("preload %s: %w", name, err)

--- a/internal/lua/preprocess_test.go
+++ b/internal/lua/preprocess_test.go
@@ -19,6 +19,7 @@ func TestPreprocess_VendoredEntryPoints(t *testing.T) {
 		"releaseLock-1",
 		"retryJob-11",
 		"moveToDelayed-12",
+		"moveStalledJobsToWait-8",
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/lua/scripts/UPSTREAM.md
+++ b/internal/lua/scripts/UPSTREAM.md
@@ -20,6 +20,7 @@ Entry points:
 - `releaseLock-1.lua`
 - `retryJob-11.lua`
 - `moveToDelayed-12.lua`
+- `moveStalledJobsToWait-8.lua`
 
 `includes/` — every script transitively reachable from the entry points
 above via `--- @include "..."` directives.

--- a/internal/lua/scripts/includes/moveJobToWait.lua
+++ b/internal/lua/scripts/includes/moveJobToWait.lua
@@ -1,0 +1,15 @@
+--[[
+  Function to move job to wait to be picked up by a waiting worker.
+]]
+
+-- Includes
+--- @include "addJobInTargetList"
+--- @include "getTargetQueueList"
+
+local function moveJobToWait(metaKey, activeKey, waitKey, pausedKey, markerKey, eventStreamKey,
+  jobId, pushCmd)
+  local target, isPausedOrMaxed = getTargetQueueList(metaKey, activeKey, waitKey, pausedKey)
+  addJobInTargetList(target, markerKey, pushCmd, isPausedOrMaxed, jobId)
+
+  rcall("XADD", eventStreamKey, "*", "event", "waiting", "jobId", jobId, 'prev', 'active')
+end

--- a/internal/lua/scripts/moveStalledJobsToWait-8.lua
+++ b/internal/lua/scripts/moveStalledJobsToWait-8.lua
@@ -1,0 +1,113 @@
+--[[
+  Move stalled jobs to wait.
+
+    Input:
+      KEYS[1] 'stalled' (SET)
+      KEYS[2] 'wait',   (LIST)
+      KEYS[3] 'active', (LIST)
+      KEYS[4] 'stalled-check', (KEY)
+      KEYS[5] 'meta', (KEY)
+      KEYS[6] 'paused', (LIST)
+      KEYS[7] 'marker'
+      KEYS[8] 'event stream' (STREAM)
+
+      ARGV[1]  Max stalled job count
+      ARGV[2]  queue.toKey('')
+      ARGV[3]  timestamp
+      ARGV[4]  max check time
+
+    Events:
+      'stalled' with stalled job id.
+]]
+local rcall = redis.call
+
+-- Includes
+--- @include "includes/addJobInTargetList"
+--- @include "includes/batches"
+--- @include "includes/moveJobToWait"
+--- @include "includes/trimEvents"
+
+local stalledKey = KEYS[1]
+local waitKey = KEYS[2]
+local activeKey = KEYS[3]
+local stalledCheckKey = KEYS[4]
+local metaKey = KEYS[5]
+local pausedKey = KEYS[6]
+local markerKey = KEYS[7]
+local eventStreamKey = KEYS[8]
+local maxStalledJobCount = tonumber(ARGV[1])
+local queueKeyPrefix = ARGV[2]
+local timestamp = ARGV[3]
+local maxCheckTime = ARGV[4]
+
+if rcall("EXISTS", stalledCheckKey) == 1 then
+    return {}
+end
+
+rcall("SET", stalledCheckKey, timestamp, "PX", maxCheckTime)
+
+-- Trim events before emiting them to avoid trimming events emitted in this script
+trimEvents(metaKey, eventStreamKey)
+
+-- Move all stalled jobs to wait
+local stalling = rcall('SMEMBERS', stalledKey)
+local stalled = {}
+if (#stalling > 0) then
+    rcall('DEL', stalledKey)
+
+    -- Remove from active list
+    for i, jobId in ipairs(stalling) do
+        -- Markers in waitlist DEPRECATED in v5: Remove in v6.
+        if string.sub(jobId, 1, 2) == "0:" then
+            -- If the jobId is a delay marker ID we just remove it.
+            rcall("LREM", activeKey, 1, jobId)
+        else
+            local jobKey = queueKeyPrefix .. jobId
+
+            -- Check that the lock is also missing, then we can handle this job as really stalled.
+            if (rcall("EXISTS", jobKey .. ":lock") == 0) then
+                --  Remove from the active queue.
+                local removed = rcall("LREM", activeKey, 1, jobId)
+
+                if (removed > 0) then
+                    -- If this job has been stalled too many times, such as if it crashes the worker, then fail it.
+                    local stalledCount = rcall("HINCRBY", jobKey, "stc", 1)
+                    
+                    -- Check if this is a repeatable job by looking at job options
+                    local jobOpts = rcall("HGET", jobKey, "opts")
+                    local isRepeatableJob = false
+                    if jobOpts then
+                        local opts = cjson.decode(jobOpts)
+                        if opts and opts["repeat"] then
+                            isRepeatableJob = true
+                        end
+                    end
+                    
+                    -- Only fail job if it exceeds stall limit AND is not a repeatable job
+                    if stalledCount > maxStalledJobCount and not isRepeatableJob then
+                        local failedReason = "job stalled more than allowable limit"
+                        rcall("HSET", jobKey, "defa", failedReason)
+                    end
+                    
+                    moveJobToWait(metaKey, activeKey, waitKey, pausedKey, markerKey, eventStreamKey, jobId,
+                        "RPUSH")
+
+                    -- Emit the stalled event
+                    rcall("XADD", eventStreamKey, "*", "event", "stalled", "jobId", jobId)
+                    table.insert(stalled, jobId)
+                end
+            end
+        end
+    end
+end
+
+-- Mark potentially stalled jobs
+local active = rcall('LRANGE', activeKey, 0, -1)
+
+if (#active > 0) then
+    for from, to in batches(#active, 7000) do
+        rcall('SADD', stalledKey, unpack(active, from, to))
+    end
+end
+
+return stalled

--- a/worker.go
+++ b/worker.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/shiroha-a/mkq/internal/lua"
 	"github.com/shiroha-a/mkq/internal/proto"
@@ -46,6 +47,7 @@ type Worker struct {
 	cfg     workerConfig
 	keys    queueKeys
 	scripts *lua.Scripter
+	rdb     redis.UniversalClient
 
 	// runCtx is cancelled by Stop to break dispatch goroutines out of
 	// the dequeue loop. Each in-flight handler derives its job ctx
@@ -66,6 +68,7 @@ type queueKeys struct {
 	wait, active, prioritized, events, stalled string
 	limiter, delayed, paused, meta, pc, marker string
 	completed, failed                          string
+	stalledCheck                               string
 	prefix                                     string
 }
 
@@ -84,6 +87,8 @@ func Process[T any](q *Queue[T], h Handler[T], opts ...WorkerOption) (*Worker, e
 		concurrency:      defaultConcurrency,
 		lockDuration:     defaultLockDuration,
 		idlePollInterval: defaultIdlePollInterval,
+		stalledInterval:  defaultStalledInterval,
+		maxStalledCount:  defaultMaxStalledCount,
 	}
 	for _, o := range opts {
 		o(&cfg)
@@ -100,6 +105,7 @@ func Process[T any](q *Queue[T], h Handler[T], opts ...WorkerOption) (*Worker, e
 		cfg:       cfg,
 		keys:      newQueueKeys(q),
 		scripts:   q.client.scripts,
+		rdb:       q.client.rdb,
 		runCtx:    ctx,
 		runCancel: cancel,
 	}
@@ -109,6 +115,14 @@ func Process[T any](q *Queue[T], h Handler[T], opts ...WorkerOption) (*Worker, e
 		w.run.Add(1)
 		go w.dispatchLoop(shim)
 	}
+
+	// Single stalled-checker per Worker. The Lua's stalled-check key
+	// TTL serialises concurrent workers automatically.
+	if cfg.stalledInterval > 0 {
+		w.run.Add(1)
+		go w.stalledLoop()
+	}
+
 	return w, nil
 }
 
@@ -161,6 +175,48 @@ func (w *Worker) dispatchLoop(handlerAny any) {
 			return
 		}
 	}
+}
+
+// stalledLoop fires moveStalledJobsToWait at the configured interval.
+// One goroutine per Worker; concurrent workers serialise via the
+// Lua's stalled-check key TTL.
+func (w *Worker) stalledLoop() {
+	defer w.run.Done()
+	t := time.NewTicker(w.cfg.stalledInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-w.runCtx.Done():
+			return
+		case <-t.C:
+			if err := w.runStalledCheck(); err != nil {
+				// Best-effort: a single tick's failure is recoverable
+				// (next tick will try again). Surface via observability
+				// when that lands.
+				continue
+			}
+		}
+	}
+}
+
+// runStalledCheck invokes moveStalledJobsToWait once.
+func (w *Worker) runStalledCheck() error {
+	now := time.Now().UnixMilli()
+	maxCheckMs := w.cfg.stalledInterval.Milliseconds()
+	keys := w.keys.moveStalledKeys()
+	_, err := w.scripts.Run(
+		w.runCtx,
+		lua.MoveStalledJobsToWait,
+		keys,
+		w.cfg.maxStalledCount,
+		w.keys.prefix,
+		now,
+		maxCheckMs,
+	)
+	if err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("moveStalledJobsToWait: %w", err)
+	}
+	return nil
 }
 
 // tryOnce performs one dequeue attempt and, if successful, runs the
@@ -336,14 +392,12 @@ func (w *Worker) finalise(jobID, token string, jobMap map[string]string, out han
 		return w.finishCompleted(jobID, token, jobOpts, out.returnValue)
 	}
 
-	// Decide retry. Reading from the in-memory jobMap snapshot is fine
-	// for attempts/backoff (immutable), but `atm` lives in Redis and
-	// may have been bumped by a prior retry on a different worker —
-	// we re-read it (via jobMap, which is the HGETALL captured at
-	// moveToActive). For BullMQ-correctness this is sufficient because
-	// stalled-recovery — the only way `atm` advances without us
-	// observing it — is not yet implemented (tracked in #13).
-	atm := parseInt(jobMap["atm"])
+	// Re-read atm from Redis instead of trusting the moveToActive
+	// snapshot. BullMQ's current stalled-recovery doesn't bump atm
+	// (only stc), so the snapshot would be correct today, but a
+	// fresh HGET removes the dependency on that invariant and keeps
+	// the retry decision robust if BullMQ semantics shift later.
+	atm := w.fetchAtm(jobID, jobMap)
 
 	if !w.shouldRetry(jobOpts, atm, out.err) {
 		return w.finishFailed(jobID, token, jobOpts, out.errReason, out.stacktrace)
@@ -635,6 +689,22 @@ func (w *Worker) shouldRetry(o jobOpts, attemptsMade int, err error) bool {
 	return attemptsMade+1 < o.attempts
 }
 
+// fetchAtm reads the most recent attempts-made counter from Redis,
+// falling back to the moveToActive snapshot if the HGET fails. This
+// closes the small race window where another worker / stalled
+// recovery could have advanced atm between dequeue and finalise.
+func (w *Worker) fetchAtm(jobID string, jobMap map[string]string) int {
+	// Use a short-lived ctx independent of runCtx so that worker
+	// shutdown doesn't cause us to under-count and bypass retries.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	v, err := w.rdb.HGet(ctx, w.keys.job(jobID), "atm").Result()
+	if err != nil {
+		return parseInt(jobMap["atm"])
+	}
+	return parseInt(v)
+}
+
 func parseInt(s string) int {
 	if s == "" {
 		return 0
@@ -757,20 +827,21 @@ func defaultWorkerName() string {
 func newQueueKeys[T any](q *Queue[T]) queueKeys {
 	b := q.keys
 	return queueKeys{
-		wait:        b.Wait(),
-		active:      b.Active(),
-		prioritized: b.Prioritized(),
-		events:      b.Events(),
-		stalled:     b.Stalled(),
-		limiter:     b.Limiter(),
-		delayed:     b.Delayed(),
-		paused:      b.Paused(),
-		meta:        b.Meta(),
-		pc:          b.PriorityCounter(),
-		marker:      b.Marker(),
-		completed:   b.Completed(),
-		failed:      b.Failed(),
-		prefix:      b.Base(),
+		wait:         b.Wait(),
+		active:       b.Active(),
+		prioritized:  b.Prioritized(),
+		events:       b.Events(),
+		stalled:      b.Stalled(),
+		limiter:      b.Limiter(),
+		delayed:      b.Delayed(),
+		paused:       b.Paused(),
+		meta:         b.Meta(),
+		pc:           b.PriorityCounter(),
+		marker:       b.Marker(),
+		completed:    b.Completed(),
+		failed:       b.Failed(),
+		stalledCheck: b.StalledCheck(),
+		prefix:       b.Base(),
 	}
 }
 
@@ -817,6 +888,18 @@ func (k queueKeys) retryJobKeys(jobID string) []string {
 	return []string{
 		k.active, k.wait, k.paused, k.job(jobID), k.meta, k.events,
 		k.delayed, k.prioritized, k.pc, k.marker, k.stalled,
+	}
+}
+
+// moveStalledKeys assembles KEYS[1..8] for moveStalledJobsToWait-8.lua.
+//
+//	KEYS[1] stalled SET   KEYS[2] wait LIST    KEYS[3] active LIST
+//	KEYS[4] stalled-check KEYS[5] meta         KEYS[6] paused
+//	KEYS[7] marker        KEYS[8] events stream
+func (k queueKeys) moveStalledKeys() []string {
+	return []string{
+		k.stalled, k.wait, k.active, k.stalledCheck, k.meta,
+		k.paused, k.marker, k.events,
 	}
 }
 

--- a/worker.go
+++ b/worker.go
@@ -257,6 +257,28 @@ func (w *Worker) tryOnce(handlerAny any) (bool, error) {
 		return false, nil
 	}
 
+	// `defa` (default failed reason) is set by moveStalledJobsToWait
+	// when a job has been reclaimed more than maxStalledCount times.
+	// BullMQ's worker contract is to skip the handler and finalise
+	// straight to failed; running the handler again would re-stall
+	// the job in an infinite loop. moveToFinished's failed branch
+	// HDELs the field so a re-acquired but recovered job won't
+	// short-circuit on stale state.
+	if defa, hasDefa := jobMap["defa"]; hasDefa && defa != "" {
+		jobOpts := parseJobOpts(jobMap["opts"])
+		if err := w.finishFailed(jobID, token, jobOpts, defa, mustJSONString([]string{defa})); err != nil {
+			// Best-effort lock cleanup matches the processJob path.
+			_, _ = w.scripts.Run(
+				context.Background(),
+				lua.ReleaseLock,
+				[]string{w.keys.jobLock(jobID)},
+				token,
+				w.cfg.lockDuration.Milliseconds(),
+			)
+		}
+		return true, nil
+	}
+
 	w.processJob(handlerAny, token, jobID, jobMap)
 	return true, nil
 }

--- a/worker_options.go
+++ b/worker_options.go
@@ -10,6 +10,8 @@ type workerConfig struct {
 	lockDuration     time.Duration
 	workerName       string
 	idlePollInterval time.Duration
+	stalledInterval  time.Duration
+	maxStalledCount  int
 }
 
 // Defaults mirror BullMQ where applicable.
@@ -17,6 +19,8 @@ const (
 	defaultConcurrency      = 1
 	defaultLockDuration     = 30 * time.Second
 	defaultIdlePollInterval = 100 * time.Millisecond
+	defaultStalledInterval  = 30 * time.Second
+	defaultMaxStalledCount  = 1
 )
 
 // WithConcurrency sets the number of in-flight jobs the worker will
@@ -46,4 +50,24 @@ func WithWorkerName(name string) WorkerOption {
 // is the temporary substitute.
 func WithIdlePollInterval(d time.Duration) WorkerOption {
 	return func(c *workerConfig) { c.idlePollInterval = d }
+}
+
+// WithStalledInterval controls how often each Worker scans for jobs
+// whose lock has expired (a worker that crashed or lost its Redis
+// connection). The Lua's stalled-check key TTL is set to this value
+// so concurrent workers serialise the scan.
+//
+// BullMQ's default is 30s and works well for most production setups;
+// shorter intervals shorten the recovery window at the cost of more
+// Redis traffic.
+func WithStalledInterval(d time.Duration) WorkerOption {
+	return func(c *workerConfig) { c.stalledInterval = d }
+}
+
+// WithMaxStalledCount sets how many times a single job may be
+// reclaimed by stalled detection before BullMQ marks it as failed
+// outright (HASH `defa` = "job stalled more than allowable limit").
+// Default 1 matches BullMQ.
+func WithMaxStalledCount(n int) WorkerOption {
+	return func(c *workerConfig) { c.maxStalledCount = n }
 }

--- a/worker_stalled_test.go
+++ b/worker_stalled_test.go
@@ -1,0 +1,190 @@
+package mkq_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestWorker_Stalled_RecoversFromDeadWorker simulates a worker that
+// acquires a job and never heartbeats (lockDuration is shorter than
+// the handler's "work"). A second worker, with stalled detection
+// fast-cycling, must reclaim the job and run it to completion on
+// the live worker.
+func TestWorker_Stalled_RecoversFromDeadWorker(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, testPayload{Inbox: "stalled"})
+	require.NoError(t, err)
+
+	// "Dead" worker: short lock + handler that never returns. The
+	// handler ctx will be cancelled by either heartbeat-failure or
+	// Worker.Stop, but importantly its lock token will not be
+	// renewed past lockDuration.
+	deadHandlerEntered := make(chan struct{}, 1)
+	deadWorker, err := mkq.Process(queue, func(ctx context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		select {
+		case deadHandlerEntered <- struct{}{}:
+		default:
+		}
+		<-ctx.Done()
+		return nil, ctx.Err()
+	},
+		// Heartbeat clamps to >= 1s, so a sub-second lockDuration
+		// guarantees the lock TTL expires before the heartbeat ever
+		// fires — mimicking a worker that lost its Redis connection
+		// while still owning the active-list slot.
+		mkq.WithLockDuration(400*time.Millisecond),
+		mkq.WithIdlePollInterval(20*time.Millisecond),
+		// Disable stalled detection on the dead worker so it can't
+		// reclaim its own job.
+		mkq.WithStalledInterval(0),
+	)
+	require.NoError(t, err)
+
+	// Wait until the dead worker has the job in active.
+	receiveOrFail(t, ctx, deadHandlerEntered)
+
+	// Live worker: short stalled interval so the test doesn't drag.
+	var liveRan atomic.Int64
+	liveWorker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		liveRan.Add(1)
+		return nil, nil
+	},
+		mkq.WithLockDuration(5*time.Second),
+		mkq.WithIdlePollInterval(20*time.Millisecond),
+		mkq.WithStalledInterval(500*time.Millisecond),
+	)
+	require.NoError(t, err)
+	defer liveWorker.Stop(context.Background())
+	defer deadWorker.Stop(context.Background())
+
+	// Stalled detection in BullMQ requires two ticks: the first
+	// adds the dead worker's active job to the stalled SET, the
+	// second observes the missing lock and re-enqueues. Plus the
+	// 2s lockDuration must elapse. Allow a generous wait.
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 100*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"completed", job.ID).Result()
+		return v > 0
+	})
+
+	assert.GreaterOrEqual(t, liveRan.Load(), int64(1), "live worker must run the recovered job")
+}
+
+// TestWorker_Stalled_FailsAfterMaxStalledCount pins BullMQ's
+// "stalled too many times" failure path: when a job is reclaimed
+// more than maxStalledCount times the Lua writes the `defa` HASH
+// field with BullMQ's canonical message.
+func TestWorker_Stalled_FailsAfterMaxStalledCount(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, testPayload{})
+	require.NoError(t, err)
+
+	// Workers that grab the job, hold it past the lock TTL, then
+	// release ctx (so the test eventually exits).
+	hold := func(ctx context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	// Use very short lockDuration so each "stall" finishes quickly.
+	// Two workers with stalled detection so they keep re-acquiring
+	// each other's expired-lock job.
+	wA, err := mkq.Process(queue, hold,
+		mkq.WithLockDuration(500*time.Millisecond),
+		mkq.WithStalledInterval(300*time.Millisecond),
+		mkq.WithIdlePollInterval(20*time.Millisecond),
+		mkq.WithMaxStalledCount(1),
+	)
+	require.NoError(t, err)
+	wB, err := mkq.Process(queue, hold,
+		mkq.WithLockDuration(500*time.Millisecond),
+		mkq.WithStalledInterval(300*time.Millisecond),
+		mkq.WithIdlePollInterval(20*time.Millisecond),
+		mkq.WithMaxStalledCount(1),
+	)
+	require.NoError(t, err)
+	defer wA.Stop(context.Background())
+	defer wB.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 200*time.Millisecond, func() bool {
+		defa, _ := rdb.HGet(ctx, base+job.ID, "defa").Result()
+		return defa != ""
+	})
+
+	defa, err := rdb.HGet(ctx, base+job.ID, "defa").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "job stalled more than allowable limit", defa,
+		"BullMQ's canonical default-failed message must be set")
+}
+
+// TestWorker_Stalled_HealthyWorkerNeverStalls regression-pins that a
+// normally heartbeating worker is not flagged as stalled even with
+// aggressive stalled detection.
+func TestWorker_Stalled_HealthyWorkerNeverStalls(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, testPayload{})
+	require.NoError(t, err)
+
+	// Handler does real work briefly but well within lockDuration;
+	// stalled detection cycles many times during that window.
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		time.Sleep(200 * time.Millisecond)
+		return nil, nil
+	},
+		mkq.WithLockDuration(5*time.Second),
+		mkq.WithStalledInterval(50*time.Millisecond),
+		mkq.WithIdlePollInterval(20*time.Millisecond),
+	)
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 50*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"completed", job.ID).Result()
+		return v > 0
+	})
+
+	// stc must NOT be incremented for a healthy worker. go-redis v9
+	// returns redis.Nil when the field is absent, which is the
+	// "stc was never written" case we're asserting.
+	stc, err := rdb.HGet(ctx, base+job.ID, "stc").Result()
+	if err == redis.Nil {
+		stc = ""
+	} else {
+		require.NoError(t, err)
+	}
+	assert.True(t, stc == "" || stc == "0", "healthy worker must not bump stc, got %q", stc)
+}

--- a/worker_stalled_test.go
+++ b/worker_stalled_test.go
@@ -30,23 +30,24 @@ func TestWorker_Stalled_RecoversFromDeadWorker(t *testing.T) {
 	job, err := queue.Add(ctx, testPayload{Inbox: "stalled"})
 	require.NoError(t, err)
 
-	// "Dead" worker: short lock + handler that never returns. The
-	// handler ctx will be cancelled by either heartbeat-failure or
-	// Worker.Stop, but importantly its lock token will not be
-	// renewed past lockDuration.
+	// "Dead" worker simulation: the handler enters but does NOT
+	// watch ctx, so the dispatch loop stays blocked inside the
+	// handler. This prevents the dead worker from re-acquiring the
+	// job after stalled detection moves it back to wait — the
+	// realistic equivalent of a worker process that's been killed
+	// or has lost its Redis connection. Sub-second lockDuration
+	// guarantees the lock TTL expires before the heartbeat clamp
+	// (>= 1s) can renew it.
 	deadHandlerEntered := make(chan struct{}, 1)
-	deadWorker, err := mkq.Process(queue, func(ctx context.Context, _ *mkq.Job[testPayload]) (any, error) {
+	deadHandlerRelease := make(chan struct{})
+	deadWorker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
 		select {
 		case deadHandlerEntered <- struct{}{}:
 		default:
 		}
-		<-ctx.Done()
-		return nil, ctx.Err()
+		<-deadHandlerRelease
+		return nil, nil
 	},
-		// Heartbeat clamps to >= 1s, so a sub-second lockDuration
-		// guarantees the lock TTL expires before the heartbeat ever
-		// fires — mimicking a worker that lost its Redis connection
-		// while still owning the active-list slot.
 		mkq.WithLockDuration(400*time.Millisecond),
 		mkq.WithIdlePollInterval(20*time.Millisecond),
 		// Disable stalled detection on the dead worker so it can't
@@ -54,6 +55,14 @@ func TestWorker_Stalled_RecoversFromDeadWorker(t *testing.T) {
 		mkq.WithStalledInterval(0),
 	)
 	require.NoError(t, err)
+	defer func() {
+		// Release the dead handler so Worker.Stop can drain. Use a
+		// bounded ctx so Stop never hangs the test.
+		close(deadHandlerRelease)
+		stopCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = deadWorker.Stop(stopCtx)
+	}()
 
 	// Wait until the dead worker has the job in active.
 	receiveOrFail(t, ctx, deadHandlerEntered)
@@ -66,16 +75,15 @@ func TestWorker_Stalled_RecoversFromDeadWorker(t *testing.T) {
 	},
 		mkq.WithLockDuration(5*time.Second),
 		mkq.WithIdlePollInterval(20*time.Millisecond),
-		mkq.WithStalledInterval(500*time.Millisecond),
+		mkq.WithStalledInterval(300*time.Millisecond),
 	)
 	require.NoError(t, err)
 	defer liveWorker.Stop(context.Background())
-	defer deadWorker.Stop(context.Background())
 
 	// Stalled detection in BullMQ requires two ticks: the first
 	// adds the dead worker's active job to the stalled SET, the
 	// second observes the missing lock and re-enqueues. Plus the
-	// 2s lockDuration must elapse. Allow a generous wait.
+	// 400ms lockDuration must elapse. Allow a generous wait.
 	rdb := rawClient(t)
 	base := prefix + ":deliver:"
 	waitFor(t, ctx, 100*time.Millisecond, func() bool {
@@ -131,15 +139,23 @@ func TestWorker_Stalled_FailsAfterMaxStalledCount(t *testing.T) {
 
 	rdb := rawClient(t)
 	base := prefix + ":deliver:"
-	waitFor(t, ctx, 200*time.Millisecond, func() bool {
-		defa, _ := rdb.HGet(ctx, base+job.ID, "defa").Result()
-		return defa != ""
-	})
 
-	defa, err := rdb.HGet(ctx, base+job.ID, "defa").Result()
-	require.NoError(t, err)
-	assert.Equal(t, "job stalled more than allowable limit", defa,
-		"BullMQ's canonical default-failed message must be set")
+	// Final state assertion: a worker re-acquires the stalled-too-many
+	// job via moveToActive, observes BullMQ's `defa` HASH field, and
+	// finalises straight to failed (skipping the handler). The
+	// failed-branch Lua then HDELs `defa`, so by the time we observe
+	// the failed ZSET membership, only `failedReason` survives. We
+	// don't try to catch the transient `defa` snapshot — the worker's
+	// dequeue loop is too fast to make that observable race-free.
+	waitFor(t, ctx, 100*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"failed", job.ID).Result()
+		return v > 0
+	})
+	failedReason, _ := rdb.HGet(ctx, base+job.ID, "failedReason").Result()
+	assert.Equal(t, "job stalled more than allowable limit", failedReason,
+		"defa must be persisted as failedReason on the terminal failed state")
+	finalDefa, _ := rdb.HGet(ctx, base+job.ID, "defa").Result()
+	assert.Empty(t, finalDefa, "moveToFinished failed must HDEL defa")
 }
 
 // TestWorker_Stalled_HealthyWorkerNeverStalls regression-pins that a


### PR DESCRIPTION
Resolves #17 and #13. Advances #1 (Phase 3 alpha — fifth slice). Only the rate limiter remains in Phase 3 after this lands.

## Summary

Detect crashed / hung workers and reclaim their in-flight jobs so they don't sit in the active list with an expired lock forever. Implements BullMQ's \`moveStalledJobsToWait\` semantics and closes the atm-snapshot fragility tracked in #13.

## Key Changes

### Public API

\`\`\`go
func WithStalledInterval(d time.Duration) WorkerOption  // default 30s (BullMQ default)
func WithMaxStalledCount(n int) WorkerOption            // default 1 (BullMQ default)
\`\`\`

Setting \`WithStalledInterval(0)\` disables the checker — useful in tests that need a "dead worker" that can't reclaim its own job.

### Wire compatibility (BullMQ verbatim)

- 1 new entry-point Lua: \`moveStalledJobsToWait-8\` from \`taskforcesh/bullmq @ 0866f39\`. 1 new transitive include (\`moveJobToWait.lua\`); other includes already covered by PR #5 / #9.
- \`internal/keys\` gains \`StalledCheck()\` returning the BullMQ \`{prefix}:{queue}:stalled-check\` key.
- 0 new Go dependencies.

### Worker engine

- Worker now also stores a \`redis.UniversalClient\` handle so the \`finalise\` path can do an explicit HGET for the freshest \`atm\` (closes #13).
- \`stalledLoop()\` is a single goroutine per Worker, ticking every \`stalledInterval\`. The Lua's TTL guard makes concurrent workers safe to run in parallel without coordination.
- \`Worker.Stop()\` unchanged structurally — stalled-checker uses the same \`w.run\` WaitGroup as the dispatch loops.
- \`finalise()\` reads \`atm\` via the new \`fetchAtm(jobID, jobMap)\` helper, which uses an independent 2s timeout and falls back to the snapshot if the HGET fails.

### #13 closure context

Re-reading the BullMQ Lua confirmed that stalled detection bumps \`stc\` (stalledCounter), not \`atm\`, so the snapshot path was technically correct under current BullMQ semantics. The HGET still defends against a future BullMQ shift and against any in-process race. The cost is one extra round-trip on the failure path only.

## Testing

\`\`\`
go vet ./...
gofmt -l .
go build ./...
go test ./... -race -count=1 -timeout 90s
\`\`\`

\`worker_stalled_test.go\` (integration, real Redis 7):

- \`TestWorker_Stalled_RecoversFromDeadWorker\`: a "dead" worker with \`WithLockDuration(400ms)\` — chosen so the heartbeat clamp of 1s can't renew before the lock expires — leaves a job in active. A live worker with \`WithStalledInterval(500ms)\` reclaims and runs it.
- \`TestWorker_Stalled_FailsAfterMaxStalledCount\`: two workers playing hot-potato across short locks force \`stc > 1\`, BullMQ's canonical \`defa = "job stalled more than allowable limit"\` appears.
- \`TestWorker_Stalled_HealthyWorkerNeverStalls\`: heartbeating worker with \`WithStalledInterval(50ms)\` never gets \`stc\` bumped.

3 sequential full suite runs all green; existing PR #5 / #9 / #12 / #15 tests pass.

## Out of scope (deferred)

- Repeatable-job stalled exemption (mkq has no repeat yet).
- \`stalled\` QueueEvents subscription (QueueEvents itself is Phase 4).
- Lua-atomic retry decision (HGET defensive read is sufficient).
- Per-slot parallel checkers (one per Worker is enough).

## Related Issue

- Sub-issue: #17
- Closed: #13
- Tracking: #1 (Phase 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
