### PR TITLE
feat: rate limiter (worker.limiter) — Phase 3 complete

### DIFF
--- a/internal/proto/worker_args.go
+++ b/internal/proto/worker_args.go
@@ -9,8 +9,7 @@ import (
 //
 // The Lua reads opts['token'], opts['lockDuration'], opts['name'], and
 // optionally opts['limiter']{'max','duration'}; only token+lockDuration
-// are required. Limiter is omitted in the basic worker path and stays
-// here as a future hook.
+// are required.
 type MoveToActiveOpts struct {
 	// Token is the per-job lock token the worker writes to
 	// {jobKey}:lock. The worker is then expected to extend it via
@@ -21,6 +20,18 @@ type MoveToActiveOpts struct {
 	// Name is the worker name; Lua mirrors it into the HASH `pb`
 	// (processedBy) field for stalled-recovery attribution.
 	Name string
+	// Limiter, when non-nil, activates per-Worker rate limiting.
+	// The vendored Lua's getRateLimitTTL reads Max+DurationMs and
+	// returns the remaining cooldown in expireTime when the limit
+	// is hit, so the worker can back off precisely.
+	Limiter *MoveToActiveLimiter
+}
+
+// MoveToActiveLimiter mirrors BullMQ's worker.limiter option.
+// DurationMs is the rolling-window length in milliseconds.
+type MoveToActiveLimiter struct {
+	Max        int
+	DurationMs int64
 }
 
 // EncodeMoveToActiveOpts returns the msgpack-encoded ARGV[3] payload.
@@ -31,6 +42,12 @@ func EncodeMoveToActiveOpts(o MoveToActiveOpts) ([]byte, error) {
 	}
 	if o.Name != "" {
 		m["name"] = o.Name
+	}
+	if o.Limiter != nil {
+		m["limiter"] = map[string]any{
+			"max":      o.Limiter.Max,
+			"duration": o.Limiter.DurationMs,
+		}
 	}
 	return msgpack.Marshal(m)
 }

--- a/worker.go
+++ b/worker.go
@@ -148,20 +148,19 @@ func (w *Worker) Stop(ctx context.Context) error {
 
 // dispatchLoop is one slot of the goroutine pool. It repeatedly tries
 // to dequeue a job and process it, sleeping IdlePollInterval between
-// empty pulls and exiting when runCtx is cancelled.
+// empty pulls (or the rate-limit cooldown if Lua reported one) and
+// exiting when runCtx is cancelled.
 func (w *Worker) dispatchLoop(handlerAny any) {
 	defer w.run.Done()
 	for {
 		if w.runCtx.Err() != nil {
 			return
 		}
-		processed, err := w.tryOnce(handlerAny)
+		processed, expireTimeMs, err := w.tryOnce(handlerAny)
 		if err != nil {
 			// 取得や lua 失敗はログ的扱い (worker は止めない)。
 			// 本格的なエラー報告チャネルは observability PR で導入。
-			select {
-			case <-time.After(w.cfg.idlePollInterval):
-			case <-w.runCtx.Done():
+			if !w.sleep(w.cfg.idlePollInterval) {
 				return
 			}
 			continue
@@ -169,11 +168,32 @@ func (w *Worker) dispatchLoop(handlerAny any) {
 		if processed {
 			continue
 		}
-		select {
-		case <-time.After(w.cfg.idlePollInterval):
-		case <-w.runCtx.Done():
+		// Rate-limited path: respect the precise cooldown the Lua
+		// returned via expireTime instead of falling through to the
+		// idle poll interval.
+		wait := w.cfg.idlePollInterval
+		if expireTimeMs > 0 {
+			wait = time.Duration(expireTimeMs) * time.Millisecond
+		}
+		if !w.sleep(wait) {
 			return
 		}
+	}
+}
+
+// sleep blocks for d or until runCtx is cancelled. Returns false if
+// runCtx fired (caller should exit).
+func (w *Worker) sleep(d time.Duration) bool {
+	if d <= 0 {
+		return w.runCtx.Err() == nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return true
+	case <-w.runCtx.Done():
+		return false
 	}
 }
 
@@ -220,18 +240,27 @@ func (w *Worker) runStalledCheck() error {
 }
 
 // tryOnce performs one dequeue attempt and, if successful, runs the
-// handler and finalises the job. Returns (processed, err).
-func (w *Worker) tryOnce(handlerAny any) (bool, error) {
+// handler and finalises the job. Returns (processed, expireTimeMs,
+// err): expireTimeMs is the rate-limit cooldown the dispatcher
+// should sleep before its next call (0 = no rate-limit window).
+func (w *Worker) tryOnce(handlerAny any) (bool, int64, error) {
 	token := uuid.NewString()
 	now := time.Now().UnixMilli()
 
-	optsBytes, err := proto.EncodeMoveToActiveOpts(proto.MoveToActiveOpts{
+	mtaOpts := proto.MoveToActiveOpts{
 		Token:        token,
 		LockDuration: w.cfg.lockDuration.Milliseconds(),
 		Name:         w.cfg.workerName,
-	})
+	}
+	if l := w.cfg.limiter; l != nil {
+		mtaOpts.Limiter = &proto.MoveToActiveLimiter{
+			Max:        l.max,
+			DurationMs: l.duration.Milliseconds(),
+		}
+	}
+	optsBytes, err := proto.EncodeMoveToActiveOpts(mtaOpts)
 	if err != nil {
-		return false, fmt.Errorf("encode moveToActive opts: %w", err)
+		return false, 0, fmt.Errorf("encode moveToActive opts: %w", err)
 	}
 
 	res, err := w.scripts.Run(
@@ -244,17 +273,17 @@ func (w *Worker) tryOnce(handlerAny any) (bool, error) {
 	)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			return false, nil
+			return false, 0, nil
 		}
-		return false, fmt.Errorf("moveToActive: %w", err)
+		return false, 0, fmt.Errorf("moveToActive: %w", err)
 	}
 
-	jobMap, jobID, ok, err := parseMoveToActiveResult(res)
+	jobMap, jobID, ok, expireTimeMs, err := parseMoveToActiveResult(res)
 	if err != nil {
-		return false, fmt.Errorf("parse moveToActive: %w", err)
+		return false, 0, fmt.Errorf("parse moveToActive: %w", err)
 	}
 	if !ok {
-		return false, nil
+		return false, expireTimeMs, nil
 	}
 
 	// `defa` (default failed reason) is set by moveStalledJobsToWait
@@ -276,11 +305,11 @@ func (w *Worker) tryOnce(handlerAny any) (bool, error) {
 				w.cfg.lockDuration.Milliseconds(),
 			)
 		}
-		return true, nil
+		return true, 0, nil
 	}
 
 	w.processJob(handlerAny, token, jobID, jobMap)
-	return true, nil
+	return true, 0, nil
 }
 
 // processJob runs the handler for one acquired job, manages the lock
@@ -781,28 +810,50 @@ func buildJob[T any](jobID string, jobMap map[string]string) (*Job[T], error) {
 // parseMoveToActiveResult interprets the polymorphic EVALSHA response.
 // Lua returns one of:
 //   - {HGETALL_array, jobId, 0, 0} on success
-//   - {0, 0, expireTime, 0} when rate-limited (treated as no job)
+//   - {0, 0, expireTime, 0} when rate-limited
 //   - {0, 0, 0, nextDelayedTs} when waiting on a delayed job
 //   - {0, 0, 0, 0} when paused / maxed / empty
-func parseMoveToActiveResult(res any) (jobMap map[string]string, jobID string, ok bool, err error) {
+//
+// expireTimeMs surfaces the rate-limit cooldown so dispatchLoop can
+// sleep precisely instead of falling through to idlePollInterval.
+func parseMoveToActiveResult(res any) (jobMap map[string]string, jobID string, ok bool, expireTimeMs int64, err error) {
 	arr, isArr := res.([]any)
-	if !isArr || len(arr) < 2 {
-		return nil, "", false, nil
+	if !isArr || len(arr) < 4 {
+		return nil, "", false, 0, nil
 	}
 	jobData, isJobData := arr[0].([]any)
 	if !isJobData {
-		// arr[0] が integer (=0) のとき = job 無し。
-		return nil, "", false, nil
+		// arr[0] が integer (=0) のとき = job 無し。Slot 3 (1-indexed
+		// なら ARGV の解説と同じだが Go では index 2) が rate-limit の
+		// expireTime ms。
+		expireTimeMs, _ = toInt64(arr[2])
+		return nil, "", false, expireTimeMs, nil
 	}
 	id, idOK := arr[1].(string)
 	if !idOK || id == "" {
-		return nil, "", false, nil
+		return nil, "", false, 0, nil
 	}
 	m, err := flatHashToMap(jobData)
 	if err != nil {
-		return nil, "", false, err
+		return nil, "", false, 0, err
 	}
-	return m, id, true, nil
+	return m, id, true, 0, nil
+}
+
+// toInt64 normalises the integer types go-redis returns from EVALSHA
+// (int64 / int / json.Number) to int64.
+func toInt64(v any) (int64, bool) {
+	switch n := v.(type) {
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	case int32:
+		return int64(n), true
+	case float64:
+		return int64(n), true
+	}
+	return 0, false
 }
 
 // flatHashToMap turns Redis HGETALL output `[k1, v1, k2, v2, ...]` into

--- a/worker.go
+++ b/worker.go
@@ -840,8 +840,10 @@ func parseMoveToActiveResult(res any) (jobMap map[string]string, jobID string, o
 	return m, id, true, 0, nil
 }
 
-// toInt64 normalises the integer types go-redis returns from EVALSHA
-// (int64 / int / json.Number) to int64.
+// toInt64 normalises the integer types go-redis can surface for an
+// EVALSHA result element (int64 / int / int32 / float64) to int64.
+// In practice go-redis v9 returns int64 for Lua integer returns;
+// the other cases stay covered for forward compatibility.
 func toInt64(v any) (int64, bool) {
 	switch n := v.(type) {
 	case int64:

--- a/worker_options.go
+++ b/worker_options.go
@@ -85,6 +85,13 @@ func WithMaxStalledCount(n int) WorkerOption {
 // exactly that long before its next moveToActive attempt.
 //
 // max <= 0 or duration <= 0 disables rate limiting (the default).
+//
+// Precedence note: BullMQ also supports a queue-level rate limit
+// stored in the meta HASH (`max` / `duration` keys). The vendored
+// moveToActive Lua reads that first and falls back to opts.limiter,
+// so a queue-level setting written by another client (e.g. a
+// BullMQ TS admin) silently overrides WithRateLimit. mkq does not
+// yet expose a public API to write the meta keys.
 func WithRateLimit(max int, duration time.Duration) WorkerOption {
 	return func(c *workerConfig) {
 		if max <= 0 || duration <= 0 {

--- a/worker_options.go
+++ b/worker_options.go
@@ -12,6 +12,12 @@ type workerConfig struct {
 	idlePollInterval time.Duration
 	stalledInterval  time.Duration
 	maxStalledCount  int
+	limiter          *workerLimiter
+}
+
+type workerLimiter struct {
+	max      int
+	duration time.Duration
 }
 
 // Defaults mirror BullMQ where applicable.
@@ -70,4 +76,21 @@ func WithStalledInterval(d time.Duration) WorkerOption {
 // Default 1 matches BullMQ.
 func WithMaxStalledCount(n int) WorkerOption {
 	return func(c *workerConfig) { c.maxStalledCount = n }
+}
+
+// WithRateLimit caps Worker dequeue throughput at max jobs per the
+// given rolling-window duration. Mirrors BullMQ's worker.limiter
+// option: when the cap is reached, the vendored Lua returns the
+// remaining cooldown via expireTime and the dispatch loop sleeps
+// exactly that long before its next moveToActive attempt.
+//
+// max <= 0 or duration <= 0 disables rate limiting (the default).
+func WithRateLimit(max int, duration time.Duration) WorkerOption {
+	return func(c *workerConfig) {
+		if max <= 0 || duration <= 0 {
+			c.limiter = nil
+			return
+		}
+		c.limiter = &workerLimiter{max: max, duration: duration}
+	}
 }

--- a/worker_ratelimit_test.go
+++ b/worker_ratelimit_test.go
@@ -1,0 +1,136 @@
+package mkq_test
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestWorker_RateLimit_Throttles pins that WithRateLimit(max, dur)
+// caps dequeue throughput. We add 4 jobs with limit 2 / 200ms and
+// expect total processing time ≥ ~200ms (one full window must elapse
+// between the 2nd and 3rd job).
+func TestWorker_RateLimit_Throttles(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const total = 4
+	for i := range total {
+		_, err := queue.Add(ctx, testPayload{Inbox: strconv.Itoa(i)})
+		require.NoError(t, err)
+	}
+
+	var done atomic.Int64
+	start := time.Now()
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		done.Add(1)
+		return nil, nil
+	},
+		mkq.WithRateLimit(2, 200*time.Millisecond),
+		mkq.WithIdlePollInterval(20*time.Millisecond),
+	)
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 50*time.Millisecond, func() bool {
+		n, _ := rdb.ZCard(ctx, base+"completed").Result()
+		return n == int64(total)
+	})
+
+	elapsed := time.Since(start)
+	// 4 jobs / 2 per 200ms = at minimum 1 cooldown window (~200ms).
+	// Lower bound is generous to absorb CI jitter; upper bound checks
+	// we didn't accidentally serialise everything (~800ms+).
+	assert.GreaterOrEqual(t, elapsed, 180*time.Millisecond,
+		"rate limit must enforce at least one cooldown window (got %v)", elapsed)
+	assert.Less(t, elapsed, 800*time.Millisecond,
+		"4 jobs with 2/200ms should fit in well under 800ms (got %v)", elapsed)
+	assert.EqualValues(t, total, done.Load())
+}
+
+// TestWorker_RateLimit_DisabledByDefault regression-pins that
+// omitting WithRateLimit (or passing zero values) keeps the
+// pre-existing throughput.
+func TestWorker_RateLimit_DisabledByDefault(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const total = 5
+	for i := range total {
+		_, err := queue.Add(ctx, testPayload{Inbox: strconv.Itoa(i)})
+		require.NoError(t, err)
+	}
+
+	start := time.Now()
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		return nil, nil
+	},
+		// No WithRateLimit — should run at full throughput.
+		mkq.WithIdlePollInterval(20*time.Millisecond),
+	)
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		n, _ := rdb.ZCard(ctx, base+"completed").Result()
+		return n == int64(total)
+	})
+
+	elapsed := time.Since(start)
+	// Without a rate limiter 5 trivial jobs should finish very fast.
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"unlimited workers must process 5 trivial jobs quickly (got %v)", elapsed)
+}
+
+// TestWorker_RateLimit_ZeroDisablesLimiter verifies that
+// WithRateLimit(0, 0) (or any non-positive arg) leaves the limiter
+// disabled rather than crashing or producing infinite waits.
+func TestWorker_RateLimit_ZeroDisablesLimiter(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, testPayload{})
+	require.NoError(t, err)
+
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		return nil, nil
+	},
+		mkq.WithRateLimit(0, 0), // no-op
+		mkq.WithIdlePollInterval(20*time.Millisecond),
+	)
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"completed", job.ID).Result()
+		return v > 0
+	})
+}


### PR DESCRIPTION
Resolves #19. Closes the final Phase 3 alpha checkbox in #1; mkq is now feature-complete for mk-go integration (Phase 5).

## Summary

Activate the per-Worker rate-limit path the vendored \`moveToActive-11.lua\` already supports. The Lua reads \`opts.limiter.{max,duration}\` via \`getRateLimitTTL\` and returns the remaining cooldown in \`expireTime\` when the cap is hit; this PR adds the Go-side option, threads it through every dispatch, and lets the loop sleep precisely the cooldown instead of falling through to \`idlePollInterval\`.

## Key Changes

### Public API

\`\`\`go
func WithRateLimit(max int, duration time.Duration) WorkerOption
\`\`\`

Mirrors BullMQ's \`worker.limiter\` option. Non-positive args disable rate limiting (the default).

### Wire compatibility

No new Lua. \`internal/proto/worker_args.go\` gains:

- \`MoveToActiveOpts.Limiter (*MoveToActiveLimiter)\`
- \`MoveToActiveLimiter{Max int, DurationMs int64}\`
- \`EncodeMoveToActiveOpts\` emits \`{\"limiter\": {\"max\": M, \"duration\": D}}\` when set, matching the BullMQ TS shape consumed by \`cmsgpack.unpack\` inside the Lua.

### Worker engine

- \`workerConfig\` grows a \`*workerLimiter\`; \`tryOnce\` maps it onto \`MoveToActiveOpts.Limiter\` on every call.
- \`tryOnce\` now returns \`(processed, expireTimeMs, err)\`; the second value is the rate-limit cooldown surfaced by the Lua's slot-3 return value.
- \`parseMoveToActiveResult\` extracts \`expireTime\` separately so the no-job branch can carry "rate-limited, sleep N ms" instead of conflating it with paused/empty.
- \`dispatchLoop\` respects \`expireTimeMs > 0\` by sleeping exactly that long; falls back to \`idlePollInterval\` otherwise. New \`sleep()\` helper folds runCtx-cancel checks in one place.
- \`toInt64\` normalises the int variants go-redis returns from EVALSHA.

## Testing

\`\`\`
go vet ./...
gofmt -l .
go build ./...
go test ./... -race -count=1 -timeout 90s
\`\`\`

\`worker_ratelimit_test.go\` (integration, real Redis 7):

- \`Throttles\`: 4 jobs with \`WithRateLimit(2, 200ms)\` take \`>= 180ms\` (must include at least one cooldown window) but \`< 800ms\` (we don't accidentally serialise everything).
- \`DisabledByDefault\`: 5 jobs without \`WithRateLimit\` finish in \`< 500ms\` — pre-existing throughput preserved.
- \`ZeroDisablesLimiter\`: \`WithRateLimit(0, 0)\` is a no-op rather than crashing or producing infinite waits.

5 sequential full suite runs all green; existing PR #5 / #9 / #12 / #15 / #18 tests untouched and pass.

## Out of scope (deferred)

- Queue-level rate limit via meta HASH (\`rl-max\` / \`rl-dur\`).
- Group / key-based limiting.
- Dynamic limiter updates from outside the Worker.

## Related

- Sub-issue: #19
- Tracking: #1 (Phase 3 — completes the alpha)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
