### PR TITLE
chore: vendor BullMQ as a submodule + lua sync drift CI

### DIFF
--- a/.github/workflows/lua-sync-verify.yml
+++ b/.github/workflows/lua-sync-verify.yml
@@ -1,0 +1,37 @@
+name: lua sync verify
+
+# Runs script/sync-lua.sh against the pinned BullMQ submodule and fails
+# if the result differs from internal/lua/scripts/. Catches the
+# "vendored lua copies got hand-edited" or "submodule pin advanced but
+# the copies were not refreshed" classes of drift before they reach
+# main.
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: run sync-lua.sh
+        run: script/sync-lua.sh
+
+      - name: assert no drift
+        run: |
+          if ! git diff --quiet internal/lua/scripts/; then
+            echo "::error::vendored lua diverged from third_party/bullmq pin"
+            git diff internal/lua/scripts/
+            exit 1
+          fi
+          echo "OK: vendored lua matches submodule pin"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/bullmq"]
+	path = third_party/bullmq
+	url = https://github.com/taskforcesh/bullmq.git

--- a/internal/lua/scripts/UPSTREAM.md
+++ b/internal/lua/scripts/UPSTREAM.md
@@ -4,8 +4,18 @@ Lua scripts in this directory are vendored verbatim from BullMQ.
 
 - Upstream: https://github.com/taskforcesh/bullmq
 - Source path: `src/commands/`
-- Pinned commit: `0866f39123010c9664fe32c1066f5e075faa4e23` (2026-04-25)
+- Pinned commit: see `.gitmodules` and the checked-out SHA of
+  `third_party/bullmq` (recorded redundantly here:
+  `0866f39123010c9664fe32c1066f5e075faa4e23`, 2026-04-25)
 - License: MIT (see `THIRD_PARTY_NOTICES.md` at the repo root)
+
+## Why both submodule and vendored copies?
+
+Go modules don't pull submodule contents on `go get`, so the Lua
+files must live inside the module tree for `go:embed` to work for
+downstream consumers. The submodule at `third_party/bullmq` is
+test/dev/CI tooling only — never required for `go get
+github.com/shiroha-a/mkq` to succeed.
 
 ## Files vendored
 
@@ -30,9 +40,26 @@ expected `KEYS` count and is preserved verbatim.
 
 ## Re-vendoring
 
-Update the pinned commit above and re-run the fetch script (see the PR that
-introduced this directory). After re-vendoring, run the integration tests to
-detect any drift in BullMQ's wire format.
+```
+git submodule update --init --recursive
+cd third_party/bullmq
+git fetch
+git checkout <new-sha>
+cd -
+script/sync-lua.sh
+# Update the SHA + date noted at the top of this file, then commit
+# everything (.gitmodules submodule pointer + sync'd lua + this file).
+```
+
+The `lua sync verify` GitHub Actions workflow runs `script/sync-lua.sh`
+on every PR and fails if the result diverges from this directory,
+catching both "submodule pin advanced but lua not refreshed" and
+"vendored lua hand-edited without updating the submodule".
+
+To add a NEW entry-point script (one that's not yet listed above), copy
+it manually the first time along with any new transitive includes
+referenced by its `--- @include "..."` directives. The sync script only
+mirrors files that already exist locally.
 
 Do not hand-edit vendored files. mkq's `@include` preprocessor (in the
 parent `internal/lua` package) is responsible for resolving directives at

--- a/script/sync-lua.sh
+++ b/script/sync-lua.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Sync vendored BullMQ Lua scripts from the third_party/bullmq submodule
+# into internal/lua/scripts/. Idempotent.
+#
+# Usage:
+#   git submodule update --init --recursive
+#   script/sync-lua.sh
+#
+# To update the pinned BullMQ version:
+#   cd third_party/bullmq && git fetch && git checkout <new-sha> && cd -
+#   script/sync-lua.sh
+#   # then update internal/lua/scripts/UPSTREAM.md and commit everything.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$REPO_ROOT/third_party/bullmq/src/commands"
+DST="$REPO_ROOT/internal/lua/scripts"
+
+if [ ! -d "$SRC" ]; then
+    echo "ERROR: submodule not initialized." >&2
+    echo "Run: git submodule update --init --recursive" >&2
+    exit 1
+fi
+
+# Sync only the files we already vendor. New entry points must be
+# copied in manually the first time (along with their transitive
+# includes resolved by internal/lua/preprocess.go).
+shopt -s nullglob
+fail=0
+synced=0
+
+for vendored in "$DST"/*.lua "$DST"/includes/*.lua; do
+    rel="${vendored#$DST/}"
+    src="$SRC/$rel"
+    if [ ! -f "$src" ]; then
+        echo "ERROR: $rel exists in vendored copy but not in submodule." >&2
+        echo "  Either remove it from internal/lua/scripts/ or update UPSTREAM.md pin." >&2
+        fail=1
+        continue
+    fi
+    cp "$src" "$vendored"
+    synced=$((synced + 1))
+done
+
+if [ "$fail" -ne 0 ]; then
+    exit 1
+fi
+
+echo "Synced $synced lua file(s) from $SRC -> $DST"


### PR DESCRIPTION
PR A from #22. Establishes a dual-track relationship with the upstream BullMQ repository ahead of the next-PR interop harness.

## Architecture

- \`internal/lua/scripts/\`   ← vendored copies, ship with \`go get\`, fed to \`go:embed\` at runtime.
- \`third_party/bullmq/\`     ← git submodule, never required for \`go get\`, used only by sync tooling and (next PR) the interop test harness.

Go modules don't pull submodule contents on dependency resolution, so Lua must stay vendored for downstream consumers. The submodule's job is to make re-vendoring scriptable and to give the upcoming interop tests a real BullMQ TS source to import.

## Changes

- \`.gitmodules\` + \`third_party/bullmq\` pinned at \`0866f39123010c9664fe32c1066f5e075faa4e23\` — the same commit the vendored copies were taken from.
- \`script/sync-lua.sh\` — idempotent re-vendoring driver. Mirrors every file that already exists under \`internal/lua/scripts/\` from the submodule's \`src/commands/\`. Errors (rather than silently drops) when a vendored file disappears upstream.
- \`.github/workflows/lua-sync-verify.yml\` — runs the script with the submodule checked out and fails if \`git diff\` is non-empty. Catches both classes of drift: "submodule pin advanced but lua not refreshed" and "vendored lua hand-edited without updating the submodule".
- \`internal/lua/scripts/UPSTREAM.md\` — rewritten to document the submodule/vendored relationship and the new re-vendoring procedure (\`git submodule update\` → \`git checkout <new-sha>\` → \`script/sync-lua.sh\`).

\`ci.yml\` is intentionally unchanged — the test suite reads only vendored copies, so the existing job doesn't need submodules.

## Verified

\`\`\`
script/sync-lua.sh                                # 55 file copies from pinned submodule
git diff internal/lua/scripts/                    # empty (idempotent)
go test ./... -race -count=1 -timeout 120s        # 5x green
\`\`\`

Existing PR #5–#21 tests untouched.

## What's next

PR B from #22: a minimal cross-language interop harness in \`tests/interop/\` that imports the submodule's TS source directly and exercises bidirectional Add/Process scenarios.

## Related

- Tracking: #22 (Phase 4 prep)
- Tracking: #1 (Phase 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
