### PR TITLE
feat: Job HASH read-side parity (Job runtime fields + JobState + Queue.Get)

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -22,3 +22,9 @@ var ErrPriorityWithDelay = errors.New("mkq: WithPriority cannot be combined with
 //
 //	return fmt.Errorf("invalid input: %w", mkq.ErrUnrecoverable)
 var ErrUnrecoverable = errors.New("mkq: unrecoverable error (skip retry)")
+
+// ErrJobNotFound is returned by Queue.Get when the HASH at the
+// expected key is missing — the job either never existed, was
+// removed via WithKeepCompleted(0), or expired from a separate
+// retention policy.
+var ErrJobNotFound = errors.New("mkq: job not found")

--- a/job.go
+++ b/job.go
@@ -1,6 +1,9 @@
 package mkq
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Job represents a job that has been enqueued via Queue.Add. The struct
 // is a snapshot of the wire-level state at the moment of enqueue;
@@ -18,4 +21,52 @@ type Job[T any] struct {
 	// Timestamp is the creation time at millisecond precision; it
 	// matches the value Lua wrote to the HASH `timestamp` field.
 	Timestamp time.Time
+
+	// AttemptsMade is the BullMQ `atm` counter — how many times the
+	// job has been moved to retry / failed before this attempt.
+	// Populated from the moveToActive HGETALL snapshot, so handler
+	// callers see the value as observed at dequeue time.
+	AttemptsMade int
+
+	// AttemptsStarted is BullMQ `ats` — total number of moveToActive
+	// dequeues for this job (incremented even when stalled-recovery
+	// re-acquires it).
+	AttemptsStarted int
+
+	// StalledCounter is BullMQ `stc` — how many times stalled
+	// detection reclaimed this job. Once it exceeds
+	// WithMaxStalledCount, BullMQ writes the canonical default-failed
+	// reason into `defa`.
+	StalledCounter int
+
+	// ProcessedBy is BullMQ `pb` — the worker name that most recently
+	// dequeued this job (set by prepareJobForProcessing.lua).
+	ProcessedBy string
+}
+
+// JobState is the post-finalisation read-only snapshot of a job's
+// HASH. Returned by Queue.Get for admin-style inspection. Fields
+// remain at their zero value when the job hasn't reached the
+// corresponding state (e.g. ProcessedOn is zero for jobs still in
+// wait).
+type JobState struct {
+	// ProcessedOn is the moment moveToActive last picked the job up.
+	// Zero for jobs that have never been dequeued.
+	ProcessedOn time.Time
+	// FinishedOn is the moment moveToFinished sealed the job. Zero
+	// when the job is still in flight or queued.
+	FinishedOn time.Time
+	// ReturnValue is the BullMQ `returnvalue` HASH field (raw JSON,
+	// the user's handler return as JSON.stringify-d). Empty when the
+	// job hasn't completed.
+	ReturnValue json.RawMessage
+	// FailedReason is the BullMQ `failedReason` HASH field, stored as
+	// a plain string (not JSON) per BullMQ TS convention.
+	FailedReason string
+	// Stacktrace is the BullMQ `stacktrace` HASH field, decoded from
+	// its JSON-array-of-strings shape.
+	Stacktrace []string
+	// Progress is the BullMQ `progress` HASH field (raw JSON, can be
+	// any value — number, string, object).
+	Progress json.RawMessage
 }

--- a/queue.go
+++ b/queue.go
@@ -234,15 +234,21 @@ func (q *Queue[T]) Get(ctx context.Context, jobID string) (*Job[T], *JobState, e
 
 // buildJobState extracts the post-processing fields from a HGETALL
 // snapshot. Missing fields stay at their Go zero values.
+//
+// Timestamp fields are parsed via strconv.ParseInt with bitSize=64
+// rather than parseInt (which delegates to strconv.Atoi → int) so
+// that 13-digit Unix-millisecond values survive on 32-bit platforms
+// where int wraps at ~2.1 × 10^9. Mirrors the existing buildJob
+// timestamp parsing in worker.go.
 func buildJobState(hash map[string]string) *JobState {
 	st := &JobState{
 		FailedReason: hash["failedReason"],
 	}
-	if v := parseInt(hash["processedOn"]); v > 0 {
-		st.ProcessedOn = time.UnixMilli(int64(v))
+	if v, err := strconv.ParseInt(hash["processedOn"], 10, 64); err == nil && v > 0 {
+		st.ProcessedOn = time.UnixMilli(v)
 	}
-	if v := parseInt(hash["finishedOn"]); v > 0 {
-		st.FinishedOn = time.UnixMilli(int64(v))
+	if v, err := strconv.ParseInt(hash["finishedOn"], 10, 64); err == nil && v > 0 {
+		st.FinishedOn = time.UnixMilli(v)
 	}
 	if rv := hash["returnvalue"]; rv != "" {
 		st.ReturnValue = json.RawMessage(rv)

--- a/queue.go
+++ b/queue.go
@@ -24,12 +24,29 @@ type Queue[T any] struct {
 
 // Define returns a Queue handle for name. Calling Define twice with the
 // same name is safe; both handles operate on identical Redis state.
+//
+// Side effect: Define writes mkq's library version into the BullMQ
+// `meta` HASH via HSETNX. The non-overwriting semantics matter for
+// queues already initialised by a foreign client (BullMQ TS would
+// have written `bullmq:<semver>`); we only stamp `mkq:<semver>` when
+// the field is missing.
 func Define[T any](c *Client, name string, _ ...QueueOption) *Queue[T] {
-	return &Queue[T]{
+	q := &Queue[T]{
 		client: c,
 		name:   name,
 		keys:   keys.New(c.keyPrefix, name),
 	}
+	q.stampVersion()
+	return q
+}
+
+// stampVersion is best-effort: a Redis hiccup here doesn't break the
+// queue, it just leaves the version field unwritten. The interop test
+// will catch that on the next bull-board read.
+func (q *Queue[T]) stampVersion() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = q.client.rdb.HSetNX(ctx, q.keys.Meta(), "version", versionTag()).Err()
 }
 
 // Name returns the queue name as passed to Define.
@@ -189,6 +206,59 @@ func buildRetentionLimit(count *int, age *time.Duration) *proto.RetentionLimit {
 		rl.AgeSeconds = &secs
 	}
 	return rl
+}
+
+// Get returns a snapshot of the BullMQ HASH for jobID. Useful for
+// admin / inspector flows; the worker dispatch path does not call
+// this. Returns ErrJobNotFound when no HASH exists at the expected
+// key.
+//
+// The Job[T] return value carries the user-facing identity (ID /
+// Name / Data) and the dequeue counters (AttemptsMade etc.). The
+// JobState carries fields that only become meaningful after
+// processing starts (ProcessedOn / FinishedOn / ReturnValue / ...).
+func (q *Queue[T]) Get(ctx context.Context, jobID string) (*Job[T], *JobState, error) {
+	hash, err := q.client.rdb.HGetAll(ctx, q.keys.Job(jobID)).Result()
+	if err != nil {
+		return nil, nil, fmt.Errorf("mkq: HGetAll %s: %w", jobID, err)
+	}
+	if len(hash) == 0 {
+		return nil, nil, ErrJobNotFound
+	}
+	job, err := buildJob[T](jobID, hash)
+	if err != nil {
+		return nil, nil, err
+	}
+	return job, buildJobState(hash), nil
+}
+
+// buildJobState extracts the post-processing fields from a HGETALL
+// snapshot. Missing fields stay at their Go zero values.
+func buildJobState(hash map[string]string) *JobState {
+	st := &JobState{
+		FailedReason: hash["failedReason"],
+	}
+	if v := parseInt(hash["processedOn"]); v > 0 {
+		st.ProcessedOn = time.UnixMilli(int64(v))
+	}
+	if v := parseInt(hash["finishedOn"]); v > 0 {
+		st.FinishedOn = time.UnixMilli(int64(v))
+	}
+	if rv := hash["returnvalue"]; rv != "" {
+		st.ReturnValue = json.RawMessage(rv)
+	}
+	if pg := hash["progress"]; pg != "" {
+		st.Progress = json.RawMessage(pg)
+	}
+	if st_ := hash["stacktrace"]; st_ != "" {
+		// BullMQ stores stacktrace as JSON-encoded array of strings.
+		// Best-effort decode; bad input → empty slice.
+		var traces []string
+		if err := json.Unmarshal([]byte(st_), &traces); err == nil {
+			st.Stacktrace = traces
+		}
+	}
+	return st
 }
 
 // parseAddResult coerces the polymorphic EVALSHA return into a job id

--- a/queue.go
+++ b/queue.go
@@ -257,8 +257,8 @@ func buildJobState(hash map[string]string) *JobState {
 		st.Progress = json.RawMessage(pg)
 	}
 	if st_ := hash["stacktrace"]; st_ != "" {
-		// BullMQ stores stacktrace as JSON-encoded array of strings.
-		// Best-effort decode; bad input → empty slice.
+		// BullMQ は stacktrace を JSON エンコードされた文字列配列として保存する。
+		// best-effort デコード; 不正入力 → 空スライス。
 		var traces []string
 		if err := json.Unmarshal([]byte(st_), &traces); err == nil {
 			st.Stacktrace = traces

--- a/queue_get_test.go
+++ b/queue_get_test.go
@@ -1,0 +1,187 @@
+package mkq_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestQueue_DefineWritesMetaVersion pins that Define stamps the BullMQ
+// `meta.version` HASH field with the mkq version tag, and that the
+// HSETNX semantics let a foreign value (e.g. a queue already
+// initialised by BullMQ TS) survive untouched.
+func TestQueue_DefineWritesMetaVersion(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+
+	rdb := rawClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Fresh Define stamps the field.
+	_ = mkq.Define[testPayload](c, "deliver")
+	got, err := rdb.HGet(ctx, prefix+":deliver:meta", "version").Result()
+	require.NoError(t, err)
+	assert.True(t, len(got) > len("mkq:") && got[:4] == "mkq:",
+		"meta.version must start with `mkq:`, got %q", got)
+
+	// Pre-populate a foreign value, re-Define, ensure it's NOT
+	// overwritten (HSETNX semantics).
+	require.NoError(t, rdb.HSet(ctx, prefix+":foreign:meta", "version", "bullmq:5.76.2").Err())
+	_ = mkq.Define[testPayload](c, "foreign")
+	got2, err := rdb.HGet(ctx, prefix+":foreign:meta", "version").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "bullmq:5.76.2", got2,
+		"Define must not overwrite an existing meta.version (HSETNX)")
+}
+
+// TestJob_RuntimeFieldsPopulatedAtDequeue pins that the new Job[T]
+// runtime fields (AttemptsMade, AttemptsStarted, StalledCounter,
+// ProcessedBy) are populated from the moveToActive HGETALL snapshot
+// at the moment the handler runs.
+func TestJob_RuntimeFieldsPopulatedAtDequeue(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	_, err := queue.Add(ctx, testPayload{Inbox: "x"},
+		mkq.WithAttempts(3),
+		mkq.WithBackoff(mkq.FixedBackoff(20*time.Millisecond)),
+	)
+	require.NoError(t, err)
+
+	type capture struct {
+		attemptsMade    int
+		attemptsStarted int
+		processedBy     string
+	}
+	captured := make(chan capture, 5)
+	worker, err := mkq.Process(queue, func(_ context.Context, j *mkq.Job[testPayload]) (any, error) {
+		captured <- capture{
+			attemptsMade:    j.AttemptsMade,
+			attemptsStarted: j.AttemptsStarted,
+			processedBy:     j.ProcessedBy,
+		}
+		return nil, errors.New("force retry")
+	}, mkq.WithIdlePollInterval(10*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	// Three attempts: atm=0,1,2 in order; ats increments each dequeue;
+	// pb is non-empty (worker name) on every attempt.
+	got := []capture{
+		receiveOrFail(t, ctx, captured),
+		receiveOrFail(t, ctx, captured),
+		receiveOrFail(t, ctx, captured),
+	}
+	assert.Equal(t, 0, got[0].attemptsMade, "first attempt: atm must be 0")
+	assert.Equal(t, 1, got[1].attemptsMade, "second attempt: atm must be 1")
+	assert.Equal(t, 2, got[2].attemptsMade, "third attempt: atm must be 2")
+	for i, c := range got {
+		assert.GreaterOrEqual(t, c.attemptsStarted, i+1, "ats monotonic on attempt %d", i)
+		assert.NotEmpty(t, c.processedBy, "pb must be set on attempt %d", i)
+	}
+}
+
+// TestQueue_Get_CompletedJob covers the success snapshot path:
+// ProcessedOn / FinishedOn / ReturnValue all populate after a
+// handler completes.
+func TestQueue_Get_CompletedJob(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	added, err := queue.Add(ctx, testPayload{Inbox: "x"})
+	require.NoError(t, err)
+
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		return map[string]any{"ok": true}, nil
+	}, mkq.WithIdlePollInterval(10*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"completed", added.ID).Result()
+		return v > 0
+	})
+
+	job, state, err := queue.Get(ctx, added.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, added.ID, job.ID)
+	assert.Equal(t, "x", job.Data.Inbox)
+	assert.False(t, state.ProcessedOn.IsZero(), "ProcessedOn must be populated")
+	assert.False(t, state.FinishedOn.IsZero(), "FinishedOn must be populated")
+	assert.NotEmpty(t, state.ReturnValue)
+	var ret map[string]any
+	require.NoError(t, json.Unmarshal(state.ReturnValue, &ret))
+	assert.Equal(t, true, ret["ok"])
+	assert.Empty(t, state.FailedReason)
+	assert.Empty(t, state.Stacktrace)
+}
+
+// TestQueue_Get_FailedJob covers the failure snapshot path:
+// FailedReason and Stacktrace populate.
+func TestQueue_Get_FailedJob(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	added, err := queue.Add(ctx, testPayload{})
+	require.NoError(t, err)
+
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		return nil, errors.New("nope")
+	}, mkq.WithIdlePollInterval(10*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"failed", added.ID).Result()
+		return v > 0
+	})
+
+	_, state, err := queue.Get(ctx, added.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "nope", state.FailedReason)
+	require.NotEmpty(t, state.Stacktrace)
+	assert.Equal(t, "nope", state.Stacktrace[0])
+}
+
+// TestQueue_Get_NotFound pins the ErrJobNotFound sentinel.
+func TestQueue_Get_NotFound(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, _, err := queue.Get(ctx, "does-not-exist")
+	assert.ErrorIs(t, err, mkq.ErrJobNotFound)
+}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,16 @@
+package mkq
+
+// Version is the mkq library version, written into the BullMQ meta
+// HASH at Queue.Define time so admin tools (bull-board, custom
+// dashboards) can identify which client populated the queue.
+//
+// The literal lives here rather than being read from
+// runtime/debug.ReadBuildInfo so it stays meaningful in unit tests
+// and in users who vendor mkq via tooling that doesn't preserve
+// build info. Bump it on every release.
+const Version = "0.0.0-dev"
+
+// versionTag is the value written to meta.version. BullMQ TS writes
+// `bullmq:<semver>`; mkq mirrors the convention with a `mkq:` prefix
+// so a foreign reader can identify the client.
+func versionTag() string { return "mkq:" + Version }

--- a/worker.go
+++ b/worker.go
@@ -827,10 +827,14 @@ func buildJob[T any](jobID string, jobMap map[string]string) (*Job[T], error) {
 	}
 	tsMs, _ := strconv.ParseInt(jobMap["timestamp"], 10, 64)
 	return &Job[T]{
-		ID:        jobID,
-		Name:      jobMap["name"],
-		Data:      data,
-		Timestamp: time.UnixMilli(tsMs),
+		ID:              jobID,
+		Name:            jobMap["name"],
+		Data:            data,
+		Timestamp:       time.UnixMilli(tsMs),
+		AttemptsMade:    parseInt(jobMap["atm"]),
+		AttemptsStarted: parseInt(jobMap["ats"]),
+		StalledCounter:  parseInt(jobMap["stc"]),
+		ProcessedBy:     jobMap["pb"],
 	}, nil
 }
 


### PR DESCRIPTION
Resolves #28. Phase 4 step B: closes the read-side of \"Job HASH field naming parity\" in #1. Mutation API (UpdateProgress / Log / UpdateData) is tracked separately in #27.

## Background

A research pass through the codebase confirmed mkq writes 100% of HASH state via vendored BullMQ Lua, so wire-level field **names** already match BullMQ exactly (grep \`HSet|HMSet|HIncrBy\` in \`*.go\` returns 0 hits). The actual gap was that \`mkq.Job[T]\` only surfaced \`ID / Name / Data / Timestamp\` — the runtime counters BullMQ persists (\`atm / ats / stc / pb\`) and the post-processing fields (\`returnvalue / failedReason / stacktrace / processedOn / finishedOn / progress\`) had no way out to Go callers.

## Changes

### A1. \`meta.version\` stamp at Define

\`Queue.Define\` now performs an idempotent HSETNX on the meta HASH:

\`\`\`
HSETNX {prefix}:{queue}:meta version mkq:<Version>
\`\`\`

HSETNX preserves a value already written by a foreign client (BullMQ TS would have written \`bullmq:<semver>\`), so a queue first touched by mkq is stamped with \`mkq:0.0.0-dev\` while a queue shared with BullMQ keeps the BullMQ-side stamp.

### B1. \`Job[T]\` runtime fields

\`Job[T]\` gets four new fields populated automatically when the worker passes a job to the user handler:

| field | BullMQ HASH key |
|---|---|
| \`AttemptsMade\` | \`atm\` |
| \`AttemptsStarted\` | \`ats\` |
| \`StalledCounter\` | \`stc\` |
| \`ProcessedBy\` | \`pb\` |

\`buildJob\` in \`worker.go\` reads them out of the moveToActive HGETALL snapshot — no extra Redis round-trip per job. Backwards compatible: no existing caller constructs \`Job[T]\` literals (verified by grep), new fields default to zero values.

### B2. \`JobState\` + \`Queue.Get\`

A new \`JobState\` snapshot type wraps the post-processing HASH fields (\`ProcessedOn / FinishedOn / ReturnValue / FailedReason / Stacktrace / Progress\`); it stays separate from \`Job[T]\` because those values only become meaningful after the worker runs.

\`\`\`go
func (q *Queue[T]) Get(ctx context.Context, jobID string) (*Job[T], *JobState, error)
\`\`\`

One HGETALL round-trip; new \`ErrJobNotFound\` sentinel returned when the HASH is missing.

## Testing

\`\`\`
go vet ./...
gofmt -l .
go build ./...
go test ./... -race -count=1 -timeout 120s
\`\`\`

\`queue_get_test.go\` (5 integration tests, real Redis 7):

- \`TestQueue_DefineWritesMetaVersion\`: confirms the \`mkq:\` stamp on a fresh queue and the HSETNX no-overwrite for a foreign \`bullmq:5.76.2\` value.
- \`TestJob_RuntimeFieldsPopulatedAtDequeue\`: \`WithAttempts(3) + Fixed(20ms)\`; the handler observes \`atm = 0/1/2\` across the three attempts and a non-empty \`pb\` on every attempt.
- \`TestQueue_Get_CompletedJob\`: \`ProcessedOn / FinishedOn / ReturnValue\` populated after a successful Process run.
- \`TestQueue_Get_FailedJob\`: \`FailedReason\` and the JSON-decoded \`Stacktrace\` populated after a handler-error fail.
- \`TestQueue_Get_NotFound\`: \`ErrJobNotFound\` for a missing key.

5 sequential full suite runs all green; existing PR #5–#26 tests untouched.

## Out of scope

- Mutation API (#27).
- Parent-child / dependencies / repeat-job persistence.
- \`Queue.GetCounts\` / \`Pause\` / \`Resume\` admin operations.
- \`opts.maxLenEvents\` init (already lazy-set by the vendored Lua).

## Related

- Closes #28
- Tracking: #1 (Phase 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
