### PR TITLE
feat: QueueEvents subscription API

### DIFF
--- a/events.go
+++ b/events.go
@@ -1,0 +1,300 @@
+package mkq
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/shiroha-a/mkq/internal/keys"
+)
+
+// Event is the marker interface for entries surfaced by QueueEvents.
+// All concrete event types embed an ID() method returning the
+// Redis Stream entry ID (e.g. "1700000000000-0") so callers can
+// resume from a specific offset later if a history-replay API
+// lands.
+type Event interface {
+	// ID returns the Redis Stream entry id. Stable across redeliveries
+	// (each entry keeps its id even if the underlying stream is
+	// trimmed).
+	ID() string
+	isQueueEvent()
+}
+
+// AddedEvent corresponds to BullMQ's `added` event (storeJob.lua).
+type AddedEvent struct {
+	id    string
+	JobID string
+	Name  string
+}
+
+// WaitingEvent corresponds to BullMQ's `waiting` event. Prev describes
+// the previous state if any (e.g. "active" when retryJob promotes a
+// failed attempt back to wait).
+type WaitingEvent struct {
+	id    string
+	JobID string
+	Prev  string
+}
+
+// ActiveEvent corresponds to BullMQ's `active` event
+// (prepareJobForProcessing.lua).
+type ActiveEvent struct {
+	id    string
+	JobID string
+	Prev  string
+}
+
+// CompletedEvent corresponds to BullMQ's `completed` event
+// (moveToFinished.lua, target=completed). ReturnValue carries the
+// JSON-stringified handler return verbatim.
+type CompletedEvent struct {
+	id          string
+	JobID       string
+	ReturnValue json.RawMessage
+	Prev        string
+}
+
+// FailedEvent corresponds to BullMQ's `failed` event
+// (moveToFinished.lua, target=failed). FailedReason is the plain-text
+// error message (no JSON encoding) per BullMQ TS convention.
+type FailedEvent struct {
+	id           string
+	JobID        string
+	FailedReason string
+	Prev         string
+}
+
+// DelayedEvent corresponds to BullMQ's `delayed` event (addDelayedJob,
+// moveToDelayed). DelayMs is the absolute target timestamp (ms epoch)
+// when the job becomes eligible.
+type DelayedEvent struct {
+	id      string
+	JobID   string
+	DelayMs int64
+}
+
+// StalledEvent corresponds to BullMQ's `stalled` event
+// (moveStalledJobsToWait.lua).
+type StalledEvent struct {
+	id    string
+	JobID string
+}
+
+// DrainedEvent corresponds to BullMQ's `drained` event, fired when
+// the last active job finalises and no more wait/prioritized/delayed
+// work is queued.
+type DrainedEvent struct {
+	id string
+}
+
+// RetriesExhaustedEvent corresponds to BullMQ's `retries-exhausted`
+// event, fired when a failed job's atm reaches the configured
+// attempts cap (gated by moveToFinished's `attemptsMade >= attempts`
+// check).
+type RetriesExhaustedEvent struct {
+	id           string
+	JobID        string
+	AttemptsMade int
+}
+
+// RemovedEvent corresponds to BullMQ's `removed` event (deduplicateJob
+// and similar paths that drop a job key).
+type RemovedEvent struct {
+	id    string
+	JobID string
+}
+
+// RawEvent wraps any event type mkq doesn't model explicitly. Future
+// BullMQ versions can emit new event names (or mutation features land
+// in #27), and this type keeps Subscribe forward-compatible.
+type RawEvent struct {
+	id     string
+	Type   string
+	Fields map[string]string
+}
+
+// ID accessors. Each event embeds the stream entry id privately so
+// callers can read it via the interface method without colliding with
+// JobID/Name fields.
+func (e AddedEvent) ID() string            { return e.id }
+func (e WaitingEvent) ID() string          { return e.id }
+func (e ActiveEvent) ID() string           { return e.id }
+func (e CompletedEvent) ID() string        { return e.id }
+func (e FailedEvent) ID() string           { return e.id }
+func (e DelayedEvent) ID() string          { return e.id }
+func (e StalledEvent) ID() string          { return e.id }
+func (e DrainedEvent) ID() string          { return e.id }
+func (e RetriesExhaustedEvent) ID() string { return e.id }
+func (e RemovedEvent) ID() string          { return e.id }
+func (e RawEvent) ID() string              { return e.id }
+
+func (AddedEvent) isQueueEvent()            {}
+func (WaitingEvent) isQueueEvent()          {}
+func (ActiveEvent) isQueueEvent()           {}
+func (CompletedEvent) isQueueEvent()        {}
+func (FailedEvent) isQueueEvent()           {}
+func (DelayedEvent) isQueueEvent()          {}
+func (StalledEvent) isQueueEvent()          {}
+func (DrainedEvent) isQueueEvent()          {}
+func (RetriesExhaustedEvent) isQueueEvent() {}
+func (RemovedEvent) isQueueEvent()          {}
+func (RawEvent) isQueueEvent()              {}
+
+// QueueEvents is a long-lived subscriber to a queue's BullMQ events
+// stream. It does not maintain background goroutines until Subscribe
+// is called.
+type QueueEvents struct {
+	keys keys.Builder
+	rdb  redis.UniversalClient
+
+	closeOnce sync.Once
+	closeCh   chan struct{}
+}
+
+// NewQueueEvents creates a subscriber for q's events stream. Construct
+// one per logical subscription; the underlying Redis client is shared
+// with the queue's Client.
+func NewQueueEvents[T any](q *Queue[T]) *QueueEvents {
+	return &QueueEvents{
+		keys:    q.keys,
+		rdb:     q.client.rdb,
+		closeCh: make(chan struct{}),
+	}
+}
+
+// Close terminates an in-flight Subscribe. Safe to call multiple times.
+// After Close, Subscribe returns nil on the next loop iteration.
+func (qe *QueueEvents) Close() {
+	qe.closeOnce.Do(func() { close(qe.closeCh) })
+}
+
+// streamBlockTimeout caps each XREAD BLOCK call. We pick a short value
+// so ctx cancellation surfaces within ~one tick rather than waiting on
+// the BullMQ default (5s+) — at this granularity Redis sees one round
+// trip per ~200ms idle, which is negligible.
+const streamBlockTimeout = 200 * time.Millisecond
+
+// Subscribe consumes the events stream and dispatches each entry to
+// handler. It returns when:
+//   - ctx is cancelled (returns ctx.Err()).
+//   - Close is called (returns nil).
+//   - handler returns a non-nil error (returns that error).
+//
+// The subscriber starts at "$" — only events written after Subscribe
+// is called are delivered. Past entries are ignored.
+func (qe *QueueEvents) Subscribe(ctx context.Context, handler func(Event) error) error {
+	if handler == nil {
+		return errors.New("mkq: QueueEvents.Subscribe requires a non-nil handler")
+	}
+
+	streamKey := qe.keys.Events()
+	lastID := "$"
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-qe.closeCh:
+			return nil
+		default:
+		}
+
+		// XREAD BLOCK with a short timeout so we can re-check
+		// ctx/closeCh each tick. go-redis surfaces a `redis.Nil`
+		// (no entries) on timeout; treat it as "loop again".
+		streams, err := qe.rdb.XRead(ctx, &redis.XReadArgs{
+			Streams: []string{streamKey, lastID},
+			Block:   streamBlockTimeout,
+		}).Result()
+		if err != nil {
+			if errors.Is(err, redis.Nil) {
+				continue
+			}
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return ctx.Err()
+			}
+			return fmt.Errorf("mkq: XREAD events: %w", err)
+		}
+
+		for _, stream := range streams {
+			for _, msg := range stream.Messages {
+				ev := decodeStreamMessage(msg)
+				lastID = msg.ID
+				if err := handler(ev); err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+// decodeStreamMessage converts a go-redis XMessage into a typed Event.
+// The BullMQ wire format keys every entry with an `event` field; the
+// rest of the fields are payload specific to each type.
+func decodeStreamMessage(msg redis.XMessage) Event {
+	fields := make(map[string]string, len(msg.Values))
+	for k, v := range msg.Values {
+		switch x := v.(type) {
+		case string:
+			fields[k] = x
+		case []byte:
+			fields[k] = string(x)
+		default:
+			// Defensive: go-redis surfaces strings here in practice,
+			// but keep RawEvent functional for surprise types.
+			fields[k] = fmt.Sprintf("%v", v)
+		}
+	}
+
+	switch fields["event"] {
+	case "added":
+		return AddedEvent{id: msg.ID, JobID: fields["jobId"], Name: fields["name"]}
+	case "waiting":
+		return WaitingEvent{id: msg.ID, JobID: fields["jobId"], Prev: fields["prev"]}
+	case "active":
+		return ActiveEvent{id: msg.ID, JobID: fields["jobId"], Prev: fields["prev"]}
+	case "completed":
+		return CompletedEvent{
+			id:          msg.ID,
+			JobID:       fields["jobId"],
+			ReturnValue: rawJSON(fields["returnvalue"]),
+			Prev:        fields["prev"],
+		}
+	case "failed":
+		return FailedEvent{
+			id:           msg.ID,
+			JobID:        fields["jobId"],
+			FailedReason: fields["failedReason"],
+			Prev:         fields["prev"],
+		}
+	case "delayed":
+		delay, _ := strconv.ParseInt(fields["delay"], 10, 64)
+		return DelayedEvent{id: msg.ID, JobID: fields["jobId"], DelayMs: delay}
+	case "stalled":
+		return StalledEvent{id: msg.ID, JobID: fields["jobId"]}
+	case "drained":
+		return DrainedEvent{id: msg.ID}
+	case "retries-exhausted":
+		atm, _ := strconv.Atoi(fields["attemptsMade"])
+		return RetriesExhaustedEvent{id: msg.ID, JobID: fields["jobId"], AttemptsMade: atm}
+	case "removed":
+		return RemovedEvent{id: msg.ID, JobID: fields["jobId"]}
+	default:
+		// 未知 event は forward compat のため RawEvent で wrap。
+		return RawEvent{id: msg.ID, Type: fields["event"], Fields: fields}
+	}
+}
+
+func rawJSON(s string) json.RawMessage {
+	if s == "" {
+		return nil
+	}
+	return json.RawMessage(s)
+}

--- a/events.go
+++ b/events.go
@@ -72,12 +72,14 @@ type FailedEvent struct {
 }
 
 // DelayedEvent corresponds to BullMQ's `delayed` event (addDelayedJob,
-// moveToDelayed). DelayMs is the absolute target timestamp (ms epoch)
-// when the job becomes eligible.
+// moveToDelayed). DelayedUntilMs is the absolute target timestamp
+// (ms since unix epoch) at which the job becomes eligible to run —
+// not a relative duration. The Lua-emitted `delay` field carries
+// this absolute value, hence the renamed Go field.
 type DelayedEvent struct {
-	id      string
-	JobID   string
-	DelayMs int64
+	id             string
+	JobID          string
+	DelayedUntilMs int64
 }
 
 // StalledEvent corresponds to BullMQ's `stalled` event
@@ -105,10 +107,12 @@ type RetriesExhaustedEvent struct {
 }
 
 // RemovedEvent corresponds to BullMQ's `removed` event (deduplicateJob
-// and similar paths that drop a job key).
+// and similar paths that drop a job key). Prev describes the state
+// the job left when removed (e.g. "delayed").
 type RemovedEvent struct {
 	id    string
 	JobID string
+	Prev  string
 }
 
 // RawEvent wraps any event type mkq doesn't model explicitly. Future
@@ -282,7 +286,7 @@ func decodeStreamMessage(msg redis.XMessage) Event {
 		}
 	case "delayed":
 		delay, _ := strconv.ParseInt(fields["delay"], 10, 64)
-		return DelayedEvent{id: msg.ID, JobID: fields["jobId"], DelayMs: delay}
+		return DelayedEvent{id: msg.ID, JobID: fields["jobId"], DelayedUntilMs: delay}
 	case "stalled":
 		return StalledEvent{id: msg.ID, JobID: fields["jobId"]}
 	case "drained":
@@ -291,7 +295,7 @@ func decodeStreamMessage(msg redis.XMessage) Event {
 		atm, _ := strconv.Atoi(fields["attemptsMade"])
 		return RetriesExhaustedEvent{id: msg.ID, JobID: fields["jobId"], AttemptsMade: atm}
 	case "removed":
-		return RemovedEvent{id: msg.ID, JobID: fields["jobId"]}
+		return RemovedEvent{id: msg.ID, JobID: fields["jobId"], Prev: fields["prev"]}
 	default:
 		// 未知 event は forward compat のため RawEvent で wrap。
 		return RawEvent{id: msg.ID, Type: fields["event"], Fields: fields}

--- a/events.go
+++ b/events.go
@@ -171,6 +171,12 @@ func NewQueueEvents[T any](q *Queue[T]) *QueueEvents {
 
 // Close terminates an in-flight Subscribe. Safe to call multiple times.
 // After Close, Subscribe returns nil on the next loop iteration.
+//
+// A QueueEvents instance is single-use: once Close has been called the
+// underlying channel stays closed forever, so any subsequent Subscribe
+// call returns nil immediately without delivering events. Construct
+// a fresh QueueEvents (NewQueueEvents) when you need a new
+// subscription.
 func (qe *QueueEvents) Close() {
 	qe.closeOnce.Do(func() { close(qe.closeCh) })
 }

--- a/events_test.go
+++ b/events_test.go
@@ -1,0 +1,290 @@
+package mkq_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// startSubscriber spawns Subscribe in a goroutine and returns a
+// stop channel + an event chan that the caller can drain. Subscribe
+// errors are surfaced on the returned err channel.
+func startSubscriber(t *testing.T, qe *mkq.QueueEvents) (events <-chan mkq.Event, errs <-chan error) {
+	t.Helper()
+	evCh := make(chan mkq.Event, 32)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- qe.Subscribe(context.Background(), func(ev mkq.Event) error {
+			evCh <- ev
+			return nil
+		})
+	}()
+	t.Cleanup(qe.Close)
+	return evCh, errCh
+}
+
+// drainUntil collects events into the returned slice until pred
+// matches, the test ctx fires, or the stream goes idle for 1s.
+func drainUntil(t *testing.T, ctx context.Context, ch <-chan mkq.Event, pred func([]mkq.Event) bool) []mkq.Event {
+	t.Helper()
+	var seen []mkq.Event
+	idle := time.NewTimer(2 * time.Second)
+	defer idle.Stop()
+	for {
+		select {
+		case ev := <-ch:
+			seen = append(seen, ev)
+			idle.Reset(2 * time.Second)
+			if pred(seen) {
+				return seen
+			}
+		case <-idle.C:
+			t.Fatalf("subscribe idle for 2s, events so far: %d", len(seen))
+		case <-ctx.Done():
+			t.Fatalf("ctx done, events so far: %d", len(seen))
+		}
+	}
+}
+
+// containsType reports whether a typed event is present in xs.
+func containsType[E mkq.Event](xs []mkq.Event) bool {
+	for _, x := range xs {
+		if _, ok := x.(E); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// findFirst returns the first event of type E (or zero value + false).
+func findFirst[E mkq.Event](xs []mkq.Event) (E, bool) {
+	var zero E
+	for _, x := range xs {
+		if e, ok := x.(E); ok {
+			return e, true
+		}
+	}
+	return zero, false
+}
+
+// TestQueueEvents_BasicFlow drives Add -> Process -> Completed and
+// asserts the four wire events in order.
+func TestQueueEvents_BasicFlow(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	qe := mkq.NewQueueEvents(queue)
+	events, _ := startSubscriber(t, qe)
+	// Subscribe starts at "$" — give the BLOCKING XREAD a brief
+	// moment to register before Add fires.
+	time.Sleep(50 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		return map[string]any{"ok": true}, nil
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	job, err := queue.Add(ctx, testPayload{Inbox: "x"})
+	require.NoError(t, err)
+
+	got := drainUntil(t, ctx, events, func(xs []mkq.Event) bool {
+		return containsType[mkq.CompletedEvent](xs)
+	})
+
+	added, ok := findFirst[mkq.AddedEvent](got)
+	require.True(t, ok, "no AddedEvent in: %v", got)
+	assert.Equal(t, job.ID, added.JobID)
+
+	require.True(t, containsType[mkq.WaitingEvent](got))
+	require.True(t, containsType[mkq.ActiveEvent](got))
+
+	completed, ok := findFirst[mkq.CompletedEvent](got)
+	require.True(t, ok)
+	assert.Equal(t, job.ID, completed.JobID)
+	require.NotEmpty(t, completed.ReturnValue)
+	var rv map[string]any
+	require.NoError(t, json.Unmarshal(completed.ReturnValue, &rv))
+	assert.Equal(t, true, rv["ok"])
+}
+
+// TestQueueEvents_FailedEvent pins the failed-path payload (jobId +
+// failedReason as plain string).
+func TestQueueEvents_FailedEvent(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	qe := mkq.NewQueueEvents(queue)
+	events, _ := startSubscriber(t, qe)
+	time.Sleep(50 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		return nil, errors.New("bad")
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	_, err = queue.Add(ctx, testPayload{})
+	require.NoError(t, err)
+
+	got := drainUntil(t, ctx, events, func(xs []mkq.Event) bool {
+		return containsType[mkq.FailedEvent](xs)
+	})
+	failed, ok := findFirst[mkq.FailedEvent](got)
+	require.True(t, ok)
+	assert.Equal(t, "bad", failed.FailedReason)
+}
+
+// TestQueueEvents_DelayedEvent verifies WithDelay produces a delayed
+// event and that the delay value (ms) round-trips.
+func TestQueueEvents_DelayedEvent(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	qe := mkq.NewQueueEvents(queue)
+	events, _ := startSubscriber(t, qe)
+	time.Sleep(50 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := queue.Add(ctx, testPayload{}, mkq.WithDelay(2*time.Second))
+	require.NoError(t, err)
+
+	got := drainUntil(t, ctx, events, func(xs []mkq.Event) bool {
+		return containsType[mkq.DelayedEvent](xs)
+	})
+	d, ok := findFirst[mkq.DelayedEvent](got)
+	require.True(t, ok)
+	// BullMQ Lua emits delay as the absolute target ms timestamp.
+	assert.Greater(t, d.DelayMs, time.Now().UnixMilli()-1000,
+		"delayed event delay should be a current-or-future ms timestamp, got %d", d.DelayMs)
+}
+
+// TestQueueEvents_HandlerError pins that returning a non-nil error
+// from the callback stops Subscribe and propagates the error.
+func TestQueueEvents_HandlerError(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	qe := mkq.NewQueueEvents(queue)
+	t.Cleanup(qe.Close)
+
+	want := errors.New("stop please")
+	done := make(chan error, 1)
+	go func() {
+		done <- qe.Subscribe(context.Background(), func(ev mkq.Event) error {
+			return want
+		})
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := queue.Add(ctx, testPayload{})
+	require.NoError(t, err)
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, want)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Subscribe did not return after handler error")
+	}
+}
+
+// TestQueueEvents_CloseStopsSubscribe pins that Close terminates the
+// loop with nil.
+func TestQueueEvents_CloseStopsSubscribe(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	qe := mkq.NewQueueEvents(queue)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- qe.Subscribe(context.Background(), func(ev mkq.Event) error {
+			return nil
+		})
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	qe.Close()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "Subscribe must return nil after Close")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Subscribe did not return after Close")
+	}
+}
+
+// TestQueueEvents_RawEventForUnknown writes an unknown event type
+// directly via XADD and confirms RawEvent is delivered with intact
+// fields.
+func TestQueueEvents_RawEventForUnknown(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	qe := mkq.NewQueueEvents(queue)
+	events, _ := startSubscriber(t, qe)
+	time.Sleep(50 * time.Millisecond)
+
+	rdb := rawClient(t)
+	ctx := context.Background()
+	rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: prefix + ":deliver:events",
+		Values: map[string]any{
+			"event":  "future-event-from-bullmq-v6",
+			"jobId":  "42",
+			"custom": "value",
+		},
+	})
+
+	tctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	got := drainUntil(t, tctx, events, func(xs []mkq.Event) bool {
+		return containsType[mkq.RawEvent](xs)
+	})
+	raw, ok := findFirst[mkq.RawEvent](got)
+	require.True(t, ok)
+	assert.Equal(t, "future-event-from-bullmq-v6", raw.Type)
+	assert.Equal(t, "42", raw.Fields["jobId"])
+	assert.Equal(t, "value", raw.Fields["custom"])
+}
+
+// TestQueueEvents_NilHandlerErrors verifies the input validation.
+func TestQueueEvents_NilHandlerErrors(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+	qe := mkq.NewQueueEvents(queue)
+	err := qe.Subscribe(context.Background(), nil)
+	require.Error(t, err)
+}

--- a/events_test.go
+++ b/events_test.go
@@ -177,8 +177,8 @@ func TestQueueEvents_DelayedEvent(t *testing.T) {
 	d, ok := findFirst[mkq.DelayedEvent](got)
 	require.True(t, ok)
 	// BullMQ Lua emits delay as the absolute target ms timestamp.
-	assert.Greater(t, d.DelayMs, time.Now().UnixMilli()-1000,
-		"delayed event delay should be a current-or-future ms timestamp, got %d", d.DelayMs)
+	assert.Greater(t, d.DelayedUntilMs, time.Now().UnixMilli()-1000,
+		"delayed event target should be a current-or-future ms timestamp, got %d", d.DelayedUntilMs)
 }
 
 // TestQueueEvents_HandlerError pins that returning a non-nil error

--- a/tests/interop/queue_events_test.go
+++ b/tests/interop/queue_events_test.go
@@ -4,6 +4,7 @@ package interop_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -36,15 +37,16 @@ func TestInterop_QueueEvents_ObservesBullMQTSEmissions(t *testing.T) {
 	}
 	var got capture
 	done := make(chan struct{})
+	var doneOnce sync.Once
 	go func() {
 		_ = qe.Subscribe(context.Background(), func(ev mkq.Event) error {
 			switch e := ev.(type) {
 			case mkq.CompletedEvent:
 				got.completed = &e
-				close(done)
+				doneOnce.Do(func() { close(done) })
 			case mkq.FailedEvent:
 				got.failed = &e
-				close(done)
+				doneOnce.Do(func() { close(done) })
 			}
 			return nil
 		})

--- a/tests/interop/queue_events_test.go
+++ b/tests/interop/queue_events_test.go
@@ -4,7 +4,7 @@ package interop_test
 
 import (
 	"context"
-	"sync"
+	"errors"
 	"testing"
 	"time"
 
@@ -37,19 +37,28 @@ func TestInterop_QueueEvents_ObservesBullMQTSEmissions(t *testing.T) {
 	}
 	var got capture
 	done := make(chan struct{})
-	var doneOnce sync.Once
+	// errStop is a sentinel returned by the handler after the first
+	// completed/failed capture so Subscribe exits immediately. This
+	// removes any post-capture concurrent write to `got` from the
+	// subscriber goroutine while the test's main goroutine reads it.
+	errStop := errors.New("interop: stop after first terminal event")
 	go func() {
-		_ = qe.Subscribe(context.Background(), func(ev mkq.Event) error {
+		err := qe.Subscribe(context.Background(), func(ev mkq.Event) error {
 			switch e := ev.(type) {
 			case mkq.CompletedEvent:
 				got.completed = &e
-				doneOnce.Do(func() { close(done) })
+				close(done)
+				return errStop
 			case mkq.FailedEvent:
 				got.failed = &e
-				doneOnce.Do(func() { close(done) })
+				close(done)
+				return errStop
 			}
 			return nil
 		})
+		if err != nil && !errors.Is(err, errStop) {
+			t.Errorf("Subscribe returned unexpected error: %v", err)
+		}
 	}()
 	// Let the BLOCK-XREAD register before BullMQ TS starts emitting.
 	time.Sleep(100 * time.Millisecond)

--- a/tests/interop/queue_events_test.go
+++ b/tests/interop/queue_events_test.go
@@ -1,0 +1,73 @@
+//go:build interop
+
+package interop_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestInterop_QueueEvents_ObservesBullMQTSEmissions pins that mkq's
+// QueueEvents subscriber sees events emitted by a BullMQ TS worker
+// processing a job that mkq enqueued. This is the cross-language
+// version of the events-side wire compatibility — the same XADD
+// payload BullMQ TS produces must decode to mkq's typed Events.
+func TestInterop_QueueEvents_ObservesBullMQTSEmissions(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "deliver"
+
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	// Subscribe FIRST so the BullMQ-emitted events land within our
+	// `$`-anchored window.
+	qe := mkq.NewQueueEvents(queue)
+	t.Cleanup(qe.Close)
+
+	type capture struct {
+		completed *mkq.CompletedEvent
+		failed    *mkq.FailedEvent
+	}
+	var got capture
+	done := make(chan struct{})
+	go func() {
+		_ = qe.Subscribe(context.Background(), func(ev mkq.Event) error {
+			switch e := ev.(type) {
+			case mkq.CompletedEvent:
+				got.completed = &e
+				close(done)
+			case mkq.FailedEvent:
+				got.failed = &e
+				close(done)
+			}
+			return nil
+		})
+	}()
+	// Let the BLOCK-XREAD register before BullMQ TS starts emitting.
+	time.Sleep(100 * time.Millisecond)
+
+	startNodeWorker(t, prefix, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, interopPayload{Inbox: "x", Body: "hello"})
+	require.NoError(t, err)
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatalf("no completed/failed event from BullMQ TS within timeout")
+	}
+
+	require.NotNil(t, got.completed, "BullMQ TS should have emitted a completed event")
+	assert.Equal(t, job.ID, got.completed.JobID)
+	assert.NotEmpty(t, got.completed.ReturnValue,
+		"completed event must carry the BullMQ TS handler's return value")
+}


### PR DESCRIPTION
Resolves #30. Phase 4 step C: ships the Go-side subscriber for the BullMQ events Redis Stream. The vendored Lua already emits to that stream verbatim (27 \`XADD\` call sites grep'd from the vendored scripts), so this PR is purely additive — no new Lua, no dependency churn.

## Public API

\`\`\`go
qe := mkq.NewQueueEvents(queue)
defer qe.Close()

err := qe.Subscribe(ctx, func(ev mkq.Event) error {
    switch e := ev.(type) {
    case mkq.CompletedEvent:
        log.Printf(\"job %s done: %s\", e.JobID, e.ReturnValue)
    case mkq.FailedEvent:
        log.Printf(\"job %s failed: %s\", e.JobID, e.FailedReason)
    }
    return nil
})
\`\`\`

10 typed events: \`AddedEvent\`, \`WaitingEvent\`, \`ActiveEvent\`, \`CompletedEvent\`, \`FailedEvent\`, \`DelayedEvent\`, \`StalledEvent\`, \`DrainedEvent\`, \`RetriesExhaustedEvent\`, \`RemovedEvent\`. Forward-compat \`RawEvent\` catches unknown event names so Subscribe never silently drops a future BullMQ payload.

## Subscribe semantics

- Starts at \`\"$\"\` (only events emitted after Subscribe registers).
- \`XREAD BLOCK 200ms\` so ctx cancellation surfaces within ~one tick.
- Returns:
  - \`nil\` on ctx cancel / \`Close\`
  - \`ctx.Err()\` on context death
  - The first non-nil handler error verbatim
- Caller does the type switch — single callback keeps the API surface minimal; per-event-type helper channels can land later without breaking changes.

## Testing

\`\`\`
go vet ./...
gofmt -l .
go build ./...
go test ./... -race -count=1 -timeout 120s
go test -tags=interop ./tests/interop/...
\`\`\`

\`events_test.go\` (7 integration tests, real Redis 7):

- \`BasicFlow\`: Add → Process → Completed delivers the four expected events (\`added\`, \`waiting\`, \`active\`, \`completed\`) with correct JobID and ReturnValue.
- \`FailedEvent\`: handler error → \`FailedEvent\` with plain-string \`failedReason\`.
- \`DelayedEvent\`: \`WithDelay\` → \`DelayedEvent\` with the absolute target ms timestamp.
- \`HandlerError\`: returning a non-nil error from the callback stops Subscribe and propagates verbatim.
- \`CloseStopsSubscribe\`: \`Close\` terminates an idle Subscribe with nil.
- \`RawEventForUnknown\`: a manually-\`XADD\`'d unknown event type is delivered as \`RawEvent\` with intact fields.
- \`NilHandlerErrors\`: input validation guard.

\`tests/interop/queue_events_test.go\` (build tag \`interop\`):

- \`ObservesBullMQTSEmissions\`: BullMQ TS worker processes a job that mkq added; mkq's QueueEvents subscriber receives the \`completed\` event with BullMQ TS's return-value payload. This is the cross-language piece — the same \`XADD\` format BullMQ TS produces decodes to mkq's typed Event without translation.

3 sequential default suite runs and 3 sequential interop runs all green; existing PR #5–#29 tests untouched.

## Out of scope

- History replay (\`XREAD STREAMS key 0\`). Subscribe ignores past events; admin-style replay is a follow-up.
- \`XREADGROUP\` consumer groups (multi-consumer exactly-once).
- Multi-queue subscriber (one \`QueueEvents\` per queue today).
- Per-event-type helper channels (e.g. \`qe.Completed()\`).
- New event emissions — those land with #27 mutation API or Phase 4 D (Repeat scheduler).

## Related

- Closes #30
- Tracking: #1 (Phase 4 — \`QueueEvents (Redis Stream)\` checkbox)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
