### PR TITLE
feat: Repeat scheduler — cron pattern mode

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -27,6 +27,11 @@ var cronParser = cron.NewParser(
 // Schedules are immutable post-compile and shared safely across
 // goroutines; the cache leaks across the process lifetime by design
 // — pattern strings in a typical app are finite and small.
+//
+// Key encoding uses "|" as the pattern/tz separator. The documented
+// v1 cron subset (5 fields + standard descriptors) never contains
+// "|", so collisions are impossible; cronParser also rejects any
+// expression that would.
 var cronCache sync.Map // key: "<pattern>|<tz>" -> *cachedCron
 
 type cachedCron struct {
@@ -75,8 +80,10 @@ func parseCron(pattern, tz string) (*cachedCron, error) {
 	return actual.(*cachedCron), nil
 }
 
-// nextFire returns the next fire time at or after `from`, in the
-// schedule's timezone.
+// nextFire returns the next fire time strictly after `from`, in the
+// schedule's timezone. This matches BullMQ's cron-parser, whose
+// `interval.next()` also advances past the input time even if it
+// already matches the pattern.
 func (c *cachedCron) nextFire(from time.Time) time.Time {
 	return c.schedule.Next(from.In(c.loc))
 }

--- a/cron.go
+++ b/cron.go
@@ -82,8 +82,12 @@ func (c *cachedCron) nextFire(from time.Time) time.Time {
 }
 
 // isAtEvery detects `@every <duration>` so the rejection error can
-// be specific. Case-insensitive prefix check, mirroring cron-parser's
-// "@every" non-support stance.
+// be specific. Case-insensitive prefix check followed by a
+// word-boundary check (next character must be whitespace or
+// end-of-string) to avoid false positives like `@everyday` or
+// `@everyone` — those should fall through to the generic invalid-
+// pattern error instead of the misleading "use WithScheduleEvery"
+// hint.
 func isAtEvery(s string) bool {
 	const prefix = "@every"
 	if len(s) < len(prefix) {
@@ -98,5 +102,12 @@ func isAtEvery(s string) bool {
 			return false
 		}
 	}
-	return true
+	if len(s) == len(prefix) {
+		return true
+	}
+	switch s[len(prefix)] {
+	case ' ', '\t':
+		return true
+	}
+	return false
 }

--- a/cron.go
+++ b/cron.go
@@ -1,0 +1,102 @@
+package mkq
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+// cronParser is the strict 5-field parser instance. mkq's documented
+// subset matches BullMQ's cron-parser@4.9.0 mainstream syntax —
+// `Descriptor` enables `@yearly` / `@daily` / etc. but `WithSeconds`
+// is intentionally absent (Quartz mode would flip DOM/DOW from Vixie
+// OR to AND, breaking BullMQ compatibility).
+//
+// `@every <duration>` is a robfig-only extension not supported by
+// cron-parser; mkq routes that use case through WithScheduleEvery
+// instead. Any expression robfig parses but cron-parser would reject
+// silently diverges, so the supported subset is documented and
+// validated explicitly via parseCron.
+var cronParser = cron.NewParser(
+	cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
+)
+
+// cronCache memoises compiled cron schedules keyed by pattern+tz.
+// Schedules are immutable post-compile and shared safely across
+// goroutines; the cache leaks across the process lifetime by design
+// — pattern strings in a typical app are finite and small.
+var cronCache sync.Map // key: "<pattern>|<tz>" -> *cachedCron
+
+type cachedCron struct {
+	schedule cron.Schedule
+	loc      *time.Location
+}
+
+// parseCron compiles `pattern` (under the IANA `tz`, empty = local)
+// and caches the result. `tz` is validated via time.LoadLocation,
+// which rejects unknown zones; `pattern` is validated via cronParser
+// which surfaces the underlying robfig error verbatim.
+//
+// Rejected up front (before robfig sees them) so the error message
+// can name the unsupported extension instead of "unrecognized
+// descriptor":
+//   - `@every <dur>` (robfig accepts it; cron-parser does not)
+func parseCron(pattern, tz string) (*cachedCron, error) {
+	if pattern == "" {
+		return nil, fmt.Errorf("mkq: pattern must be non-empty")
+	}
+	if isAtEvery(pattern) {
+		return nil, fmt.Errorf("mkq: %q is not supported as a cron pattern; use WithScheduleEvery for fixed intervals", pattern)
+	}
+
+	key := pattern + "|" + tz
+	if v, ok := cronCache.Load(key); ok {
+		return v.(*cachedCron), nil
+	}
+
+	loc := time.Local
+	if tz != "" {
+		l, err := time.LoadLocation(tz)
+		if err != nil {
+			return nil, fmt.Errorf("mkq: invalid timezone %q: %w", tz, err)
+		}
+		loc = l
+	}
+
+	sched, err := cronParser.Parse(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("mkq: invalid cron pattern %q: %w", pattern, err)
+	}
+
+	cc := &cachedCron{schedule: sched, loc: loc}
+	actual, _ := cronCache.LoadOrStore(key, cc)
+	return actual.(*cachedCron), nil
+}
+
+// nextFire returns the next fire time at or after `from`, in the
+// schedule's timezone.
+func (c *cachedCron) nextFire(from time.Time) time.Time {
+	return c.schedule.Next(from.In(c.loc))
+}
+
+// isAtEvery detects `@every <duration>` so the rejection error can
+// be specific. Case-insensitive prefix check, mirroring cron-parser's
+// "@every" non-support stance.
+func isAtEvery(s string) bool {
+	const prefix = "@every"
+	if len(s) < len(prefix) {
+		return false
+	}
+	for i := range len(prefix) {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		if c != prefix[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/go.mod
+++ b/go.mod
@@ -3,19 +3,20 @@ module github.com/shiroha-a/mkq
 go 1.25.0
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.18.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.11.1
 	github.com/vmihailenco/msgpack/v5 v5.4.1
+	golang.org/x/sync v0.20.0
 )
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=

--- a/internal/proto/schedule_args.go
+++ b/internal/proto/schedule_args.go
@@ -7,9 +7,9 @@ import (
 // ScheduleOpts is the BullMQ schedule template — the value
 // addJobScheduler-11.lua reads as ARGV[2] (cmsgpack-unpacked).
 //
-// `pattern` (cron) is excluded by design: the every-mode PR ships
-// without a Go cron parser. When pattern support lands, this struct
-// gains `Pattern string` and `TZ string` fields.
+// EveryMs と Pattern は相互排他: every-mode は Lua 側で次 millis を
+// 再計算するが、pattern-mode は Go 側で計算した nextMillis を
+// ARGV[1] に渡し、Lua はそれを verbatim で使用する。
 type ScheduleOpts struct {
 	// Name is the BullMQ job name written to each created instance
 	// (Job.name). Defaults to the queue name.
@@ -18,6 +18,12 @@ type ScheduleOpts struct {
 	// every-mode; the vendored Lua's getJobSchedulerEveryNextMillis
 	// computes the next fire time from this.
 	EveryMs int64
+	// Pattern is the cron expression (5-field) for pattern-mode
+	// schedules. Mutually exclusive with EveryMs.
+	Pattern string
+	// TZ is the IANA timezone name for pattern-mode (e.g.
+	// "Asia/Tokyo"). Empty = local time. Pattern-mode only.
+	TZ string
 	// StartDate (optional) is the earliest absolute ms timestamp at
 	// which the first instance fires. 0 = unset (fire as soon as
 	// possible).
@@ -35,6 +41,12 @@ func EncodeScheduleOpts(o ScheduleOpts) ([]byte, error) {
 	m := map[string]any{"name": o.Name}
 	if o.EveryMs > 0 {
 		m["every"] = o.EveryMs
+	}
+	if o.Pattern != "" {
+		m["pattern"] = o.Pattern
+	}
+	if o.TZ != "" {
+		m["tz"] = o.TZ
 	}
 	if o.StartDate > 0 {
 		m["startDate"] = o.StartDate
@@ -76,6 +88,12 @@ func EncodeScheduleDelayedOpts(o ScheduleOpts) ([]byte, error) {
 	repeat := map[string]any{}
 	if o.EveryMs > 0 {
 		repeat["every"] = o.EveryMs
+	}
+	if o.Pattern != "" {
+		repeat["pattern"] = o.Pattern
+	}
+	if o.TZ != "" {
+		repeat["tz"] = o.TZ
 	}
 	if o.StartDate > 0 {
 		repeat["startDate"] = o.StartDate

--- a/internal/proto/schedule_args.go
+++ b/internal/proto/schedule_args.go
@@ -7,9 +7,10 @@ import (
 // ScheduleOpts is the BullMQ schedule template — the value
 // addJobScheduler-11.lua reads as ARGV[2] (cmsgpack-unpacked).
 //
-// EveryMs と Pattern は相互排他: every-mode は Lua 側で次 millis を
-// 再計算するが、pattern-mode は Go 側で計算した nextMillis を
-// ARGV[1] に渡し、Lua はそれを verbatim で使用する。
+// EveryMs and Pattern are mutually exclusive: every-mode lets Lua
+// recompute the next millis via getJobSchedulerEveryNextMillis,
+// while pattern-mode passes a Go-computed nextMillis in ARGV[1]
+// and Lua uses it verbatim.
 type ScheduleOpts struct {
 	// Name is the BullMQ job name written to each created instance
 	// (Job.name). Defaults to the queue name.

--- a/schedule.go
+++ b/schedule.go
@@ -4,22 +4,28 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/shiroha-a/mkq/internal/lua"
 	"github.com/shiroha-a/mkq/internal/proto"
 )
 
-// scheduleConfig is the typed-option bag for UpsertScheduleEvery.
-// Public callers populate it via WithSchedule* options; internal
-// re-upserts (worker auto-schedule) construct it directly.
+// scheduleConfig is the typed-option bag for UpsertScheduleEvery /
+// UpsertSchedulePattern. Public callers populate it via WithSchedule*
+// options; internal re-upserts (worker auto-schedule) construct it
+// directly.
 type scheduleConfig struct {
-	limit     int
-	endDate   time.Time
-	startDate time.Time
+	limit       int
+	endDate     time.Time
+	startDate   time.Time
+	tz          string
+	immediately bool
 }
 
-// ScheduleOption customises an UpsertScheduleEvery call.
+// ScheduleOption customises an UpsertScheduleEvery / UpsertSchedulePattern
+// call. Some options (timezone, immediately) only make sense for
+// pattern-mode and are validated at upsert time.
 type ScheduleOption func(*scheduleConfig)
 
 // WithScheduleLimit caps the total number of fires for a schedule.
@@ -40,6 +46,22 @@ func WithScheduleEndDate(t time.Time) ScheduleOption {
 // after upsert".
 func WithScheduleStartDate(t time.Time) ScheduleOption {
 	return func(c *scheduleConfig) { c.startDate = t }
+}
+
+// WithScheduleTimezone sets the IANA timezone (e.g. "Asia/Tokyo")
+// in which a cron pattern is evaluated. Pattern-mode only; ignored
+// for fixed-interval schedules. Empty string = local time, matching
+// BullMQ's default when `tz` is omitted.
+func WithScheduleTimezone(tz string) ScheduleOption {
+	return func(c *scheduleConfig) { c.tz = tz }
+}
+
+// WithScheduleImmediately makes the first iteration fire at upsert
+// time rather than waiting for the next pattern match. Pattern-mode
+// only. Mutually exclusive with WithScheduleStartDate (BullMQ TS
+// rejects the combination at upsertJobScheduler).
+func WithScheduleImmediately() ScheduleOption {
+	return func(c *scheduleConfig) { c.immediately = true }
 }
 
 // UpsertScheduleEvery registers (or replaces) a fixed-interval
@@ -71,29 +93,18 @@ func (q *Queue[T]) UpsertScheduleEvery(
 	for _, o := range opts {
 		o(&cfg)
 	}
+	if cfg.tz != "" || cfg.immediately {
+		return fmt.Errorf("mkq: WithScheduleTimezone / WithScheduleImmediately are pattern-mode only; use UpsertSchedulePattern")
+	}
 
 	dataJSON, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("mkq: marshal schedule payload: %w", err)
 	}
 
-	return q.upsertSchedule(ctx, scheduleID, every.Milliseconds(), cfg, string(dataJSON))
-}
-
-// upsertSchedule is the wire-level call shared by UpsertScheduleEvery
-// (public) and the worker's auto-rescheduling path.
-func (q *Queue[T]) upsertSchedule(
-	ctx context.Context,
-	scheduleID string,
-	everyMs int64,
-	cfg scheduleConfig,
-	dataJSON string,
-) error {
-	now := time.Now().UnixMilli()
-
 	scheduleOpts := proto.ScheduleOpts{
 		Name:    q.name,
-		EveryMs: everyMs,
+		EveryMs: every.Milliseconds(),
 		Limit:   cfg.limit,
 	}
 	if !cfg.startDate.IsZero() {
@@ -102,6 +113,97 @@ func (q *Queue[T]) upsertSchedule(
 	if !cfg.endDate.IsZero() {
 		scheduleOpts.EndDate = cfg.endDate.UnixMilli()
 	}
+
+	// every-mode は ARGV[1]="0" → lua が getJobSchedulerEveryNextMillis
+	// で次 millis を再計算する。
+	return q.upsertSchedule(ctx, scheduleID, "0", scheduleOpts, string(dataJSON))
+}
+
+// UpsertSchedulePattern registers (or replaces) a cron-pattern
+// recurring schedule. Behaves like UpsertScheduleEvery except next
+// fire times are derived from the cron expression Go-side (see
+// cron.go for the supported subset, which mirrors BullMQ's
+// cron-parser@4.9.0 mainstream syntax).
+//
+// pattern is a 5-field cron expression or a standard descriptor
+// macro (`@daily`, etc.). `@every <duration>` is rejected — use
+// UpsertScheduleEvery for fixed intervals.
+//
+// WithScheduleTimezone(tz) controls the timezone for evaluation
+// (default: local). WithScheduleImmediately() makes the first
+// iteration fire at upsert time; mutually exclusive with
+// WithScheduleStartDate per BullMQ TS validation.
+func (q *Queue[T]) UpsertSchedulePattern(
+	ctx context.Context,
+	scheduleID string,
+	pattern string,
+	payload T,
+	opts ...ScheduleOption,
+) error {
+	if scheduleID == "" {
+		return fmt.Errorf("mkq: scheduleID must be non-empty")
+	}
+
+	cfg := scheduleConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if cfg.immediately && !cfg.startDate.IsZero() {
+		return fmt.Errorf("mkq: WithScheduleImmediately and WithScheduleStartDate are mutually exclusive")
+	}
+
+	cc, err := parseCron(pattern, cfg.tz)
+	if err != nil {
+		return err
+	}
+
+	dataJSON, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("mkq: marshal schedule payload: %w", err)
+	}
+
+	scheduleOpts := proto.ScheduleOpts{
+		Name:    q.name,
+		Pattern: pattern,
+		TZ:      cfg.tz,
+		Limit:   cfg.limit,
+	}
+	if !cfg.startDate.IsZero() {
+		scheduleOpts.StartDate = cfg.startDate.UnixMilli()
+	}
+	if !cfg.endDate.IsZero() {
+		scheduleOpts.EndDate = cfg.endDate.UnixMilli()
+	}
+
+	// pattern-mode は Go 側で次 millis を計算して ARGV[1] に渡す。
+	// immediately なら今すぐ、startDate があればそれ以降の最初の
+	// pattern マッチ、それ以外は now 以降の最初のマッチ。
+	now := time.Now()
+	var firstFire time.Time
+	switch {
+	case cfg.immediately:
+		firstFire = now
+	case !cfg.startDate.IsZero():
+		firstFire = cc.nextFire(cfg.startDate)
+	default:
+		firstFire = cc.nextFire(now)
+	}
+	nextMillis := strconv.FormatInt(firstFire.UnixMilli(), 10)
+
+	return q.upsertSchedule(ctx, scheduleID, nextMillis, scheduleOpts, string(dataJSON))
+}
+
+// upsertSchedule is the wire-level call shared by UpsertScheduleEvery,
+// UpsertSchedulePattern, and the worker's auto-rescheduling path.
+// `nextMillis` is "0" for every-mode (lua recomputes) or the
+// pre-computed pattern next-fire ms timestamp as a decimal string.
+func (q *Queue[T]) upsertSchedule(
+	ctx context.Context,
+	scheduleID string,
+	nextMillis string,
+	scheduleOpts proto.ScheduleOpts,
+	dataJSON string,
+) error {
 	scheduleOptsBytes, err := proto.EncodeScheduleOpts(scheduleOpts)
 	if err != nil {
 		return fmt.Errorf("mkq: encode schedule opts: %w", err)
@@ -111,18 +213,20 @@ func (q *Queue[T]) upsertSchedule(
 		return fmt.Errorf("mkq: encode template opts: %w", err)
 	}
 	// 各 iteration の job HASH に書かれる opts。BullMQ TS Worker は
-	// 自前で再スケジュールするとき opts.repeat.every を参照するので、
-	// foreign worker と互換にするため repeat ブロックを必ず埋める。
+	// 自前で再スケジュールするとき opts.repeat.every / pattern を
+	// 参照するので、foreign worker と互換にするため repeat ブロックを
+	// 必ず埋める。
 	delayedOptsBytes, err := proto.EncodeScheduleDelayedOpts(scheduleOpts)
 	if err != nil {
 		return fmt.Errorf("mkq: encode delayed opts: %w", err)
 	}
 
+	now := time.Now().UnixMilli()
 	res, err := q.client.scripts.Run(
 		ctx,
 		lua.AddJobScheduler,
 		q.scheduleKeys(),
-		"0", // ARGV[1] nextMillis: every-mode は lua が再計算
+		nextMillis,
 		scheduleOptsBytes,
 		scheduleID,
 		dataJSON,

--- a/schedule.go
+++ b/schedule.go
@@ -114,6 +114,20 @@ func (q *Queue[T]) UpsertScheduleEvery(
 		scheduleOpts.EndDate = cfg.endDate.UnixMilli()
 	}
 
+	// every-mode の初回 fire は max(startDate, now)。lua の
+	// getJobSchedulerEveryNextMillis と同じ式を Go 側で再現し、
+	// firstFire > endDate なら dead schedule を作らずに reject。
+	// pattern-mode 側 (UpsertSchedulePattern) と同じ gating ポリシー。
+	if !cfg.endDate.IsZero() {
+		firstFire := time.Now()
+		if !cfg.startDate.IsZero() && cfg.startDate.After(firstFire) {
+			firstFire = cfg.startDate
+		}
+		if firstFire.After(cfg.endDate) {
+			return fmt.Errorf("mkq: first fire %v exceeds endDate %v; schedule would never run", firstFire, cfg.endDate)
+		}
+	}
+
 	// every-mode は ARGV[1]="0" → lua が getJobSchedulerEveryNextMillis
 	// で次 millis を再計算する。
 	return q.upsertSchedule(ctx, scheduleID, "0", scheduleOpts, string(dataJSON))
@@ -187,6 +201,13 @@ func (q *Queue[T]) UpsertSchedulePattern(
 		firstFire = cc.nextFire(cfg.startDate)
 	default:
 		firstFire = cc.nextFire(now)
+	}
+	// endDate を超えた firstFire を許すと、yearly cron + endDate=24h の
+	// ように lua 側で月単位の delay job を作ってしまう。worker の
+	// rescheduleNext が以後の iteration を gate するのと同じロジックを
+	// 初回 upsert にも適用し、dead schedule の作成を未然に弾く。
+	if !cfg.endDate.IsZero() && firstFire.After(cfg.endDate) {
+		return fmt.Errorf("mkq: first fire %v exceeds endDate %v; schedule would never run", firstFire, cfg.endDate)
 	}
 	nextMillis := strconv.FormatInt(firstFire.UnixMilli(), 10)
 

--- a/schedule.go
+++ b/schedule.go
@@ -49,9 +49,9 @@ func WithScheduleStartDate(t time.Time) ScheduleOption {
 }
 
 // WithScheduleTimezone sets the IANA timezone (e.g. "Asia/Tokyo")
-// in which a cron pattern is evaluated. Pattern-mode only; ignored
-// for fixed-interval schedules. Empty string = local time, matching
-// BullMQ's default when `tz` is omitted.
+// in which a cron pattern is evaluated. Pattern-mode only; passing
+// it to UpsertScheduleEvery returns an error. Empty string = local
+// time, matching BullMQ's default when `tz` is omitted.
 func WithScheduleTimezone(tz string) ScheduleOption {
 	return func(c *scheduleConfig) { c.tz = tz }
 }

--- a/schedule_pattern_test.go
+++ b/schedule_pattern_test.go
@@ -1,0 +1,168 @@
+package mkq_test
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestSchedulePattern_ImmediatelyFires validates that
+// WithScheduleImmediately makes the first iteration fire at upsert
+// time, without waiting for the next pattern-match. This decouples
+// the test from the cron grain (`* * * * *` would otherwise force a
+// wait of up to 60s for the first fire).
+func TestSchedulePattern_ImmediatelyFires(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "tick")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, queue.UpsertSchedulePattern(ctx,
+		"now", "* * * * *", testPayload{Inbox: "tick"},
+		mkq.WithScheduleImmediately(),
+	))
+
+	var seen atomic.Int64
+	worker, err := mkq.Process(queue, func(_ context.Context, j *mkq.Job[testPayload]) (any, error) {
+		assert.True(t, strings.HasPrefix(j.ID, "repeat:now:"), "unexpected job id %q", j.ID)
+		seen.Add(1)
+		return nil, nil
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	waitFor(t, ctx, 50*time.Millisecond, func() bool { return seen.Load() >= 1 })
+
+	rdb := rawClient(t)
+	got, err := rdb.HGetAll(ctx, prefix+":tick:repeat:now").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "* * * * *", got["pattern"], "schedule HASH must record pattern")
+	assert.NotEmpty(t, got["ic"], "ic counter must be set after first fire")
+}
+
+// TestSchedulePattern_HASHCarriesTimezone confirms that the tz
+// option lands in the schedule HASH so foreign clients (BullMQ TS)
+// can pick it up unchanged.
+func TestSchedulePattern_HASHCarriesTimezone(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "tick")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, queue.UpsertSchedulePattern(ctx,
+		"tz", "0 9 * * *", testPayload{},
+		mkq.WithScheduleTimezone("Asia/Tokyo"),
+	))
+
+	rdb := rawClient(t)
+	got, err := rdb.HGetAll(ctx, prefix+":tick:repeat:tz").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "0 9 * * *", got["pattern"])
+	assert.Equal(t, "Asia/Tokyo", got["tz"])
+}
+
+// TestSchedulePattern_RejectsExoticSyntax pins the documented v1
+// subset by checking that syntax mkq does not promise to handle is
+// rejected at upsert time rather than silently producing
+// BullMQ-incompatible iterations.
+func TestSchedulePattern_RejectsExoticSyntax(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "tick")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cases := map[string]string{
+		"6-field seconds":                  "0 * * * * *",
+		"@every (use UpsertScheduleEvery)": "@every 5m",
+		"empty pattern":                    "",
+		"random garbage":                   "not a cron",
+	}
+	for name, pat := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := queue.UpsertSchedulePattern(ctx, "x", pat, testPayload{})
+			assert.Error(t, err, "pattern %q should be rejected", pat)
+		})
+	}
+}
+
+// TestSchedulePattern_RejectsBogusTimezone catches a typo / unknown
+// IANA name before it gets persisted to the schedule HASH.
+func TestSchedulePattern_RejectsBogusTimezone(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "tick")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := queue.UpsertSchedulePattern(ctx, "x", "0 9 * * *", testPayload{},
+		mkq.WithScheduleTimezone("Mars/Olympus"),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timezone")
+}
+
+// TestSchedulePattern_RejectsImmediatelyWithStartDate mirrors BullMQ
+// TS's mutual-exclusion validation in upsertJobScheduler.
+func TestSchedulePattern_RejectsImmediatelyWithStartDate(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "tick")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := queue.UpsertSchedulePattern(ctx, "x", "* * * * *", testPayload{},
+		mkq.WithScheduleImmediately(),
+		mkq.WithScheduleStartDate(time.Now().Add(time.Hour)),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+// TestScheduleEvery_RejectsPatternOnlyOptions keeps every-mode and
+// pattern-mode option surfaces from leaking into each other. Passing
+// WithScheduleTimezone or WithScheduleImmediately to UpsertScheduleEvery
+// is a programmer error — those options have no meaning for fixed
+// intervals — so the upsert call fails fast rather than silently
+// dropping the option.
+func TestScheduleEvery_RejectsPatternOnlyOptions(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "tick")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	t.Run("timezone", func(t *testing.T) {
+		err := queue.UpsertScheduleEvery(ctx, "x", time.Second, testPayload{},
+			mkq.WithScheduleTimezone("UTC"),
+		)
+		require.Error(t, err)
+	})
+	t.Run("immediately", func(t *testing.T) {
+		err := queue.UpsertScheduleEvery(ctx, "x", time.Second, testPayload{},
+			mkq.WithScheduleImmediately(),
+		)
+		require.Error(t, err)
+	})
+}

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -134,6 +134,58 @@ func TestSchedule_EndDateStops(t *testing.T) {
 		"endDate must allow at least the initial iterations to fire")
 }
 
+// TestScheduleEvery_RejectsEndDateInPast pins the initial-upsert
+// endDate guard for every-mode: passing an endDate that has already
+// passed (or one that's earlier than startDate) means the schedule
+// could never fire even once, so the upsert returns an error rather
+// than persisting a dead schedule HASH.
+func TestScheduleEvery_RejectsEndDateInPast(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "tick")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	t.Run("endDate in past", func(t *testing.T) {
+		err := queue.UpsertScheduleEvery(ctx, "x", time.Second, testPayload{},
+			mkq.WithScheduleEndDate(time.Now().Add(-time.Hour)),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "endDate")
+	})
+	t.Run("startDate after endDate", func(t *testing.T) {
+		err := queue.UpsertScheduleEvery(ctx, "x", time.Second, testPayload{},
+			mkq.WithScheduleStartDate(time.Now().Add(time.Hour)),
+			mkq.WithScheduleEndDate(time.Now().Add(time.Minute)),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "endDate")
+	})
+}
+
+// TestSchedulePattern_RejectsFirstFireBeyondEndDate pins the
+// equivalent guard for pattern-mode: a yearly cron with endDate=24h
+// would compute firstFire as next Jan 1st (months out), creating a
+// "dead" delayed job. The upsert call rejects it instead.
+func TestSchedulePattern_RejectsFirstFireBeyondEndDate(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "tick")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := queue.UpsertSchedulePattern(ctx,
+		"yearly", "0 0 1 1 *", testPayload{},
+		mkq.WithScheduleEndDate(time.Now().Add(24*time.Hour)),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "endDate")
+}
+
 // TestSchedule_RemoveStops confirms that RemoveSchedule prevents
 // further iterations: the in-flight job (if any) finishes normally and
 // the worker's re-upsert path no-ops because the schedule HASH is gone.

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -92,6 +92,48 @@ func TestSchedule_LimitStops(t *testing.T) {
 	assert.GreaterOrEqual(t, icN, limit, "ic counter must reach limit")
 }
 
+// TestSchedule_EndDateStops confirms that WithScheduleEndDate caps
+// further iterations Go-side: once the next computed fire would
+// exceed endDate, the worker's reschedule path no-ops without
+// queueing the next instance. BullMQ TS performs the same check in
+// worker.getNextMillis; the gate is client-side because the lua
+// doesn't enforce it.
+func TestSchedule_EndDateStops(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "tick")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// endDate を 250ms 先に設定。every=100ms なので、iteration 0/1/2
+	// あたりまでは進み、3 回目以降は endDate 超過で止まる。
+	endDate := time.Now().Add(250 * time.Millisecond)
+	require.NoError(t, queue.UpsertScheduleEvery(ctx,
+		"sunset", 100*time.Millisecond, testPayload{},
+		mkq.WithScheduleEndDate(endDate),
+	))
+
+	var seen atomic.Int64
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		seen.Add(1)
+		return nil, nil
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	// endDate 超過後は新しい iteration が積まれないので、ある時点で
+	// 確実に増加が止まる。 endDate + 数 iteration 分の余裕で待機。
+	time.Sleep(700 * time.Millisecond)
+	stopped := seen.Load()
+	time.Sleep(300 * time.Millisecond)
+	assert.Equal(t, stopped, seen.Load(),
+		"schedule must stop firing after endDate (got %d -> %d)", stopped, seen.Load())
+	assert.Greater(t, stopped, int64(0),
+		"endDate must allow at least the initial iterations to fire")
+}
+
 // TestSchedule_RemoveStops confirms that RemoveSchedule prevents
 // further iterations: the in-flight job (if any) finishes normally and
 // the worker's re-upsert path no-ops because the schedule HASH is gone.

--- a/tests/interop/schedule_pattern_test.go
+++ b/tests/interop/schedule_pattern_test.go
@@ -1,0 +1,70 @@
+//go:build interop
+
+package interop_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestInterop_MkqPatternBullMQProcess: mkq UpsertSchedulePattern
+// writes the schedule HASH (pattern, tz fields), and a BullMQ TS
+// Worker subprocess processes the immediate first iteration. The
+// asserted invariant is that BullMQ TS reads mkq's HASH layout
+// without errors and that the iteration job ID matches the
+// repeat:<id>:<millis> convention both sides agree on.
+//
+// We deliberately use WithScheduleImmediately to avoid waiting for
+// the next minute boundary; second-iteration timing is a function
+// of cron grain (1 minute), not interop correctness.
+func TestInterop_MkqPatternBullMQProcess(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "tick"
+	const scheduleID = "interop-cron"
+
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	startNodeWorker(t, prefix, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	require.NoError(t, queue.UpsertSchedulePattern(ctx,
+		scheduleID, "* * * * *",
+		interopPayload{Inbox: "https://x", Body: "tick"},
+		mkq.WithScheduleImmediately(),
+	))
+
+	rdb := rawClient(t)
+	scheduleKey := prefix + ":" + queueName + ":repeat:" + scheduleID
+	completed := prefix + ":" + queueName + ":completed"
+
+	// 即時 fire の後、BullMQ TS は次 iteration を minute boundary に
+	// スケジュールする。最初の 1 件が completed に入るところまで待てば、
+	// HASH layout 互換性は十分検証できる。
+	waitFor(t, ctx, 50*time.Millisecond, func() bool {
+		n, _ := rdb.ZCard(ctx, completed).Result()
+		return n >= 1
+	})
+
+	ids, err := rdb.ZRange(ctx, completed, 0, -1).Result()
+	require.NoError(t, err)
+	for _, id := range ids {
+		assert.True(t, strings.HasPrefix(id, "repeat:"+scheduleID+":"),
+			"unexpected jobId %q in completed set", id)
+	}
+
+	got, err := rdb.HGetAll(ctx, scheduleKey).Result()
+	require.NoError(t, err)
+	assert.Equal(t, queueName, got["name"], "schedule HASH name field")
+	assert.Equal(t, "* * * * *", got["pattern"], "pattern field preserved")
+	assert.NotEmpty(t, got["ic"], "ic counter must be set")
+}

--- a/worker.go
+++ b/worker.go
@@ -476,10 +476,13 @@ func (w *Worker) rescheduleNext(scheduleID, currentJobID string) {
 	defer cancel()
 
 	// limit=0 (unset) は cap なし。limit>0 かつ ic>=limit で打ち止め。
-	// every は次 iteration の opts.repeat に詰めるため必須。HMGET は
-	// scheduler が消えていれば nil を返すので、その場合 lua 側 no-op。
-	vals, err := w.rdb.HMGet(ctx, scheduleKey, "limit", "ic", "every", "startDate", "endDate").Result()
-	if err != nil || len(vals) != 5 {
+	// every / pattern のいずれかが必須 (両者とも未設定なら HASH が
+	// 消えている = no-op で終了)。HMGET は scheduler が消えていれば
+	// nil を返すので、その場合は startDate/endDate も nil で安全。
+	vals, err := w.rdb.HMGet(ctx, scheduleKey,
+		"limit", "ic", "every", "startDate", "endDate", "pattern", "tz",
+	).Result()
+	if err != nil || len(vals) != 7 {
 		return
 	}
 	limit := parseInt(asString(vals[0]))
@@ -488,22 +491,43 @@ func (w *Worker) rescheduleNext(scheduleID, currentJobID string) {
 		return
 	}
 	everyMs, _ := strconv.ParseInt(asString(vals[2]), 10, 64)
-	if everyMs <= 0 {
-		// every が未設定 = pattern モードか、HASH が消えている。
-		// pattern モードは未対応なので no-op。
-		return
-	}
 	startDate, _ := strconv.ParseInt(asString(vals[3]), 10, 64)
 	endDate, _ := strconv.ParseInt(asString(vals[4]), 10, 64)
+	pattern := asString(vals[5])
+	tz := asString(vals[6])
 
-	delayedOpts, err := proto.EncodeScheduleDelayedOpts(proto.ScheduleOpts{
+	if everyMs <= 0 && pattern == "" {
+		// HASH が消えた、または不完全な状態。lua の prevMillis check に
+		// 任せても良いが、ここで早期 return しておけば余計な EVAL を省ける。
+		return
+	}
+
+	scheduleProto := proto.ScheduleOpts{
 		EveryMs:   everyMs,
+		Pattern:   pattern,
+		TZ:        tz,
 		StartDate: startDate,
 		EndDate:   endDate,
 		Limit:     limit,
-	})
+	}
+	delayedOpts, err := proto.EncodeScheduleDelayedOpts(scheduleProto)
 	if err != nil {
 		return
+	}
+
+	// pattern-mode は Go 側で次 millis を計算 → ARGV[1]。
+	// every-mode は "0" を渡し、lua が getJobSchedulerEveryNextMillis
+	// で計算する。
+	nextMillisArg := "0"
+	if pattern != "" {
+		cc, err := parseCron(pattern, tz)
+		if err != nil {
+			// HASH に書かれている pattern が parse できない = データ
+			// 破損 or 別 client が書き換えた。ログ手段がまだ無いので
+			// no-op (次 iteration が出ないだけ)。
+			return
+		}
+		nextMillisArg = strconv.FormatInt(cc.nextFire(time.Now()).UnixMilli(), 10)
 	}
 
 	now := time.Now().UnixMilli()
@@ -526,10 +550,10 @@ func (w *Worker) rescheduleNext(scheduleID, currentJobID string) {
 		ctx,
 		lua.UpdateJobScheduler,
 		keysArg,
-		"0",           // ARGV[1] nextMillis: every-mode は lua が再計算
+		nextMillisArg, // ARGV[1] nextMillis: every="0" / pattern=Go計算値
 		scheduleID,    // ARGV[2]
 		"{}",          // ARGV[3] data fallback (HASH 優先)
-		delayedOpts,   // ARGV[4] msgpack delayed opts (repeat.every 含む)
+		delayedOpts,   // ARGV[4] msgpack delayed opts (repeat.every / pattern 含む)
 		now,           // ARGV[5]
 		w.keys.prefix, // ARGV[6]
 		currentJobID,  // ARGV[7] producerId — current job ID で dedupe

--- a/worker.go
+++ b/worker.go
@@ -517,9 +517,14 @@ func (w *Worker) rescheduleNext(scheduleID, currentJobID string) {
 
 	// pattern-mode は Go 側で次 millis を計算 → ARGV[1]。
 	// every-mode は "0" を渡し、lua が getJobSchedulerEveryNextMillis
-	// で計算する。
+	// で計算する。every-mode の場合は endDate ガードを行うために
+	// nextMillis を Go 側でも算出する (lua に任せるとガードできない)。
+	nowTime := time.Now()
+	now := nowTime.UnixMilli()
 	nextMillisArg := "0"
-	if pattern != "" {
+	var nextMillisVal int64
+	switch {
+	case pattern != "":
 		cc, err := parseCron(pattern, tz)
 		if err != nil {
 			// HASH に書かれている pattern が parse できない = データ
@@ -527,10 +532,21 @@ func (w *Worker) rescheduleNext(scheduleID, currentJobID string) {
 			// no-op (次 iteration が出ないだけ)。
 			return
 		}
-		nextMillisArg = strconv.FormatInt(cc.nextFire(time.Now()).UnixMilli(), 10)
+		nextMillisVal = cc.nextFire(nowTime).UnixMilli()
+		nextMillisArg = strconv.FormatInt(nextMillisVal, 10)
+	default: // every-mode
+		// getJobSchedulerEveryNextMillis のロジック: 前回 fire 時刻 +
+		// every。前回 fire 時刻が無い (初回) なら startDate or now。
+		// rescheduleNext は worker が job を完了した直後に呼ばれるので、
+		// 必ず prevMillis が ZSCORE で取れる前提だが、endDate ガード
+		// 用途では now + every で近似すれば十分。
+		nextMillisVal = now + everyMs
 	}
-
-	now := time.Now().UnixMilli()
+	if endDate > 0 && nextMillisVal > endDate {
+		// BullMQ TS は worker.getNextMillis() で同様の endDate チェックを
+		// 行っており、超過した場合は新しい iteration を作らない。
+		return
+	}
 	keysArg := []string{
 		w.keys.repeat,      // KEYS[1]  repeat
 		w.keys.delayed,     // KEYS[2]  delayed


### PR DESCRIPTION
## Summary

- Resolves #34. Follow-up to #32 / PR #33: adds cron-pattern recurring schedules, completing the BullMQ compat surface for both `every` and `pattern` repeat modes.
- New entry point `Queue[T].UpsertSchedulePattern(ctx, scheduleID, pattern, payload, opts...)` with `WithScheduleTimezone(tz)` and `WithScheduleImmediately()` options.
- Strict 5-field cron parser (`robfig/cron/v3`), explicitly rejecting syntax cron-parser would silently disagree on.

## Key Changes

**Parser choice (cron.go).** `robfig/cron/v3` configured as `cron.NewParser(Minute|Hour|Dom|Month|Dow|Descriptor)`. Verified against BullMQ TS's `cron-parser@4.9.0`:

- Vixie OR semantics for DOM/DOW (matches).
- `Sun = 0` and `7` both supported.
- Native `time.Location` for DST (matches cron-parser's Luxon timezone).
- No `WithSeconds` (would flip DOM/DOW to Quartz AND).
- No `@every <dur>` (collides with `WithScheduleEvery`; not supported by cron-parser anyway).

Compiled `cron.Schedule` cached per `(pattern, tz)` via `sync.Map` (intentional process-lifetime leak: pattern strings are finite per app).

**Documented v1 subset.** 5 fields + `@yearly`/`@daily`/etc. macros + IANA tz + `WithScheduleImmediately()`. Out of scope and rejected at parse time: 6-field seconds, `L`/`W`/`#` extensions, `@every`, `@reboot`, `@5minutes`/`@always`/`@everysecond`. Rejecting fast prevents silent BullMQ divergence.

**Wire layer.** No new lua. `addJobScheduler-11.lua` and `updateJobScheduler-12.lua` already branch on `every`; when `every` is unset (pattern mode), they use ARGV[1] `nextMillis` verbatim. mkq computes next-fire Go-side. `internal/proto/schedule_args.go` adds `Pattern` / `TZ` fields; `EncodeScheduleOpts` and `EncodeScheduleDelayedOpts` emit them in both the schedule HASH msgpack and the per-iteration `repeat` block (BullMQ TS Worker reads the latter for its own re-schedule path).

**Worker (worker.go).** `rescheduleNext` extension: HMGET adds `pattern` / `tz`; if `pattern` non-empty, compute `schedule.Next(time.Now()).UnixMilli()` and pass into ARGV[1]. Else every-mode behavior unchanged.

**Validation.** `WithScheduleImmediately + WithScheduleStartDate` rejected at upsert time (matches BullMQ TS). `WithScheduleTimezone` / `WithScheduleImmediately` on `UpsertScheduleEvery` rejected fast — keeps the two API surfaces from leaking into each other.

## Testing

`schedule_pattern_test.go` (6 tests, real Redis 7):

- `ImmediatelyFires` — `WithScheduleImmediately` fires the first iteration at upsert time without waiting for the cron grain; HASH `pattern` / `ic` written.
- `HASHCarriesTimezone` — tz lands in schedule HASH so foreign clients pick it up unchanged.
- `RejectsExoticSyntax` — 6-field seconds, `@every`, empty, garbage all rejected.
- `RejectsBogusTimezone` — `Mars/Olympus` error mentions `timezone`.
- `RejectsImmediatelyWithStartDate` — mutual-exclusion check matches BullMQ TS.
- `ScheduleEvery_RejectsPatternOnlyOptions` — pattern-only options on every-mode error fast.

`tests/interop/schedule_pattern_test.go` (build tag `interop`):

- `MkqPatternBullMQProcess` — mkq creates a pattern schedule with `WithScheduleImmediately`; BullMQ TS Worker subprocess processes the first iteration. Asserts schedule HASH `pattern` / `name` / `ic` survive the cross-language round-trip and the iteration jobId follows the `repeat:<id>:<millis>` convention both sides agree on.

How to run:

```
go test ./... -count=1 -timeout 120s
go test -tags=interop ./tests/interop/...
```

5× default + 3× interop sweep all green; existing PR #5–#33 tests untouched. `gofmt` / `goimports` / `go vet` clean.

## Related

- Resolves #34
- Follow-up to #32 / PR #33 (every-mode)
- Closes the cron half of the Phase 4 scheduler tracking checkbox in #1

## Out of Scope (Explicit Deferrals)

- 6-field seconds cron — cron-parser default is 5-field; mkq matches.
- `L` / `W` / `#` extensions — divergence risk; reject up front.
- Schedule listing API (`Queue.GetSchedules`) — orthogonal, both modes.
- Per-instance retry/backoff on scheduled jobs — same scope as #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
