### PR TITLE
feat: Job mutation API (UpdateProgress / UpdateData / Log)

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -23,8 +23,16 @@ var ErrPriorityWithDelay = errors.New("mkq: WithPriority cannot be combined with
 //	return fmt.Errorf("invalid input: %w", mkq.ErrUnrecoverable)
 var ErrUnrecoverable = errors.New("mkq: unrecoverable error (skip retry)")
 
-// ErrJobNotFound is returned by Queue.Get when the HASH at the
-// expected key is missing — the job either never existed, was
+// ErrJobNotFound is returned by Queue.Get and the mutation methods
+// (UpdateProgress / UpdateData / Log) when the BullMQ HASH for the
+// target jobID is missing — the job either never existed, was
 // removed via WithKeepCompleted(0), or expired from a separate
 // retention policy.
 var ErrJobNotFound = errors.New("mkq: job not found")
+
+// ErrJobDetached is returned by Job mutation methods when the Job
+// was constructed without a queue back-pointer (e.g. zero-valued
+// for tests). All Job values produced by the mkq API — Queue.Add,
+// Queue.Get, and the handler-dispatch path — carry the back-pointer
+// automatically.
+var ErrJobDetached = errors.New("mkq: job has no queue back-pointer (constructed outside mkq?)")

--- a/events.go
+++ b/events.go
@@ -115,6 +115,18 @@ type RemovedEvent struct {
 	Prev  string
 }
 
+// ProgressEvent corresponds to BullMQ's `progress` event, emitted by
+// updateProgress-3.lua whenever a worker (or out-of-band caller)
+// reports a progress value via Job.UpdateProgress /
+// Queue.UpdateJobProgress. Data is the JSON-encoded progress value
+// — number, string, object — exactly as the lua wrote it to the
+// stream's `data` field.
+type ProgressEvent struct {
+	id    string
+	JobID string
+	Data  json.RawMessage
+}
+
 // RawEvent wraps any event type mkq doesn't model explicitly. Future
 // BullMQ versions can emit new event names (or mutation features land
 // in #27), and this type keeps Subscribe forward-compatible.
@@ -137,6 +149,7 @@ func (e StalledEvent) ID() string          { return e.id }
 func (e DrainedEvent) ID() string          { return e.id }
 func (e RetriesExhaustedEvent) ID() string { return e.id }
 func (e RemovedEvent) ID() string          { return e.id }
+func (e ProgressEvent) ID() string         { return e.id }
 func (e RawEvent) ID() string              { return e.id }
 
 func (AddedEvent) isQueueEvent()            {}
@@ -149,6 +162,7 @@ func (StalledEvent) isQueueEvent()          {}
 func (DrainedEvent) isQueueEvent()          {}
 func (RetriesExhaustedEvent) isQueueEvent() {}
 func (RemovedEvent) isQueueEvent()          {}
+func (ProgressEvent) isQueueEvent()         {}
 func (RawEvent) isQueueEvent()              {}
 
 // QueueEvents is a long-lived subscriber to a queue's BullMQ events
@@ -296,6 +310,12 @@ func decodeStreamMessage(msg redis.XMessage) Event {
 		return RetriesExhaustedEvent{id: msg.ID, JobID: fields["jobId"], AttemptsMade: atm}
 	case "removed":
 		return RemovedEvent{id: msg.ID, JobID: fields["jobId"], Prev: fields["prev"]}
+	case "progress":
+		return ProgressEvent{
+			id:    msg.ID,
+			JobID: fields["jobId"],
+			Data:  rawJSON(fields["data"]),
+		}
 	default:
 		// 未知 event は forward compat のため RawEvent で wrap。
 		return RawEvent{id: msg.ID, Type: fields["event"], Fields: fields}

--- a/internal/lua/loader.go
+++ b/internal/lua/loader.go
@@ -29,6 +29,9 @@ const (
 	MoveStalledJobsToWait ScriptName = "moveStalledJobsToWait-8"
 	AddJobScheduler       ScriptName = "addJobScheduler-11"
 	UpdateJobScheduler    ScriptName = "updateJobScheduler-12"
+	UpdateProgress        ScriptName = "updateProgress-3"
+	UpdateData            ScriptName = "updateData-1"
+	AddLog                ScriptName = "addLog-2"
 )
 
 // Scripter executes vendored Lua scripts via EVALSHA, with transparent
@@ -67,6 +70,7 @@ func NewScripter(ctx context.Context, client redis.Scripter) (*Scripter, error) 
 		MoveToActive, MoveToFinished, ExtendLock, ReleaseLock,
 		RetryJob, MoveToDelayed, MoveStalledJobsToWait,
 		AddJobScheduler, UpdateJobScheduler,
+		UpdateProgress, UpdateData, AddLog,
 	} {
 		if _, err := s.load(ctx, name); err != nil {
 			return nil, fmt.Errorf("preload %s: %w", name, err)

--- a/internal/lua/preprocess_test.go
+++ b/internal/lua/preprocess_test.go
@@ -22,6 +22,9 @@ func TestPreprocess_VendoredEntryPoints(t *testing.T) {
 		"moveStalledJobsToWait-8",
 		"addJobScheduler-11",
 		"updateJobScheduler-12",
+		"updateProgress-3",
+		"updateData-1",
+		"addLog-2",
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/lua/scripts/UPSTREAM.md
+++ b/internal/lua/scripts/UPSTREAM.md
@@ -33,6 +33,9 @@ Entry points:
 - `moveStalledJobsToWait-8.lua`
 - `addJobScheduler-11.lua`
 - `updateJobScheduler-12.lua`
+- `updateProgress-3.lua`
+- `updateData-1.lua`
+- `addLog-2.lua`
 
 `includes/` — every script transitively reachable from the entry points
 above via `--- @include "..."` directives.

--- a/internal/lua/scripts/addLog-2.lua
+++ b/internal/lua/scripts/addLog-2.lua
@@ -1,0 +1,30 @@
+--[[
+  Add job log
+
+  Input:
+    KEYS[1] job id key
+    KEYS[2] job logs key
+
+    ARGV[1] id
+    ARGV[2] log
+    ARGV[3] keepLogs
+
+  Output:
+    -1 - Missing job.
+]]
+local rcall = redis.call
+
+if rcall("EXISTS", KEYS[1]) == 1 then -- // Make sure job exists
+  local logCount = rcall("RPUSH", KEYS[2], ARGV[2])
+
+  if ARGV[3] ~= '' then
+    local keepLogs = tonumber(ARGV[3])
+    rcall("LTRIM", KEYS[2], -keepLogs, -1)
+
+    return math.min(keepLogs, logCount)
+  end
+
+  return logCount
+else
+  return -1
+end

--- a/internal/lua/scripts/updateData-1.lua
+++ b/internal/lua/scripts/updateData-1.lua
@@ -1,0 +1,20 @@
+--[[
+  Update job data
+
+  Input:
+    KEYS[1] Job id key
+
+    ARGV[1] data
+
+  Output:
+    0 - OK
+   -1 - Missing job.
+]]
+local rcall = redis.call
+
+if rcall("EXISTS",KEYS[1]) == 1 then -- // Make sure job exists
+  rcall("HSET", KEYS[1], "data", ARGV[1])
+  return 0
+else
+  return -1
+end

--- a/internal/lua/scripts/updateProgress-3.lua
+++ b/internal/lua/scripts/updateProgress-3.lua
@@ -1,0 +1,33 @@
+--[[
+  Update job progress
+
+  Input:
+    KEYS[1] Job id key
+    KEYS[2] event stream key
+    KEYS[3] meta key
+
+    ARGV[1] id
+    ARGV[2] progress
+
+  Output:
+     0 - OK
+    -1 - Missing job.
+
+  Event:
+    progress(jobId, progress)
+]]
+local rcall = redis.call
+
+-- Includes
+--- @include "includes/getOrSetMaxEvents"
+
+if rcall("EXISTS", KEYS[1]) == 1 then -- // Make sure job exists
+    local maxEvents = getOrSetMaxEvents(KEYS[3])
+
+    rcall("HSET", KEYS[1], "progress", ARGV[2])
+    rcall("XADD", KEYS[2], "MAXLEN", "~", maxEvents, "*", "event", "progress",
+          "jobId", ARGV[1], "data", ARGV[2]);
+    return 0
+else
+    return -1
+end

--- a/job.go
+++ b/job.go
@@ -5,10 +5,16 @@ import (
 	"time"
 )
 
-// Job represents a job that has been enqueued via Queue.Add. The struct
-// is a snapshot of the wire-level state at the moment of enqueue;
-// progress / returnvalue / state transitions are not reflected here
-// (that surface arrives with the worker API in a follow-up PR).
+// Job represents a job that has been enqueued via Queue.Add or
+// reconstructed by the worker dispatch path. The exported fields are
+// a wire-level snapshot taken at construction time and never refresh
+// in place; for the post-finalisation view of the same job (progress,
+// return value, finished/processed timestamps), call Queue.Get and
+// inspect the JobState companion.
+//
+// Mutations performed via the methods on this type (UpdateProgress,
+// UpdateData, Log) write through to Redis directly via the BullMQ
+// vendored Lua scripts; they do not update the local Job struct.
 type Job[T any] struct {
 	// ID is the BullMQ job id. Numeric for auto-allocated jobs;
 	// arbitrary string when WithJobID is used.

--- a/job.go
+++ b/job.go
@@ -42,6 +42,13 @@ type Job[T any] struct {
 	// ProcessedBy is BullMQ `pb` — the worker name that most recently
 	// dequeued this job (set by prepareJobForProcessing.lua).
 	ProcessedBy string
+
+	// queue is set when the Job is constructed via a Queue path
+	// (Add / Get / handler dispatch), enabling the mutation methods
+	// (UpdateProgress / UpdateData / Log) without forcing callers to
+	// thread the queue separately. Stays nil for synthetic Jobs
+	// constructed by tests; methods then return ErrJobDetached.
+	queue *Queue[T]
 }
 
 // JobState is the post-finalisation read-only snapshot of a job's

--- a/job_mutation.go
+++ b/job_mutation.go
@@ -1,0 +1,149 @@
+package mkq
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/shiroha-a/mkq/internal/lua"
+)
+
+// UpdateProgress reports a progress value for the job. The value is
+// JSON-encoded and stored in the BullMQ `progress` HASH field; a
+// `progress` event is also XADDed so QueueEvents subscribers see the
+// update in real time.
+//
+// Mirrors BullMQ's Job.updateProgress: best-effort, no lock-token
+// validation. A worker that has lost its lock to stalled-recovery
+// can race with the new owner; mkq does not guard against that
+// (BullMQ TS doesn't either — the contract is "use it from your own
+// handler").
+//
+// Returns ErrJobNotFound when the underlying HASH no longer exists
+// (e.g. the job was finalised with WithKeepCompleted(0)) and
+// ErrJobDetached when the Job was constructed outside the mkq API.
+func (j *Job[T]) UpdateProgress(ctx context.Context, progress any) error {
+	if j.queue == nil {
+		return ErrJobDetached
+	}
+	return j.queue.UpdateJobProgress(ctx, j.ID, progress)
+}
+
+// UpdateData replaces the job's `data` HASH field with the JSON
+// encoding of d. Useful for handlers that need to persist
+// intermediate computation across retries — the next attempt will
+// see the new data via buildJob.
+//
+// Same best-effort / lock-token caveats as UpdateProgress.
+func (j *Job[T]) UpdateData(ctx context.Context, d T) error {
+	if j.queue == nil {
+		return ErrJobDetached
+	}
+	return j.queue.UpdateJobData(ctx, j.ID, d)
+}
+
+// Log appends a single log line to the per-job logs LIST
+// (`{prefix}:{queue}:{jobID}:logs`). bull-board surfaces this list
+// in its log tab. mkq does not currently apply the BullMQ `keepLogs`
+// trim — every Log() call grows the list. A WithKeepLogs option can
+// land in a follow-up if retention becomes a concern.
+//
+// Same best-effort / lock-token caveats as UpdateProgress.
+func (j *Job[T]) Log(ctx context.Context, line string) error {
+	if j.queue == nil {
+		return ErrJobDetached
+	}
+	return j.queue.AppendJobLog(ctx, j.ID, line)
+}
+
+// UpdateJobProgress is the out-of-band counterpart to
+// Job.UpdateProgress: callers who hold a Queue handle and a jobID
+// (e.g. an admin reporter goroutine) can update progress without
+// dequeuing the job.
+//
+// progress is JSON-encoded; pass any value the user-defined
+// JobState.Progress json.RawMessage consumer expects (number,
+// string, object).
+func (q *Queue[T]) UpdateJobProgress(ctx context.Context, jobID string, progress any) error {
+	if jobID == "" {
+		return fmt.Errorf("mkq: jobID must be non-empty")
+	}
+	progJSON, err := json.Marshal(progress)
+	if err != nil {
+		return fmt.Errorf("mkq: marshal progress: %w", err)
+	}
+	res, err := q.client.scripts.Run(
+		ctx,
+		lua.UpdateProgress,
+		[]string{q.keys.Job(jobID), q.keys.Events(), q.keys.Meta()},
+		jobID,
+		string(progJSON),
+	)
+	if err != nil {
+		return fmt.Errorf("mkq: updateProgress: %w", err)
+	}
+	return classifyMutationResult(res)
+}
+
+// UpdateJobData is the out-of-band counterpart to Job.UpdateData.
+func (q *Queue[T]) UpdateJobData(ctx context.Context, jobID string, data T) error {
+	if jobID == "" {
+		return fmt.Errorf("mkq: jobID must be non-empty")
+	}
+	dataJSON, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("mkq: marshal data: %w", err)
+	}
+	res, err := q.client.scripts.Run(
+		ctx,
+		lua.UpdateData,
+		[]string{q.keys.Job(jobID)},
+		string(dataJSON),
+	)
+	if err != nil {
+		return fmt.Errorf("mkq: updateData: %w", err)
+	}
+	return classifyMutationResult(res)
+}
+
+// AppendJobLog is the out-of-band counterpart to Job.Log.
+func (q *Queue[T]) AppendJobLog(ctx context.Context, jobID, line string) error {
+	if jobID == "" {
+		return fmt.Errorf("mkq: jobID must be non-empty")
+	}
+	res, err := q.client.scripts.Run(
+		ctx,
+		lua.AddLog,
+		[]string{q.keys.Job(jobID), q.keys.JobLogs(jobID)},
+		jobID,
+		line,
+		"", // keepLogs="" → keep all (BullMQ default when retention not configured)
+	)
+	if err != nil {
+		return fmt.Errorf("mkq: addLog: %w", err)
+	}
+	// addLog returns the resulting list length on success and -1 on
+	// missing-job. Any non-negative integer counts as success.
+	if code, ok := res.(int64); ok && code < 0 {
+		return ErrJobNotFound
+	}
+	return nil
+}
+
+// classifyMutationResult maps the shared 0/-1 return of updateProgress
+// and updateData to nil / ErrJobNotFound. Lua scripts that use a
+// different sentinel (addLog returns the new list length) call sites
+// inline their own check.
+func classifyMutationResult(res any) error {
+	code, ok := res.(int64)
+	if !ok {
+		return nil
+	}
+	if code == -1 {
+		return ErrJobNotFound
+	}
+	if code < 0 {
+		return fmt.Errorf("mkq: mutation lua returned error code %d", code)
+	}
+	return nil
+}

--- a/job_mutation_test.go
+++ b/job_mutation_test.go
@@ -1,0 +1,237 @@
+package mkq_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestJobMutation_UpdateProgress_EmitsEvent verifies the wire round
+// trip: handler writes progress via the Job back-pointer; the BullMQ
+// `progress` HASH field reflects the update and a `progress` event
+// is XADDed to the events stream so a QueueEvents subscriber observes
+// it in real time.
+func TestJobMutation_UpdateProgress_EmitsEvent(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	qe := mkq.NewQueueEvents(queue)
+	t.Cleanup(qe.Close)
+
+	gotProgress := make(chan mkq.Event, 4)
+	subDone := make(chan error, 1)
+	go func() {
+		subDone <- qe.Subscribe(ctx, func(e mkq.Event) error {
+			if _, ok := e.(mkq.ProgressEvent); ok {
+				select {
+				case gotProgress <- e:
+				default:
+				}
+			}
+			return nil
+		})
+	}()
+	// QueueEvents は "$" 起点で購読する。テストの handler が走る前に
+	// 確実に subscribe を確立させるため、軽くスリープ。
+	time.Sleep(50 * time.Millisecond)
+
+	addedJob, err := queue.Add(ctx, testPayload{Inbox: "https://x"})
+	require.NoError(t, err)
+
+	worker, err := mkq.Process(queue, func(ctx context.Context, j *mkq.Job[testPayload]) (any, error) {
+		assert.NoError(t, j.UpdateProgress(ctx, 0.5))
+		return nil, nil
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = worker.Stop(context.Background()) })
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"completed", addedJob.ID).Result()
+		return v > 0
+	})
+
+	progress, err := rdb.HGet(ctx, base+addedJob.ID, "progress").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "0.5", progress, "HASH `progress` field must reflect the update")
+
+	select {
+	case ev := <-gotProgress:
+		pe := ev.(mkq.ProgressEvent)
+		assert.Equal(t, addedJob.ID, pe.JobID)
+		assert.JSONEq(t, "0.5", string(pe.Data))
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not observe progress event within 2s")
+	}
+
+	qe.Close()
+	<-subDone
+}
+
+// TestJobMutation_UpdateData_ReplacesField confirms UpdateData
+// rewrites the BullMQ `data` HASH field with the new JSON. A retry
+// triggered after the handler returns sees the new payload via
+// buildJob.
+func TestJobMutation_UpdateData_ReplacesField(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	addedJob, err := queue.Add(ctx, testPayload{Inbox: "old"})
+	require.NoError(t, err)
+
+	worker, err := mkq.Process(queue, func(ctx context.Context, j *mkq.Job[testPayload]) (any, error) {
+		assert.NoError(t, j.UpdateData(ctx, testPayload{Inbox: "new", Body: "after"}))
+		return nil, nil
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = worker.Stop(context.Background()) })
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"completed", addedJob.ID).Result()
+		return v > 0
+	})
+
+	raw, err := rdb.HGet(ctx, base+addedJob.ID, "data").Result()
+	require.NoError(t, err)
+	var got testPayload
+	require.NoError(t, json.Unmarshal([]byte(raw), &got))
+	assert.Equal(t, "new", got.Inbox)
+	assert.Equal(t, "after", got.Body)
+}
+
+// TestJobMutation_Log_AppendsToList exercises Log append semantics.
+// Two calls produce two LIST entries in submission order; bull-board
+// renders them as the job's log tab.
+func TestJobMutation_Log_AppendsToList(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	addedJob, err := queue.Add(ctx, testPayload{})
+	require.NoError(t, err)
+
+	worker, err := mkq.Process(queue, func(ctx context.Context, j *mkq.Job[testPayload]) (any, error) {
+		assert.NoError(t, j.Log(ctx, "first"))
+		assert.NoError(t, j.Log(ctx, "second"))
+		return nil, nil
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = worker.Stop(context.Background()) })
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"completed", addedJob.ID).Result()
+		return v > 0
+	})
+
+	logs, err := rdb.LRange(ctx, base+addedJob.ID+":logs", 0, -1).Result()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"first", "second"}, logs)
+}
+
+// TestJobMutation_OutOfBand_QueueMethods covers the parallel admin
+// path: callers without a Job handle (e.g. a reporter goroutine
+// holding only the Queue + jobID) can still mutate via
+// Queue.UpdateJobProgress / UpdateJobData / AppendJobLog.
+func TestJobMutation_OutOfBand_QueueMethods(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, testPayload{Inbox: "init"})
+	require.NoError(t, err)
+
+	// Job がまだ wait 状態でも HASH は存在するので、out-of-band 経路で
+	// 全 3 method が成功することを確認。
+	require.NoError(t, queue.UpdateJobProgress(ctx, job.ID, map[string]any{"phase": "x", "pct": 42}))
+	require.NoError(t, queue.UpdateJobData(ctx, job.ID, testPayload{Inbox: "rewritten"}))
+	require.NoError(t, queue.AppendJobLog(ctx, job.ID, "out-of-band note"))
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	progress, err := rdb.HGet(ctx, base+job.ID, "progress").Result()
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"phase":"x","pct":42}`, progress)
+
+	dataRaw, err := rdb.HGet(ctx, base+job.ID, "data").Result()
+	require.NoError(t, err)
+	var data testPayload
+	require.NoError(t, json.Unmarshal([]byte(dataRaw), &data))
+	assert.Equal(t, "rewritten", data.Inbox)
+
+	logs, err := rdb.LRange(ctx, base+job.ID+":logs", 0, -1).Result()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"out-of-band note"}, logs)
+}
+
+// TestJobMutation_MissingJob_ReturnsErrJobNotFound pins the wire
+// contract: when the BullMQ HASH is gone (manually deleted, retention
+// cleared), the lua scripts return -1 and mkq surfaces ErrJobNotFound.
+func TestJobMutation_MissingJob_ReturnsErrJobNotFound(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const missing = "does-not-exist"
+
+	t.Run("UpdateJobProgress", func(t *testing.T) {
+		err := queue.UpdateJobProgress(ctx, missing, 0.1)
+		assert.ErrorIs(t, err, mkq.ErrJobNotFound)
+	})
+	t.Run("UpdateJobData", func(t *testing.T) {
+		err := queue.UpdateJobData(ctx, missing, testPayload{})
+		assert.ErrorIs(t, err, mkq.ErrJobNotFound)
+	})
+	t.Run("AppendJobLog", func(t *testing.T) {
+		err := queue.AppendJobLog(ctx, missing, "x")
+		assert.ErrorIs(t, err, mkq.ErrJobNotFound)
+	})
+}
+
+// TestJobMutation_DetachedJob_ReturnsErrJobDetached pins the safety
+// behavior for synthetic Jobs (e.g. zero-valued in tests, or built
+// outside the mkq API): mutation methods return ErrJobDetached
+// instead of panicking on a nil queue back-pointer.
+func TestJobMutation_DetachedJob_ReturnsErrJobDetached(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var j mkq.Job[testPayload]
+	assert.True(t, errors.Is(j.UpdateProgress(ctx, 1), mkq.ErrJobDetached))
+	assert.True(t, errors.Is(j.UpdateData(ctx, testPayload{}), mkq.ErrJobDetached))
+	assert.True(t, errors.Is(j.Log(ctx, "x"), mkq.ErrJobDetached))
+}

--- a/queue.go
+++ b/queue.go
@@ -113,6 +113,7 @@ func (q *Queue[T]) Add(ctx context.Context, payload T, opts ...AddOption) (*Job[
 		Name:      q.name,
 		Data:      payload,
 		Timestamp: time.UnixMilli(timestampMs),
+		queue:     q,
 	}, nil
 }
 
@@ -229,6 +230,7 @@ func (q *Queue[T]) Get(ctx context.Context, jobID string) (*Job[T], *JobState, e
 	if err != nil {
 		return nil, nil, err
 	}
+	job.queue = q
 	return job, buildJobState(hash), nil
 }
 

--- a/worker.go
+++ b/worker.go
@@ -126,7 +126,7 @@ func Process[T any](q *Queue[T], h Handler[T], opts ...WorkerOption) (*Worker, e
 		stopDone:  make(chan struct{}),
 	}
 
-	shim := newHandlerShim(h)
+	shim := newHandlerShim(q, h)
 	for i := 0; i < cfg.concurrency; i++ {
 		w.run.Add(1)
 		go w.dispatchLoop(shim)
@@ -948,13 +948,17 @@ func invokeHandler(ctx context.Context, handlerAny any, jobID string, jobMap map
 
 // newHandlerShim wraps a typed Handler[T] in the type-erased adapter
 // the Worker invokes. Lives here so worker.go owns the only place that
-// reaches into Job[T] reconstruction.
-func newHandlerShim[T any](h Handler[T]) any {
+// reaches into Job[T] reconstruction. The Queue[T] back-pointer is
+// stitched into every reconstructed Job[T] so handler-side mutation
+// methods (Job.UpdateProgress / Job.UpdateData / Job.Log) work
+// without forcing handlers to capture the queue separately.
+func newHandlerShim[T any](q *Queue[T], h Handler[T]) any {
 	return func(ctx context.Context, jobID string, jobMap map[string]string) (any, error) {
 		job, err := buildJob[T](jobID, jobMap)
 		if err != nil {
 			return nil, fmt.Errorf("mkq: rebuild job %s: %w", jobID, err)
 		}
+		job.queue = q
 		return h(ctx, job)
 	}
 }


### PR DESCRIPTION
## Summary

- Resolves #27. Closes the write-side gap from PR #29's read-side parity work, finishing the BullMQ Job surface for Phase 4.
- New `Job[T]` mutation methods (`UpdateProgress` / `UpdateData` / `Log`) for handler use, plus parallel `Queue[T]` methods (`UpdateJobProgress` / `UpdateJobData` / `AppendJobLog`) for out-of-band callers.
- Vendors `updateProgress-3.lua`, `updateData-1.lua`, `addLog-2.lua` from BullMQ verbatim; matches BullMQ TS's no-token-validation stance.
- New `ProgressEvent` typed event for QueueEvents; existing `RawEvent` subscribers from PR #31 keep working through the type-switch fallback.

## Key Changes

**Wire layer.** Three vendored entry-point scripts (idempotent under `script/sync-lua.sh`) writing the canonical BullMQ HASH fields and stream entries:

- `updateProgress-3` — KEYS=[job, events, meta], ARGV=[id, progress]; HSETs `progress` and XADDs the `progress` event.
- `updateData-1` — KEYS=[job], ARGV=[data]; HSETs `data`.
- `addLog-2` — KEYS=[job, jobLogs], ARGV=[id, log, keepLogs]; RPUSHes onto the per-job logs LIST.

`saveStacktrace-1` is intentionally **not** vendored: mkq's worker already writes the BullMQ-equivalent `stacktrace` HASH field via the failed-state `moveToFinished` call, so vendoring would only support an unused admin-side path.

**Job back-pointer.** `Job[T]` gains an unexported `queue *Queue[T]` field. `Queue.Add`, `Queue.Get`, and the `newHandlerShim` plumbing all stitch the back-pointer into the constructed `Job`, so handler-side mutation methods work without forcing handlers to capture the queue separately. Synthetic Jobs (zero-valued, constructed outside the mkq API) return `ErrJobDetached` instead of panicking on a nil pointer.

**Errors.** New `ErrJobDetached` sentinel; `ErrJobNotFound` reused for the `-1` lua return path (consistent with `Queue.Get`).

**Events.** New `ProgressEvent` type with JSON-decoded `Data` field, threaded into the `decodeStreamMessage` switch.

## Testing

`job_mutation_test.go` (6 integration tests, real Redis 7):

- `UpdateProgress_EmitsEvent` — handler updates progress to 0.5, HASH `progress` field reflects the JSON encoding, and a QueueEvents subscriber observes a typed `ProgressEvent` with matching JobID and JSON-decoded Data.
- `UpdateData_ReplacesField` — handler rewrites `data`; HGET confirms the new JSON.
- `Log_AppendsToList` — handler calls `Log` twice; LRANGE shows both lines in order.
- `OutOfBand_QueueMethods` — all three `Queue[T]` methods succeed against a job in `wait`, with HASH / LIST verification.
- `MissingJob_ReturnsErrJobNotFound` — each method returns `ErrJobNotFound` for a nonexistent jobID.
- `DetachedJob_ReturnsErrJobDetached` — zero-valued `Job[T]` returns `ErrJobDetached` on each mutation method.

How to run:

```
go test ./... -count=1 -timeout 120s
go test -tags=interop ./tests/interop/...
```

5× sequential default suite + 3× sequential interop suite all green; existing PR #5–#35 tests untouched. `gofmt` / `goimports` / `go vet` clean.

## Related

- Resolves #27
- Closes the last open Phase 4 follow-up tracked in #1
- Built on the read-side parity from #28 / PR #29 and the QueueEvents subscriber from #30 / PR #31

## Out of Scope (Explicit Deferrals)

- Token validation — BullMQ TS mutations don't validate either; mkq matches the contract.
- `WithKeepLogs(n)` option — `addLog-2` accepts a per-call `keepLogs` ARGV but mkq passes empty (keep all). Per-job retention can land in a follow-up if needed.
- `moveToWaitingChildren` / parent-child orchestration.
- Dedicated cross-language interop test for mutations — wire format is mkq writing what BullMQ TS already writes, so the existing bull-board / QueueEvents interop scenarios cover the BullMQ-TS-reads-mkq-mutations direction implicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
