### PR TITLE
feat: Inspector API (read-only) — Queues / Counts / ListJobs

### DIFF
--- a/inspector.go
+++ b/inspector.go
@@ -1,0 +1,120 @@
+package mkq
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shiroha-a/mkq/internal/lua"
+)
+
+// JobBucket identifies a state-key bucket the BullMQ wire format uses
+// to partition jobs (waiting / active / etc.). The string values match
+// BullMQ verbatim — they're sent into getCounts-1.lua and
+// getRanges-1.lua as ARGV, where they're concatenated onto the queue
+// prefix to derive the actual Redis key.
+//
+// The deliberate design choice is to use a string type rather than an
+// int enum so foreign callers (admin tooling, log lines) can compare
+// by value without reaching into mkq for a stringer.
+type JobBucket string
+
+// JobBucket constants align with BullMQ's vendored Lua expectations.
+// "wait" / "paused" / "active" are LIST-backed; the rest are ZSET-
+// backed. The lua scripts handle the LIST vs ZSET branch internally,
+// so callers can mix bucket types in a single Counts / ListJobs call.
+const (
+	JobBucketWait        JobBucket = "wait"
+	JobBucketActive      JobBucket = "active"
+	JobBucketDelayed     JobBucket = "delayed"
+	JobBucketPrioritized JobBucket = "prioritized"
+	JobBucketCompleted   JobBucket = "completed"
+	JobBucketFailed      JobBucket = "failed"
+	JobBucketPaused      JobBucket = "paused"
+)
+
+// allBuckets lists every bucket Counts iterates when the caller
+// supplies no explicit set. Matches the order the QueueCounts struct
+// exposes them.
+var allBuckets = []JobBucket{
+	JobBucketWait, JobBucketActive, JobBucketDelayed, JobBucketPrioritized,
+	JobBucketCompleted, JobBucketFailed, JobBucketPaused,
+}
+
+// QueueCounts is the per-state job count snapshot returned by
+// Queue[T].Counts. Fields not requested in the Counts call stay at
+// their zero value.
+type QueueCounts struct {
+	Wait        int64
+	Active      int64
+	Delayed     int64
+	Prioritized int64
+	Completed   int64
+	Failed      int64
+	Paused      int64
+}
+
+// Counts returns the number of jobs currently sitting in each of the
+// requested buckets. Calling Counts with no buckets returns counts
+// for every bucket (matching the BullMQ Queue.getJobCounts() default).
+//
+// The lua collapses the per-bucket LLEN/ZCARD calls into one round
+// trip; pure-Go callers that only need one count are still better
+// off via the dedicated helper rather than repeated single-state
+// Counts calls.
+func (q *Queue[T]) Counts(ctx context.Context, buckets ...JobBucket) (QueueCounts, error) {
+	if len(buckets) == 0 {
+		buckets = allBuckets
+	}
+
+	args := make([]any, 0, len(buckets))
+	for _, b := range buckets {
+		args = append(args, string(b))
+	}
+	res, err := q.client.scripts.Run(
+		ctx,
+		lua.GetCounts,
+		[]string{q.keys.Base()},
+		args...,
+	)
+	if err != nil {
+		return QueueCounts{}, fmt.Errorf("mkq: getCounts: %w", err)
+	}
+	arr, ok := res.([]any)
+	if !ok {
+		return QueueCounts{}, fmt.Errorf("mkq: getCounts: unexpected result type %T", res)
+	}
+	if len(arr) != len(buckets) {
+		return QueueCounts{}, fmt.Errorf("mkq: getCounts: result length %d != buckets %d", len(arr), len(buckets))
+	}
+
+	var out QueueCounts
+	for i, raw := range arr {
+		n, _ := toInt64(raw)
+		assignBucket(&out, buckets[i], n)
+	}
+	return out, nil
+}
+
+// assignBucket dispatches a per-bucket count into the corresponding
+// QueueCounts field. Unknown buckets are dropped silently — they
+// never reach this path because allBuckets / caller-supplied values
+// are validated by the lua's branch matching, but the default case
+// keeps the function safe against future bucket additions.
+func assignBucket(c *QueueCounts, b JobBucket, n int64) {
+	switch b {
+	case JobBucketWait:
+		c.Wait = n
+	case JobBucketActive:
+		c.Active = n
+	case JobBucketDelayed:
+		c.Delayed = n
+	case JobBucketPrioritized:
+		c.Prioritized = n
+	case JobBucketCompleted:
+		c.Completed = n
+	case JobBucketFailed:
+		c.Failed = n
+	case JobBucketPaused:
+		c.Paused = n
+	}
+}

--- a/inspector_list.go
+++ b/inspector_list.go
@@ -1,0 +1,137 @@
+package mkq
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/shiroha-a/mkq/internal/lua"
+)
+
+// ListedJob bundles a typed Job with its post-processing JobState
+// snapshot — the ListJobs caller usually wants both halves in a
+// single round-trip.
+type ListedJob[T any] struct {
+	Job   *Job[T]
+	State *JobState
+}
+
+// ListJobs returns the jobs sitting in `bucket` between [start, end]
+// (inclusive, zero-based) at the moment of the call. The semantics
+// mirror BullMQ's Queue.getJobs: pass `start=0, end=-1` to fetch the
+// whole bucket, `start=0, end=N` for the first N+1 entries, and so
+// on. asynq-style page/pageSize callers can shim with
+// `(start = page*pageSize, end = start+pageSize-1)`.
+//
+// The bucket determines fetch semantics inside the lua:
+//
+//   - LIST-backed buckets (wait, paused, active) honour insertion
+//     order; ascending=false reads in LIST-native order.
+//   - ZSET-backed buckets (delayed, prioritized, completed, failed)
+//     read by score. Ascending applies in the obvious sense.
+//
+// Pass ascending=true to get the oldest-first / lowest-score-first
+// view that admin UIs typically want; ascending=false returns the
+// BullMQ default (newest first / highest score first).
+//
+// Each returned ListedJob carries both the typed Job (with the user
+// payload decoded into T) and the JobState snapshot (terminal-state
+// fields like FinishedOn / ReturnValue). For jobs still in flight
+// JobState is non-nil but its time fields stay zero.
+func (q *Queue[T]) ListJobs(ctx context.Context, bucket JobBucket, start, end int64, ascending bool) ([]ListedJob[T], error) {
+	asc := "0"
+	if ascending {
+		asc = "1"
+	}
+
+	res, err := q.client.scripts.Run(
+		ctx,
+		lua.GetRanges,
+		[]string{q.keys.Base()},
+		fmt.Sprintf("%d", start),
+		fmt.Sprintf("%d", end),
+		asc,
+		string(bucket),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("mkq: getRanges: %w", err)
+	}
+
+	// getRanges returns one entry per requested bucket; we only ever
+	// pass a single bucket, so unwrap the outer wrapper.
+	outer, ok := res.([]any)
+	if !ok {
+		return nil, fmt.Errorf("mkq: getRanges: unexpected result type %T", res)
+	}
+	if len(outer) == 0 {
+		return nil, nil
+	}
+	ids, err := toStringSlice(outer[0])
+	if err != nil {
+		return nil, fmt.Errorf("mkq: getRanges: %w", err)
+	}
+	if len(ids) == 0 {
+		return []ListedJob[T]{}, nil
+	}
+
+	return q.fetchJobs(ctx, ids)
+}
+
+// fetchJobs HGETALLs every id in a pipeline (one round-trip per
+// pipeline batch). Missing HASHes (e.g. job removed between getRanges
+// and HGETALL) are skipped silently — the lua's snapshot is point-in-
+// time and a follow-up reader can race with a delete.
+func (q *Queue[T]) fetchJobs(ctx context.Context, ids []string) ([]ListedJob[T], error) {
+	pipe := q.client.rdb.Pipeline()
+	cmds := make([]*redis.MapStringStringCmd, len(ids))
+	for i, id := range ids {
+		cmds[i] = pipe.HGetAll(ctx, q.keys.Job(id))
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		return nil, fmt.Errorf("mkq: pipeline HGetAll: %w", err)
+	}
+
+	out := make([]ListedJob[T], 0, len(ids))
+	for i, cmd := range cmds {
+		hash, err := cmd.Result()
+		if err != nil {
+			if err == redis.Nil {
+				continue
+			}
+			return nil, fmt.Errorf("mkq: HGetAll %s: %w", ids[i], err)
+		}
+		if len(hash) == 0 {
+			continue
+		}
+		job, err := buildJob[T](ids[i], hash)
+		if err != nil {
+			return nil, fmt.Errorf("mkq: buildJob %s: %w", ids[i], err)
+		}
+		job.queue = q
+		out = append(out, ListedJob[T]{Job: job, State: buildJobState(hash)})
+	}
+	return out, nil
+}
+
+// toStringSlice normalises go-redis's polymorphic Lua-array result
+// (often []any of strings) into []string. Empty / nil inputs return
+// nil so callers can range over the result safely.
+func toStringSlice(v any) ([]string, error) {
+	if v == nil {
+		return nil, nil
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return nil, fmt.Errorf("expected []any, got %T", v)
+	}
+	out := make([]string, 0, len(arr))
+	for i, raw := range arr {
+		s, ok := raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("element %d not a string (%T)", i, raw)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}

--- a/inspector_list.go
+++ b/inspector_list.go
@@ -58,14 +58,15 @@ func (q *Queue[T]) ListJobs(ctx context.Context, bucket JobBucket, start, end in
 		return nil, fmt.Errorf("mkq: getRanges: %w", err)
 	}
 
-	// getRanges returns one entry per requested bucket; we only ever
-	// pass a single bucket, so unwrap the outer wrapper.
+	// getRanges-1.lua は要求された bucket ごとに 1 エントリ返す。
+	// ListJobs は常に 1 bucket しか渡さないので、外側の配列を剥がす。
 	outer, ok := res.([]any)
 	if !ok {
 		return nil, fmt.Errorf("mkq: getRanges: unexpected result type %T", res)
 	}
 	if len(outer) == 0 {
-		return nil, nil
+		// safe-range contract: 空でも nil ではなく empty slice を返す。
+		return []ListedJob[T]{}, nil
 	}
 	ids, err := toStringSlice(outer[0])
 	if err != nil {

--- a/inspector_test.go
+++ b/inspector_test.go
@@ -1,0 +1,188 @@
+package mkq_test
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestInspector_Queues_TracksDefine pins the SADD-on-Define contract:
+// every Queue[T] handle stitched into a Client appears in
+// Client.Queues, idempotent across repeat Define calls.
+func TestInspector_Queues_TracksDefine(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+
+	mkq.Define[testPayload](c, "alpha")
+	mkq.Define[testPayload](c, "beta")
+	mkq.Define[testPayload](c, "gamma")
+	mkq.Define[testPayload](c, "alpha") // duplicate Define must not duplicate registry entry
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	got, err := c.Queues(ctx)
+	require.NoError(t, err)
+	sort.Strings(got)
+	assert.Equal(t, []string{"alpha", "beta", "gamma"}, got)
+}
+
+// TestInspector_Counts_PerState exercises the multi-bucket count path.
+// We seed three jobs into wait, two into delayed (via WithDelay), and
+// run one to completion — the resulting Counts must reflect each
+// bucket independently.
+func TestInspector_Counts_PerState(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// 3 wait jobs.
+	for i := range 3 {
+		_, err := queue.Add(ctx, testPayload{Inbox: strconv.Itoa(i)})
+		require.NoError(t, err)
+	}
+	// 2 delayed jobs (10 minutes out so they don't promote during the test).
+	for range 2 {
+		_, err := queue.Add(ctx, testPayload{Inbox: "later"}, mkq.WithDelay(10*time.Minute))
+		require.NoError(t, err)
+	}
+	// 1 completed job: write directly into the completed ZSET. We
+	// deliberately bypass the worker — running Process in this test
+	// would drain the wait LIST as a side effect, making the
+	// per-bucket assertions racy. Inspector logic only reads ZCARD,
+	// so a synthetic ZADD is wire-equivalent for the count check.
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	require.NoError(t, rdb.ZAdd(ctx, base+"completed", redis.Z{
+		Score:  float64(time.Now().UnixMilli()),
+		Member: "synthetic-completed",
+	}).Err())
+
+	counts, err := queue.Counts(ctx)
+	require.NoError(t, err)
+	assert.EqualValues(t, 3, counts.Wait, "3 plain Add()s should land in wait")
+	assert.EqualValues(t, 2, counts.Delayed, "2 WithDelay Add()s should land in delayed")
+	assert.EqualValues(t, 1, counts.Completed, "1 successfully processed job should land in completed")
+	assert.EqualValues(t, 0, counts.Active, "no in-flight handlers after Stop")
+	assert.EqualValues(t, 0, counts.Failed)
+
+	// Subset call returns only the requested bucket fields.
+	subset, err := queue.Counts(ctx, mkq.JobBucketWait, mkq.JobBucketDelayed)
+	require.NoError(t, err)
+	assert.EqualValues(t, 3, subset.Wait)
+	assert.EqualValues(t, 2, subset.Delayed)
+	assert.EqualValues(t, 0, subset.Completed, "Completed should be zero — not requested")
+}
+
+// TestInspector_ListJobs_Pagination exercises the (start, end) range
+// semantics against a known wait-queue seed. The lua's LIST handling
+// for the wait bucket reads in BullMQ insertion order.
+func TestInspector_ListJobs_Pagination(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// 5 jobs: payload Inbox carries the index so we can verify order.
+	added := make([]string, 5)
+	for i := range 5 {
+		j, err := queue.Add(ctx, testPayload{Inbox: strconv.Itoa(i)})
+		require.NoError(t, err)
+		added[i] = j.ID
+	}
+
+	// Two pages collectively cover the 5 added IDs. Within-page
+	// ordering is bucket-specific (BullMQ's wait LIST is LPUSH-backed
+	// so newest-first is the lua-native shape) — exposing the exact
+	// per-page ordering as a contract would over-specify and trip
+	// future BullMQ tweaks. The contract callers care about is
+	// "every job appears exactly once across the pages."
+	page1, err := queue.ListJobs(ctx, mkq.JobBucketWait, 0, 1, false)
+	require.NoError(t, err)
+	require.Len(t, page1, 2)
+
+	page2, err := queue.ListJobs(ctx, mkq.JobBucketWait, 2, -1, false)
+	require.NoError(t, err)
+	require.Len(t, page2, 3)
+
+	gotIDs := make([]string, 0, 5)
+	for _, j := range page1 {
+		gotIDs = append(gotIDs, j.Job.ID)
+	}
+	for _, j := range page2 {
+		gotIDs = append(gotIDs, j.Job.ID)
+	}
+	sort.Strings(gotIDs)
+	wantIDs := append([]string(nil), added...)
+	sort.Strings(wantIDs)
+	assert.Equal(t, wantIDs, gotIDs, "every added job must appear exactly once across the pages")
+}
+
+// TestInspector_ListJobs_TypedPayload pins the buildJob[T] round-trip:
+// the ListedJob.Job.Data field decodes into the user's T (testPayload),
+// and the JobState companion is populated even for in-flight jobs
+// (timestamp fields stay zero, which is the documented behaviour).
+func TestInspector_ListJobs_TypedPayload(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := queue.Add(ctx, testPayload{Inbox: "https://example.org", Body: "hello"})
+	require.NoError(t, err)
+
+	listed, err := queue.ListJobs(ctx, mkq.JobBucketWait, 0, -1, true)
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+
+	got := listed[0]
+	assert.Equal(t, "https://example.org", got.Job.Data.Inbox)
+	assert.Equal(t, "hello", got.Job.Data.Body)
+	require.NotNil(t, got.State)
+	assert.True(t, got.State.ProcessedOn.IsZero(), "untouched job should have zero ProcessedOn")
+	assert.True(t, got.State.FinishedOn.IsZero(), "untouched job should have zero FinishedOn")
+}
+
+// TestInspector_ListJobs_EmptyState returns an empty slice (not nil)
+// for empty buckets so callers can range over the result without a
+// nil check.
+func TestInspector_ListJobs_EmptyState(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "empty")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	for _, b := range []mkq.JobBucket{
+		mkq.JobBucketWait, mkq.JobBucketActive, mkq.JobBucketDelayed,
+		mkq.JobBucketCompleted, mkq.JobBucketFailed,
+	} {
+		t.Run(string(b), func(t *testing.T) {
+			got, err := queue.ListJobs(ctx, b, 0, -1, true)
+			require.NoError(t, err)
+			assert.NotNil(t, got, "empty bucket must return non-nil slice for safe range")
+			assert.Len(t, got, 0)
+		})
+	}
+}

--- a/internal/lua/loader.go
+++ b/internal/lua/loader.go
@@ -32,6 +32,8 @@ const (
 	UpdateProgress        ScriptName = "updateProgress-3"
 	UpdateData            ScriptName = "updateData-1"
 	AddLog                ScriptName = "addLog-2"
+	GetCounts             ScriptName = "getCounts-1"
+	GetRanges             ScriptName = "getRanges-1"
 )
 
 // Scripter executes vendored Lua scripts via EVALSHA, with transparent
@@ -71,6 +73,7 @@ func NewScripter(ctx context.Context, client redis.Scripter) (*Scripter, error) 
 		RetryJob, MoveToDelayed, MoveStalledJobsToWait,
 		AddJobScheduler, UpdateJobScheduler,
 		UpdateProgress, UpdateData, AddLog,
+		GetCounts, GetRanges,
 	} {
 		if _, err := s.load(ctx, name); err != nil {
 			return nil, fmt.Errorf("preload %s: %w", name, err)

--- a/internal/lua/preprocess_test.go
+++ b/internal/lua/preprocess_test.go
@@ -25,6 +25,8 @@ func TestPreprocess_VendoredEntryPoints(t *testing.T) {
 		"updateProgress-3",
 		"updateData-1",
 		"addLog-2",
+		"getCounts-1",
+		"getRanges-1",
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/lua/scripts/UPSTREAM.md
+++ b/internal/lua/scripts/UPSTREAM.md
@@ -36,6 +36,8 @@ Entry points:
 - `updateProgress-3.lua`
 - `updateData-1.lua`
 - `addLog-2.lua`
+- `getCounts-1.lua`
+- `getRanges-1.lua`
 
 `includes/` — every script transitively reachable from the entry points
 above via `--- @include "..."` directives.

--- a/internal/lua/scripts/getCounts-1.lua
+++ b/internal/lua/scripts/getCounts-1.lua
@@ -1,0 +1,36 @@
+--[[
+  Get counts per provided states
+
+    Input:
+      KEYS[1]    'prefix'
+
+      ARGV[1...] types
+]]
+local rcall = redis.call;
+local prefix = KEYS[1]
+local results = {}
+
+for i = 1, #ARGV do
+  local stateKey = prefix .. ARGV[i]
+  if ARGV[i] == "wait" or ARGV[i] == "paused" then
+    -- Markers in waitlist DEPRECATED in v5: Remove in v6.
+    local marker = rcall("LINDEX", stateKey, -1)
+    if marker and string.sub(marker, 1, 2) == "0:" then
+      local count = rcall("LLEN", stateKey)
+      if count > 1 then
+        rcall("RPOP", stateKey)
+        results[#results+1] = count-1
+      else
+        results[#results+1] = 0
+      end
+    else
+      results[#results+1] = rcall("LLEN", stateKey)
+    end
+  elseif ARGV[i] == "active" then
+    results[#results+1] = rcall("LLEN", stateKey)
+  else
+    results[#results+1] = rcall("ZCARD", stateKey)
+  end
+end
+
+return results

--- a/internal/lua/scripts/getRanges-1.lua
+++ b/internal/lua/scripts/getRanges-1.lua
@@ -1,0 +1,70 @@
+--[[
+  Get job ids per provided states
+
+    Input:
+      KEYS[1]    'prefix'
+
+      ARGV[1]    start
+      ARGV[2]    end
+      ARGV[3]    asc
+      ARGV[4...] types
+]]
+local rcall = redis.call
+local prefix = KEYS[1]
+local rangeStart = tonumber(ARGV[1])
+local rangeEnd = tonumber(ARGV[2])
+local asc = ARGV[3]
+local results = {}
+
+local function getRangeInList(listKey, asc, rangeStart, rangeEnd, results)
+  if asc == "1" then
+    local modifiedRangeStart
+    local modifiedRangeEnd
+    if rangeStart == -1 then
+      modifiedRangeStart = 0
+    else
+      modifiedRangeStart = -(rangeStart + 1)
+    end
+
+    if rangeEnd == -1 then
+      modifiedRangeEnd = 0
+    else
+      modifiedRangeEnd = -(rangeEnd + 1)
+    end
+
+    results[#results+1] = rcall("LRANGE", listKey,
+      modifiedRangeEnd,
+      modifiedRangeStart)
+  else
+    results[#results+1] = rcall("LRANGE", listKey, rangeStart, rangeEnd)
+  end
+end
+
+for i = 4, #ARGV do
+  local stateKey = prefix .. ARGV[i]
+  if ARGV[i] == "wait" or ARGV[i] == "paused" then
+    -- Markers in waitlist DEPRECATED in v5: Remove in v6.
+    local marker = rcall("LINDEX", stateKey, -1)
+    if marker and string.sub(marker, 1, 2) == "0:" then
+      local count = rcall("LLEN", stateKey)
+      if count > 1 then
+        rcall("RPOP", stateKey)
+        getRangeInList(stateKey, asc, rangeStart, rangeEnd, results)
+      else
+        results[#results+1] = {}
+      end
+    else
+      getRangeInList(stateKey, asc, rangeStart, rangeEnd, results)
+    end
+  elseif ARGV[i] == "active" then
+    getRangeInList(stateKey, asc, rangeStart, rangeEnd, results)
+  else
+    if asc == "1" then
+      results[#results+1] = rcall("ZRANGE", stateKey, rangeStart, rangeEnd)
+    else
+      results[#results+1] = rcall("ZREVRANGE", stateKey, rangeStart, rangeEnd)
+    end
+  end
+end
+
+return results

--- a/mkq.go
+++ b/mkq.go
@@ -73,3 +73,32 @@ func (c *Client) Close() error {
 // imported from internal/keys to keep the public surface free of
 // internal-package leaks.
 const defaultKeyPrefix = "bull"
+
+// queueRegistryKey is the auxiliary SET that tracks every queue
+// Define[T] has touched against this Client. The key uses a double
+// colon (empty queue-name slot) so it cannot collide with any
+// BullMQ queue key — BullMQ requires a non-empty queue name, so
+// `{prefix}::queues` is unreachable from the BullMQ wire format.
+//
+// BullMQ itself has no queue registry (bull-board accepts the queue
+// list as configuration); this is an mkq-only addition. Foreign
+// queues that BullMQ TS created without mkq Define'ing them won't
+// appear here — the registry under-reports rather than over-reports.
+func (c *Client) queueRegistryKey() string {
+	return c.keyPrefix + "::queues"
+}
+
+// Queues returns every queue name mkq has Define'd against this
+// client (idempotent registration in Define keeps the SET clean).
+//
+// Foreign queues not Define'd through mkq are absent; for a complete
+// view, mk-go-style admin paths can layer a SCAN-based discovery on
+// top — that's a separate API addition tracked in the inspector
+// follow-up.
+func (c *Client) Queues(ctx context.Context) ([]string, error) {
+	res, err := c.rdb.SMembers(ctx, c.queueRegistryKey()).Result()
+	if err != nil {
+		return nil, fmt.Errorf("mkq: SMembers %s: %w", c.queueRegistryKey(), err)
+	}
+	return res, nil
+}

--- a/queue.go
+++ b/queue.go
@@ -37,7 +37,17 @@ func Define[T any](c *Client, name string, _ ...QueueOption) *Queue[T] {
 		keys:   keys.New(c.keyPrefix, name),
 	}
 	q.stampVersion()
+	q.registerInClient()
 	return q
+}
+
+// registerInClient is the SADD half of the queue-registry contract
+// (Client.Queues consumes the same SET). Best-effort: a Redis hiccup
+// here just means Queues() will under-report on the next call.
+func (q *Queue[T]) registerInClient() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = q.client.rdb.SAdd(ctx, q.client.queueRegistryKey(), q.name).Err()
 }
 
 // stampVersion is best-effort: a Redis hiccup here doesn't break the

--- a/queue.go
+++ b/queue.go
@@ -36,27 +36,27 @@ func Define[T any](c *Client, name string, _ ...QueueOption) *Queue[T] {
 		name:   name,
 		keys:   keys.New(c.keyPrefix, name),
 	}
-	q.stampVersion()
-	q.registerInClient()
+	q.bootstrap()
 	return q
 }
 
-// registerInClient is the SADD half of the queue-registry contract
-// (Client.Queues consumes the same SET). Best-effort: a Redis hiccup
-// here just means Queues() will under-report on the next call.
-func (q *Queue[T]) registerInClient() {
+// bootstrap fires the two best-effort side effects Define needs:
+// stamp meta.version (HSETNX, BullMQ-compatible) and add this queue
+// to the Client.Queues registry SET. Both are pipelined so Define's
+// worst-case latency stays within a single 2s timeout instead of
+// stacking — a single Redis round-trip carries both writes.
+//
+// Errors are intentionally dropped: a Redis hiccup here just means
+// the version stays unstamped (interop test will catch the gap on
+// the next bull-board read) or Queues() under-reports until the
+// next Define for the same name re-runs the SADD.
+func (q *Queue[T]) bootstrap() {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	_ = q.client.rdb.SAdd(ctx, q.client.queueRegistryKey(), q.name).Err()
-}
-
-// stampVersion is best-effort: a Redis hiccup here doesn't break the
-// queue, it just leaves the version field unwritten. The interop test
-// will catch that on the next bull-board read.
-func (q *Queue[T]) stampVersion() {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	_ = q.client.rdb.HSetNX(ctx, q.keys.Meta(), "version", versionTag()).Err()
+	pipe := q.client.rdb.Pipeline()
+	pipe.HSetNX(ctx, q.keys.Meta(), "version", versionTag())
+	pipe.SAdd(ctx, q.client.queueRegistryKey(), q.name)
+	_, _ = pipe.Exec(ctx)
 }
 
 // Name returns the queue name as passed to Define.


### PR DESCRIPTION
## Summary

- Resolves #37. First half of the inspector surface mk-go's port needs to replace \`asynq.Inspector\`. Mutation half (DeleteTask / DeleteAllPendingTasks / RunTask) tracked separately in #38.
- Adds \`Client.Queues\`, \`Queue[T].Counts\`, \`Queue[T].ListJobs\` plus a \`JobBucket\` string enum aligned with BullMQ state names.
- Vendors \`getCounts-1.lua\` and \`getRanges-1.lua\` from BullMQ verbatim.

## Key Changes

**Public API.**

\`\`\`go
func (c *Client) Queues(ctx context.Context) ([]string, error)

type JobBucket string  // wait / active / delayed / prioritized /
                       // completed / failed / paused

type QueueCounts struct {
    Wait, Active, Delayed, Prioritized, Completed, Failed, Paused int64
}
func (q *Queue[T]) Counts(ctx context.Context, buckets ...JobBucket) (QueueCounts, error)
//   Empty buckets = all (matches BullMQ Queue.getJobCounts() default).

type ListedJob[T any] struct {
    Job   *Job[T]
    State *JobState
}
func (q *Queue[T]) ListJobs(ctx context.Context,
                            bucket JobBucket,
                            start, end int64,
                            ascending bool) ([]ListedJob[T], error)
//   (start, end) zero-based inclusive, -1 = "to end" — BullMQ semantics.
//   asynq-style page/pageSize callers shim with
//   (start = page*pageSize, end = start+pageSize-1).
\`\`\`

**Queue registry.** mkq tracks every queue \`Define[T]\` has touched against a Client in an auxiliary SET at \`{prefix}::queues\`. The double colon (empty queue-name slot) cannot collide with any BullMQ queue key — BullMQ requires non-empty queue names — so wire compatibility is preserved (BullMQ never reads the key). \`Client.Queues\` is a SMEMBERS read.

Foreign queues created by BullMQ TS that mkq has never \`Define\`d will not appear here — the registry under-reports rather than over-reports. A SCAN-based discovery API can layer on top in a follow-up if needed; today the documented behaviour matches asynq's \"queues this client knows about\" semantics.

**Wire layer.** Two vendored entry-point scripts:

- \`getCounts-1.lua\` — KEYS=[prefix], ARGV=[bucket...]; returns LLEN/ZCARD per bucket in one round-trip.
- \`getRanges-1.lua\` — KEYS=[prefix], ARGV=[start, end, asc, bucket]; returns the id slice from LRANGE/ZRANGE.

\`ListJobs\` follows the lua call with a pipelined HGETALL per id, then \`buildJob[T]\` for the typed payload + \`buildJobState\` for the post-finalisation snapshot. Missing HASHes (job removed between getRanges and HGETALL) are skipped silently — the lua's snapshot is point-in-time. Each ListedJob carries the \`Queue[T]\` back-pointer (via the same plumbing PR #36 added) so callers can chain mutations.

## Testing

\`inspector_test.go\` (5 integration tests, real Redis 7):

- \`Queues_TracksDefine\` — three Define calls land in the SET, fourth duplicate Define doesn't.
- \`Counts_PerState\` — 3 wait + 2 delayed + 1 synthetic completed seed; full Counts call returns each bucket independently; subset call leaves un-requested buckets at zero. Synthetic ZADD for completed bypasses the worker so the wait LIST stays deterministic.
- \`ListJobs_Pagination\` — 5 wait jobs, two pages cover all 5 IDs exactly once. Within-page ordering is left unspecified (BullMQ bucket-internal LIST/ZSET semantics) — the contract is coverage, not order.
- \`ListJobs_TypedPayload\` — \`ListedJob.Job.Data\` round-trips through \`buildJob[T]\` for testPayload; JobState populated even for untouched jobs (timestamps stay zero).
- \`ListJobs_EmptyState\` — empty bucket returns non-nil empty slice so callers can range without a nil guard.

How to run:

\`\`\`
go test ./... -count=1 -timeout 120s
go test -tags=interop ./tests/interop/...
\`\`\`

5× default + 3× interop sweep all green; existing PR #5–#36 tests untouched. \`gofmt\` / \`goimports\` / \`go vet\` clean.

## Related

- Resolves #37
- Phase 5 prerequisite (mk-go integration), tracked in #1
- Mutation half: #38
- Other Phase 5 prereqs: #39 (\`WithUnique\`), #40 (\`WithJobName\`)

## Out of Scope (Deferred)

- Inspector mutations (RemoveJob / DrainPending / PromoteJob / RetryJob) — see #38.
- \`Client.DiscoverQueues\` SCAN fallback for foreign queues.
- \`Queue[T].Clean(state, opts)\` for state-scoped bulk cleanup.
- \`getJobLogs\` reader for per-job log inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
