### PR TITLE
feat: WithDeduplication / WithUnique AddOption — TTL-bounded job dedup

### DIFF
--- a/add_dedup_test.go
+++ b/add_dedup_test.go
@@ -1,0 +1,140 @@
+package mkq_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestAddDedup_SuppressesWithinTTL pins the BullMQ deduplication
+// contract: a second Add with the same dedup ID inside the TTL
+// window does NOT create a new job. mkq surfaces the suppression
+// via ErrDuplicateJob; the returned Job[T] points at the existing
+// (first) job's ID so callers can still inspect it via Queue.Get.
+func TestAddDedup_SuppressesWithinTTL(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	first, err := queue.Add(ctx, testPayload{Inbox: "first"},
+		mkq.WithDeduplication("dedup-x", 10*time.Second),
+	)
+	require.NoError(t, err)
+
+	second, err := queue.Add(ctx, testPayload{Inbox: "second"},
+		mkq.WithDeduplication("dedup-x", 10*time.Second),
+	)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, mkq.ErrDuplicateJob), "expected ErrDuplicateJob, got %v", err)
+	assert.Equal(t, first.ID, second.ID, "second Add must surface the existing job ID")
+
+	rdb := rawClient(t)
+	count, err := rdb.LLen(ctx, prefix+":deliver:wait").Result()
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, count, "only one job should sit in wait")
+}
+
+// TestAddDedup_AllowsAfterTTL waits past the dedup TTL and verifies
+// a second Add lands as a distinct job. This is the BullMQ analogue
+// of asynq's `Unique(100ms)` allowing repeats once the window expires.
+func TestAddDedup_AllowsAfterTTL(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	first, err := queue.Add(ctx, testPayload{},
+		mkq.WithDeduplication("dedup-y", 100*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	// PX expire is millisecond-resolution; 250ms cushion guards the
+	// CI-flaky window between Redis tick rate and our test pace.
+	time.Sleep(250 * time.Millisecond)
+
+	second, err := queue.Add(ctx, testPayload{},
+		mkq.WithDeduplication("dedup-y", 100*time.Millisecond),
+	)
+	require.NoError(t, err, "second Add after TTL must succeed")
+	assert.NotEqual(t, first.ID, second.ID, "post-TTL Add must allocate a fresh job ID")
+}
+
+// TestAddDedup_DistinctIDsAreSeparate confirms that two different
+// dedup IDs each get their own dedup window without cross-talk.
+func TestAddDedup_DistinctIDsAreSeparate(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	a, err := queue.Add(ctx, testPayload{},
+		mkq.WithDeduplication("a", 10*time.Second),
+	)
+	require.NoError(t, err)
+	b, err := queue.Add(ctx, testPayload{},
+		mkq.WithDeduplication("b", 10*time.Second),
+	)
+	require.NoError(t, err)
+	assert.NotEqual(t, a.ID, b.ID)
+}
+
+// TestAddDedup_RejectsEmptyID enforces the "id must be non-empty"
+// guard documented on WithDeduplication. Passing "" is a programmer
+// error (the option becomes a silent no-op without the guard).
+func TestAddDedup_RejectsEmptyID(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := queue.Add(ctx, testPayload{},
+		mkq.WithDeduplication("", 10*time.Second),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be non-empty")
+}
+
+// TestAddDedup_UniqueAlias confirms the asynq-compat WithUnique alias
+// behaves identically to WithDeduplication. mk-go's adapter shim
+// reaches for the WithUnique name so a regression here would silently
+// break asynq-style call sites in the port.
+func TestAddDedup_UniqueAlias(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	first, err := queue.Add(ctx, testPayload{},
+		mkq.WithUnique("alias-test", 10*time.Second),
+	)
+	require.NoError(t, err)
+
+	_, err = queue.Add(ctx, testPayload{},
+		mkq.WithUnique("alias-test", 10*time.Second),
+	)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, mkq.ErrDuplicateJob))
+	_ = first
+}

--- a/errors.go
+++ b/errors.go
@@ -61,3 +61,17 @@ var ErrJobNotInDelayed = errors.New("mkq: job is not in the delayed state")
 // WithRetryFromState (default: "failed"). BullMQ's reprocessJob-8.lua
 // returns -3 in this case.
 var ErrJobNotInExpectedState = errors.New("mkq: job is not in the expected source state for retry")
+
+// ErrDuplicateJob is returned by Queue.Add (alongside the existing
+// Job[T] handle) when WithDeduplication / WithUnique suppresses the
+// new enqueue because a prior job with the same dedup id is still
+// within its TTL window. Callers can errors.Is-check this sentinel
+// to distinguish "I just enqueued" from "the prior job is still
+// pending"; the returned Job[T] points at the surviving (existing)
+// job so a follow-up Queue.Get works either way.
+//
+// Detection is best-effort: a narrow race between the pre-EVAL
+// dedup-key GET and the EVAL itself can let a true duplicate slip
+// through as a non-error response. The returned job ID is always
+// usable regardless.
+var ErrDuplicateJob = errors.New("mkq: job suppressed by deduplication; existing job returned")

--- a/errors.go
+++ b/errors.go
@@ -62,16 +62,23 @@ var ErrJobNotInDelayed = errors.New("mkq: job is not in the delayed state")
 // returns -3 in this case.
 var ErrJobNotInExpectedState = errors.New("mkq: job is not in the expected source state for retry")
 
-// ErrDuplicateJob is returned by Queue.Add (alongside the existing
-// Job[T] handle) when WithDeduplication / WithUnique suppresses the
-// new enqueue because a prior job with the same dedup id is still
+// ErrDuplicateJob is returned by Queue.Add (alongside a Job[T]
+// handle) when WithDeduplication / WithUnique suppresses the new
+// enqueue because a prior job with the same dedup id is still
 // within its TTL window. Callers can errors.Is-check this sentinel
 // to distinguish "I just enqueued" from "the prior job is still
-// pending"; the returned Job[T] points at the surviving (existing)
-// job so a follow-up Queue.Get works either way.
+// pending."
+//
+// The returned Job[T] is a partial view: only Job.ID is the
+// surviving job's identity (the lua returns the prior job's id
+// here). Job.Data and Job.Timestamp are the *current call's*
+// values — mkq cannot fish the prior payload out of Redis without
+// a second round trip, so callers who need it should follow up with
+// Queue.Get(jobID).
 //
 // Detection is best-effort: a narrow race between the pre-EVAL
 // dedup-key GET and the EVAL itself can let a true duplicate slip
 // through as a non-error response. The returned job ID is always
-// usable regardless.
+// usable regardless (the lua atomically enforces no-duplicate-job
+// regardless of whether mkq surfaces the sentinel).
 var ErrDuplicateJob = errors.New("mkq: job suppressed by deduplication; existing job returned")

--- a/internal/keys/keys.go
+++ b/internal/keys/keys.go
@@ -78,6 +78,14 @@ func (b Builder) Schedule(scheduleID string) string {
 	return b.Base() + "repeat:" + scheduleID
 }
 
+// Dedup returns the per-id deduplication key BullMQ writes when an
+// Add carries `opts.de` (deduplication options). The composition
+// `{prefix}:{queue}:de:<id>` mirrors BullMQ TS's
+// `${queueKeys.de}:${job.deduplicationId}` from scripts.ts addJob.
+func (b Builder) Dedup(id string) string {
+	return b.Base() + "de:" + id
+}
+
 // Job returns the per-job HASH key.
 func (b Builder) Job(jobID string) string { return b.Base() + jobID }
 

--- a/internal/keys/keys_test.go
+++ b/internal/keys/keys_test.go
@@ -28,6 +28,7 @@ func TestBuilder_BullMQLayout(t *testing.T) {
 		{"limiter", New("bull", "deliver").Limiter(), "bull:deliver:limiter"},
 		{"repeat", New("bull", "deliver").Repeat(), "bull:deliver:repeat"},
 		{"schedule", New("bull", "deliver").Schedule("daily"), "bull:deliver:repeat:daily"},
+		{"dedup", New("bull", "deliver").Dedup("user:42"), "bull:deliver:de:user:42"},
 		{"job", New("bull", "deliver").Job("42"), "bull:deliver:42"},
 		{"job-uint", New("bull", "deliver").JobUint(42), "bull:deliver:42"},
 		{"job-logs", New("bull", "deliver").JobLogs("42"), "bull:deliver:42:logs"},

--- a/internal/proto/opts.go
+++ b/internal/proto/opts.go
@@ -10,10 +10,13 @@ import (
 //
 // Field naming mirrors what BullMQ stores in the on-Redis HASH, which is
 // a JSON-ified version of this same map: long keys for non-compressable
-// fields (delay, priority, ...) and short keys ("de", ...) for the
-// fields listed in BullMQ's optsEncodeMap. Since the basic add path
-// touches none of the compressed fields, every key here uses the long
-// form.
+// fields (delay, priority, ...) and short keys for the fields listed in
+// BullMQ's optsEncodeMap. Most fields here use the long form because
+// the lua references them long, but a few (notably "de" for
+// Deduplication) use BullMQ's compressed key — the lua reads
+// `opts['de']` and round-tripping the long name would diverge from the
+// wire format. Add new compressed-key fields with the same explicit
+// note if BullMQ extends the map.
 type AddOpts struct {
 	// Delay is the delay before the job becomes eligible to run, in
 	// unix milliseconds offset.

--- a/internal/proto/opts.go
+++ b/internal/proto/opts.go
@@ -35,6 +35,23 @@ type AddOpts struct {
 	// object — caller responsibility to use (nil) for that case.
 	RemoveOnComplete *RetentionLimit
 	RemoveOnFail     *RetentionLimit
+	// Deduplication enables BullMQ's `opts.de` deduplication path.
+	// nil means "not set" (no dedup); set ID to a non-empty string
+	// to opt in.
+	Deduplication *Deduplication
+}
+
+// Deduplication mirrors the relevant subset of BullMQ's
+// `DeduplicationOpts` shape. mkq's first cut exposes only the
+// always-supported fields (id, ttl); replace / extend / keepLastIfActive
+// can land in follow-ups if mk-go ever needs them.
+type Deduplication struct {
+	// ID is the dedup correlation key. Required.
+	ID string
+	// TTLMillis is the dedup window in milliseconds. 0 = no TTL
+	// (the key sticks until manually removed or job finalisation
+	// clears it via the BullMQ on-finalization include).
+	TTLMillis int64
 }
 
 // RetentionLimit is BullMQ's `removeOnComplete` / `removeOnFail`
@@ -88,6 +105,13 @@ func EncodeAddOpts(o AddOpts) ([]byte, error) {
 	}
 	if v := encodeRetentionLimit(o.RemoveOnFail); v != nil {
 		m["removeOnFail"] = v
+	}
+	if d := o.Deduplication; d != nil && d.ID != "" {
+		de := map[string]any{"id": d.ID}
+		if d.TTLMillis > 0 {
+			de["ttl"] = d.TTLMillis
+		}
+		m["de"] = de
 	}
 	return msgpack.Marshal(m)
 }

--- a/options.go
+++ b/options.go
@@ -23,6 +23,9 @@ type addConfig struct {
 	keepFailed       *int
 	keepCompletedAge *time.Duration
 	keepFailedAge    *time.Duration
+	dedupID          string
+	dedupTTL         time.Duration
+	dedupSet         bool // distinguishes "WithDeduplication never called" from "called with empty id"
 }
 
 // WithJobID forces the job id instead of letting Redis INCR allocate
@@ -100,4 +103,38 @@ func WithKeepCompletedAge(age time.Duration) AddOption {
 // WithKeepCompletedAge.
 func WithKeepFailedAge(age time.Duration) AddOption {
 	return func(c *addConfig) { c.keepFailedAge = &age }
+}
+
+// WithDeduplication opts the Add into BullMQ's deduplication wire
+// path. Within ttl from the previous Add carrying the same id, a
+// repeat Add does NOT create a new job — it returns the prior job's
+// handle alongside ErrDuplicateJob.
+//
+// id must be non-empty; an empty id surfaces as an error from
+// Queue.Add. ttl <= 0 disables auto-expiry of the dedup key (the
+// key sticks until the corresponding job is finalised; matches
+// BullMQ's "no ttl" branch).
+//
+// Wire compatibility: this is BullMQ's `JobsOptions.deduplication`,
+// stored at `{prefix}:{queue}:de:<id>` with PX ttl. mkq's
+// implementation pre-GETs the dedup key before the EVAL to surface
+// ErrDuplicateJob; the detection is best-effort under concurrent
+// writers.
+func WithDeduplication(id string, ttl time.Duration) AddOption {
+	return func(c *addConfig) {
+		c.dedupID = id
+		c.dedupTTL = ttl
+		c.dedupSet = true
+	}
+}
+
+// WithUnique is the asynq-compat alias for WithDeduplication. Lets
+// mk-go's adapter keep the asynq.Unique(ttl) call sites readable
+// while internally translating to BullMQ's wire path.
+//
+// asynq derives the dedup id from `task.Type() + sha256(payload)`;
+// adapters that want strict asynq parity should reproduce that
+// derivation when constructing the id arg.
+func WithUnique(id string, ttl time.Duration) AddOption {
+	return WithDeduplication(id, ttl)
 }

--- a/options.go
+++ b/options.go
@@ -115,6 +115,12 @@ func WithKeepFailedAge(age time.Duration) AddOption {
 // key sticks until the corresponding job is finalised; matches
 // BullMQ's "no ttl" branch).
 //
+// TTL resolution is one millisecond — sub-millisecond values
+// truncate to zero and therefore behave like ttl <= 0 (no auto-
+// expiry, key persists until job finalisation). Callers that
+// expected a microsecond-grained window should round up to the
+// nearest millisecond explicitly.
+//
 // Wire compatibility: this is BullMQ's `JobsOptions.deduplication`,
 // stored at `{prefix}:{queue}:de:<id>` with PX ttl. mkq's
 // implementation pre-GETs the dedup key before the EVAL to surface

--- a/queue.go
+++ b/queue.go
@@ -83,6 +83,9 @@ func (q *Queue[T]) Add(ctx context.Context, payload T, opts ...AddOption) (*Job[
 	if delayMs > 0 && cfg.priority > 0 {
 		return nil, ErrPriorityWithDelay
 	}
+	if cfg.dedupSet && cfg.dedupID == "" {
+		return nil, fmt.Errorf("mkq: WithDeduplication / WithUnique id must be non-empty")
+	}
 
 	dataJSON, err := json.Marshal(payload)
 	if err != nil {
@@ -97,6 +100,14 @@ func (q *Queue[T]) Add(ctx context.Context, payload T, opts ...AddOption) (*Job[
 		Name:      q.name,
 		Timestamp: timestampMs,
 	}
+	// dedup key を AddArgs[9] にも渡しておかないと lua 側の
+	// deduplicateJob が SET 対象のキーを知らない。空文字なら
+	// EncodeAddArgs が nil として詰めるので非 dedup 用途には影響なし。
+	var dedupKey string
+	if cfg.dedupID != "" {
+		dedupKey = q.keys.Dedup(cfg.dedupID)
+		args.DeduplicationKey = dedupKey
+	}
 	argsBytes, err := proto.EncodeAddArgs(args)
 	if err != nil {
 		return nil, fmt.Errorf("mkq: encode args: %w", err)
@@ -105,6 +116,15 @@ func (q *Queue[T]) Add(ctx context.Context, payload T, opts ...AddOption) (*Job[
 	optsBytes, err := proto.EncodeAddOpts(toProtoOpts(cfg, delayMs))
 	if err != nil {
 		return nil, fmt.Errorf("mkq: encode opts: %w", err)
+	}
+
+	// dedup hit を Go 側で検出するため、EVAL 直前の dedup key の値を
+	// 取っておく。lua は hit / miss どちらでも返り値が string jobID
+	// なので、pre-GET の結果と返り値を比較して hit を識別する。
+	// pre-GET と EVAL の間の race は下流ドキュメント通り best-effort。
+	var preDedupID string
+	if dedupKey != "" {
+		preDedupID, _ = q.client.rdb.Get(ctx, dedupKey).Result()
 	}
 
 	scriptName, ks := q.dispatch(delayMs, cfg.priority)
@@ -118,13 +138,20 @@ func (q *Queue[T]) Add(ctx context.Context, payload T, opts ...AddOption) (*Job[
 		return nil, err
 	}
 
-	return &Job[T]{
+	job := &Job[T]{
 		ID:        jobID,
 		Name:      q.name,
 		Data:      payload,
 		Timestamp: time.UnixMilli(timestampMs),
 		queue:     q,
-	}, nil
+	}
+	if preDedupID != "" && preDedupID == jobID {
+		// dedup hit — 既存 job をそのまま返しつつ ErrDuplicateJob で
+		// 通知。Job.Data は呼び出し側 payload なので、本当に既存 job
+		// の payload が欲しい場合は Queue.Get(jobID) で再取得する。
+		return job, ErrDuplicateJob
+	}
+	return job, nil
 }
 
 // dispatch picks the BullMQ Lua entry point and assembles its KEYS list
@@ -197,6 +224,12 @@ func toProtoOpts(cfg addConfig, delayMs int64) proto.AddOpts {
 		o.Backoff = &proto.Backoff{
 			Type:  cfg.backoff.Type,
 			Delay: cfg.backoff.Delay.Milliseconds(),
+		}
+	}
+	if cfg.dedupID != "" {
+		o.Deduplication = &proto.Deduplication{
+			ID:        cfg.dedupID,
+			TTLMillis: cfg.dedupTTL.Milliseconds(),
 		}
 	}
 	return o


### PR DESCRIPTION
## Summary

- Resolves #39. Phase 5 prerequisite: mk-go uses \`asynq.Unique(ttl)\` on 8+ enqueue paths and on every scheduler entry; this PR adds the mkq equivalent so the port doesn't have to fall back to ad-hoc \`WithJobID\` + retention hacks.
- Adds \`WithDeduplication(id, ttl)\` (BullMQ name) and \`WithUnique(id, ttl)\` (asynq alias), \`ErrDuplicateJob\` sentinel, and a \`keys.Builder.Dedup(id)\` helper.
- No new lua: the vendored \`addStandardJob-9\` / \`addDelayedJob-6\` / \`addPrioritizedJob-9\` already integrate \`deduplicateJob\`; this PR is the Go-side plumbing.

## Key Changes

**Public API.**

\`\`\`go
func WithDeduplication(id string, ttl time.Duration) AddOption
//   id required; ttl <= 0 disables auto-expiry of the dedup key
//   (key sticks until job finalisation removes it via the
//   on-finalization include).

func WithUnique(id string, ttl time.Duration) AddOption
//   asynq-aligned alias for WithDeduplication. asynq derives the
//   dedup id from task.Type() + sha256(payload); strict-parity
//   adapters reproduce that derivation.

var ErrDuplicateJob = errors.New(...)
//   Returned ALONGSIDE the existing Job[T] handle when the dedup
//   sentinel hits. Caller can errors.Is-check. The returned
//   Job[T] always points at the surviving job so a follow-up
//   Queue.Get works either way.
\`\`\`

**Wire layer.** \`internal/proto/opts.go\` gains \`Deduplication{ID, TTLMillis}\` encoded as \`opts['de'] = {id, ttl?}\`. \`internal/keys\` gains \`Dedup(id)\` returning \`{prefix}:{queue}:de:<id>\` (mirrors BullMQ TS's \`\${queueKeys.de}:\${job.deduplicationId}\` from \`scripts.ts\` addJob). \`Queue.Add\` stitches the dedup key into \`AddArgs.DeduplicationKey\` (forwarded as \`args[9]\`).

The lua's wire shape returns the same string job-ID either way (hit or miss), so mkq detects the suppression by reading the dedup key BEFORE the EVAL and comparing the returned ID to the pre-EVAL value. A narrow race between the GET and the EVAL can let a true duplicate slip through as a non-error response — documented in the \`ErrDuplicateJob\` godoc as best-effort detection. The returned job ID is always usable regardless.

**Validation.** \`WithDeduplication(\"\", _)\` is a programmer error (\`addConfig\` carries a \`dedupSet\` bool to distinguish \"never called\" from \"called with empty\"). \`Add\` returns the validation error rather than silently disabling.

## Testing

\`add_dedup_test.go\` (5 integration tests, real Redis 7):

- \`SuppressesWithinTTL\` — first Add succeeds; second Add inside TTL returns ErrDuplicateJob with the first job's ID; wait LIST has exactly one entry.
- \`AllowsAfterTTL\` — TTL=100ms, sleep 250ms (Redis tick cushion), second Add allocates a fresh ID.
- \`DistinctIDsAreSeparate\` — independent dedup IDs don't cross-talk.
- \`RejectsEmptyID\` — \`WithDeduplication(\"\", _)\` returns the validation error.
- \`UniqueAlias\` — WithUnique behaves identically; mk-go's adapter depends on this.

How to run:

\`\`\`
go test ./... -count=1 -timeout 120s
go test -tags=interop ./tests/interop/...
\`\`\`

5× default + 3× interop sweep all green; existing PR #5–#42 tests untouched. \`gofmt\` / \`goimports\` / \`go vet\` clean.

## Related

- Resolves #39
- Phase 5 prerequisite (mk-go integration), tracked in #1
- Last remaining Phase 5 prereq: #40 (\`WithJobName\`)

## Out of Scope (Deferred)

- \`replace\` / \`extend\` / \`keepLastIfActive\` deduplication options. The vendored Lua already supports the full set; a follow-up just needs to plumb additional fields through \`proto.Deduplication\`.
- Atomic dedup-key GET + EVAL via a custom mkq lua wrapper. Current pre-GET race is acceptable for mk-go's single-writer-per-dedupID case; revisit if multi-writer dedup becomes a pattern.
- Dedicated cross-language interop test — wire format is mkq writing what BullMQ TS already writes; bull-board scenario implicitly verifies the read direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
