### PR TITLE
feat: WithJobName(string) AddOption — per-task-type fan-out

### DIFF
--- a/add_jobname_test.go
+++ b/add_jobname_test.go
@@ -1,0 +1,113 @@
+package mkq_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestAddJobName_SetsHashField confirms the wire-level effect:
+// the BullMQ HASH `name` field reflects what WithJobName passed,
+// not the queue name. This is the field bull-board renders as the
+// job's display label and the field mk-go's adapter dispatches on.
+func TestAddJobName_SetsHashField(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, testPayload{}, mkq.WithJobName("ap:deliver"))
+	require.NoError(t, err)
+	assert.Equal(t, "ap:deliver", job.Name, "Job.Name reflects the override")
+
+	rdb := rawClient(t)
+	got, err := rdb.HGet(ctx, prefix+":deliver:"+job.ID, "name").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "ap:deliver", got, "BullMQ HASH `name` field must carry the override")
+}
+
+// TestAddJobName_DefaultIsQueueName pins the regression contract:
+// without WithJobName, Job.Name remains the queue name (mkq's
+// pre-#40 behaviour). Skipping this would silently leak the new
+// option's behaviour into the default path.
+func TestAddJobName_DefaultIsQueueName(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, testPayload{})
+	require.NoError(t, err)
+	assert.Equal(t, "deliver", job.Name)
+
+	rdb := rawClient(t)
+	got, err := rdb.HGet(ctx, prefix+":deliver:"+job.ID, "name").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "deliver", got)
+}
+
+// TestAddJobName_HandlerSeesIt confirms the handler-side round trip:
+// buildJob[T] reads the `name` HASH field into Job.Name so the
+// adapter's per-task-type dispatch can read it without a separate
+// Redis hop. This is the contract mk-go's MkqDriver depends on for
+// asynq-style mux registration.
+func TestAddJobName_HandlerSeesIt(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "maintenance")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	added, err := queue.Add(ctx, testPayload{Inbox: "x"}, mkq.WithJobName("system:retention"))
+	require.NoError(t, err)
+
+	var seen atomic.Value
+	worker, err := mkq.Process(queue, func(_ context.Context, j *mkq.Job[testPayload]) (any, error) {
+		seen.Store(j.Name)
+		return nil, nil
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = worker.Stop(context.Background()) })
+
+	rdb := rawClient(t)
+	base := prefix + ":maintenance:"
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"completed", added.ID).Result()
+		return v > 0
+	})
+
+	got, _ := seen.Load().(string)
+	assert.Equal(t, "system:retention", got, "handler must see the per-Add name override")
+}
+
+// TestAddJobName_RejectsEmpty enforces the "name must be non-empty"
+// guard. Passing "" would silently disable the override and fall
+// back to the queue name — surfacing the misuse as an error
+// prevents that surprise.
+func TestAddJobName_RejectsEmpty(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := queue.Add(ctx, testPayload{}, mkq.WithJobName(""))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be non-empty")
+}

--- a/options.go
+++ b/options.go
@@ -14,6 +14,8 @@ type queueConfig struct {
 
 type addConfig struct {
 	jobID            string
+	jobName          string
+	jobNameSet       bool // distinguishes "WithJobName never called" from "called with empty name"
 	delay            time.Duration
 	attempts         int
 	priority         uint32
@@ -33,6 +35,25 @@ type addConfig struct {
 // layer ("if a job with this id already exists, do nothing").
 func WithJobID(id string) AddOption {
 	return func(c *addConfig) { c.jobID = id }
+}
+
+// WithJobName overrides the per-job BullMQ `name` field, which mkq
+// otherwise sets to the queue name. The handler observes the value
+// via Job.Name and bull-board displays it as the job's label.
+//
+// The primary use case is adapter-side per-task-type fan-out: a
+// single mkq Queue can carry multiple logical task types whose
+// dispatch the handler decodes from Job.Name. mk-go's MkqDriver
+// uses this to map asynq-style `mux.HandleFunc(taskType, ...)`
+// registration onto mkq's per-queue Process.
+//
+// An empty name is rejected by Queue.Add (use the option to set a
+// real name, omit it to fall back to the queue-name default).
+func WithJobName(name string) AddOption {
+	return func(c *addConfig) {
+		c.jobName = name
+		c.jobNameSet = true
+	}
 }
 
 // WithDelay schedules the job to first become eligible after d. The

--- a/queue.go
+++ b/queue.go
@@ -86,6 +86,9 @@ func (q *Queue[T]) Add(ctx context.Context, payload T, opts ...AddOption) (*Job[
 	if cfg.dedupSet && cfg.dedupID == "" {
 		return nil, fmt.Errorf("mkq: WithDeduplication / WithUnique id must be non-empty")
 	}
+	if cfg.jobNameSet && cfg.jobName == "" {
+		return nil, fmt.Errorf("mkq: WithJobName name must be non-empty")
+	}
 
 	dataJSON, err := json.Marshal(payload)
 	if err != nil {
@@ -94,10 +97,15 @@ func (q *Queue[T]) Add(ctx context.Context, payload T, opts ...AddOption) (*Job[
 
 	timestampMs := time.Now().UnixMilli()
 
+	jobName := q.name
+	if cfg.jobName != "" {
+		jobName = cfg.jobName
+	}
+
 	args := proto.AddArgs{
 		Prefix:    q.keys.Base(),
 		CustomID:  cfg.jobID,
-		Name:      q.name,
+		Name:      jobName,
 		Timestamp: timestampMs,
 	}
 	// dedup key を AddArgs[9] にも渡しておかないと lua 側の
@@ -140,7 +148,7 @@ func (q *Queue[T]) Add(ctx context.Context, payload T, opts ...AddOption) (*Job[
 
 	job := &Job[T]{
 		ID:        jobID,
-		Name:      q.name,
+		Name:      jobName,
 		Data:      payload,
 		Timestamp: time.UnixMilli(timestampMs),
 		queue:     q,


### PR DESCRIPTION
## Summary

- Resolves #40. Last of the four Phase 5 prerequisites for mk-go's asynq → mkq port. mkq's \`Queue.Add\` previously hard-coded \`Job.Name\` = queue name; this PR exposes per-Add naming so mk-go's adapter can route multiple asynq task types onto a single mkq queue.

## Background

asynq's mux dispatches by task-type string within one queue:

\`\`\`go
mux.HandleFunc("chart:tick", handleChartTick)
mux.HandleFunc("chart:resync", handleChartResync)
// ... 6+ task types in mk-go's "maintenance" queue alone
\`\`\`

mkq is one \`Process[T]\` per queue with one \`Handler[T]\`. Without WithJobName the adapter would have to spread each task type into its own Redis queue (renaming bull-board's view, breaking foreign clients, doubling stalled-checker load). With WithJobName, the adapter wraps a single \`Process[envelope]\` and dispatches internally on \`Job.Name\`:

\`\`\`go
mkq.Process(maintenanceQueue, func(ctx, j *mkq.Job[envelope]) (any, error) {
    return registry[j.Name](ctx, j.Data.Payload)
})
\`\`\`

## Public API

\`\`\`go
func WithJobName(name string) AddOption
//   Overrides Job.Name (default: queue name) for this enqueue.
//   Empty name is rejected by Queue.Add (use the option to set a
//   real name, omit it for the queue-name default).
\`\`\`

\`addConfig\` carries a \`jobNameSet\` bool to distinguish "WithJobName never called" (preserve queue-name default) from "called with empty" (programmer error → Add returns the validation error). Mirrors the \`dedupSet\` pattern from #39.

## Wire layer

\`Job.Name\` is already a BullMQ HASH field (\`name\`); the lua scripts accept it via the msgpack \`args[3]\` slot. No lua changes — \`Queue.Add\` just plumbs the override through \`proto.AddArgs.Name\` and into the returned \`Job[T].Name\`.

## Testing

\`add_jobname_test.go\` (4 integration tests, real Redis 7):

- \`SetsHashField\` — Add with \`WithJobName("ap:deliver")\`; BullMQ HASH \`name\` field reflects the override.
- \`DefaultIsQueueName\` — Add without WithJobName preserves the queue-name default (regression guard).
- \`HandlerSeesIt\` — handler observes \`Job.Name == "system:retention"\` via the \`buildJob[T]\` reconstruction path, confirming the round trip mk-go's adapter dispatch depends on.
- \`RejectsEmpty\` — \`WithJobName("")\` returns the validation error.

How to run:

\`\`\`
go test ./... -count=1 -timeout 120s
go test -tags=interop ./tests/interop/...
\`\`\`

5× default + 3× interop sweep all green; existing PR #5–#43 tests untouched. \`gofmt\` / \`go vet\` clean.

## Phase 5 prereq status

With #37 / #38 / #39 / #40 all merged, every mkq-side gap from the mk-go integration audit is closed. The MkqDriver port can begin in the mk-go repo without waiting on further mkq features.

## Related

- Resolves #40
- Final Phase 5 prerequisite, tracked in #1
- Other prereqs: #37 / #38 (Inspector), #39 (\`WithUnique\`)

## Out of Scope (Deferred)

- Per-schedule Name override on \`UpsertScheduleEvery\` / \`UpsertSchedulePattern\`. Schedules currently fire jobs with \`Job.Name\` = queue name; mk-go's scheduler tasks have a 1:1 type:queue mapping today so this isn't blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
