### PR TITLE
perf: marker-based BZPopMin dispatch + delayed-aware precise sleep

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -168,19 +168,29 @@ func (w *Worker) Stop(ctx context.Context) error {
 }
 
 // dispatchLoop is one slot of the goroutine pool. It repeatedly tries
-// to dequeue a job and process it, sleeping IdlePollInterval between
-// empty pulls (or the rate-limit cooldown if Lua reported one) and
-// exiting when runCtx is cancelled.
+// to dequeue a job and process it; on empty pulls it picks the
+// tightest available wakeup signal:
+//
+//   - rate-limited (Lua returned a cooldown ms): precise sleep
+//   - delayed work scheduled (Lua returned the next-due ms): precise
+//     sleep until that timestamp (BZPopMin's 1s floor would overshoot
+//     sub-second delayed targets like exponential-backoff retries)
+//   - truly idle: BZPopMin on the BullMQ marker key, waking ms after
+//     a new wait/prioritized job lands
+//
+// Exits when runCtx is cancelled.
 func (w *Worker) dispatchLoop(handlerAny any) {
 	defer w.run.Done()
 	for {
 		if w.runCtx.Err() != nil {
 			return
 		}
-		processed, expireTimeMs, err := w.tryOnce(handlerAny)
+		processed, expireTimeMs, nextDelayedTs, err := w.tryOnce(handlerAny)
 		if err != nil {
 			// 取得や lua 失敗はログ的扱い (worker は止めない)。
 			// 本格的なエラー報告チャネルは observability PR で導入。
+			// エラー時は marker を待たずに idle interval だけ眠る:
+			// 連続失敗時に hot-loop しないため。
 			if !w.sleep(w.cfg.idlePollInterval) {
 				return
 			}
@@ -189,14 +199,39 @@ func (w *Worker) dispatchLoop(handlerAny any) {
 		if processed {
 			continue
 		}
-		// Rate-limited path: respect the precise cooldown the Lua
-		// returned via expireTime instead of falling through to the
-		// idle poll interval.
-		wait := w.cfg.idlePollInterval
 		if expireTimeMs > 0 {
-			wait = time.Duration(expireTimeMs) * time.Millisecond
+			// Rate-limited: precise cooldown the Lua reported. Don't
+			// short-circuit on marker — we'd hammer moveToActive with
+			// rate-limit-rejected calls.
+			if !w.sleep(time.Duration(expireTimeMs) * time.Millisecond) {
+				return
+			}
+			continue
 		}
-		if !w.sleep(wait) {
+		if nextDelayedTs > 0 {
+			// 次 delayed job の絶対 ms timestamp が分かるので、precise
+			// sleep でその時刻まで待つ。BZPopMin の 1s floor だと
+			// sub-second delayed (e.g. 50ms exp-backoff retry) で
+			// overshoot する。delay <= 0 はもう due なので即時 retry。
+			delay := time.Until(time.UnixMilli(nextDelayedTs))
+			if delay <= 0 {
+				continue
+			}
+			// idlePollInterval を上限とし、delay が長くても worker が
+			// 完全 unresponsive にならないようにする。BZPopMin で待つ
+			// のと違い、新しい wait-list job 到着では起きないが、
+			// delay > idlePollInterval なら次 iter で marker 待ちに
+			// 切り替わる (= sparse-arrival ケースでも応答性維持)。
+			if delay > w.cfg.idlePollInterval {
+				delay = w.cfg.idlePollInterval
+			}
+			if !w.sleep(delay) {
+				return
+			}
+			continue
+		}
+		// Idle queue: wake on marker push or timeout.
+		if !w.awaitMarker(w.cfg.idlePollInterval) {
 			return
 		}
 	}
@@ -216,6 +251,45 @@ func (w *Worker) sleep(d time.Duration) bool {
 	case <-w.runCtx.Done():
 		return false
 	}
+}
+
+// awaitMarker blocks waiting for a push to the BullMQ marker key
+// (`{prefix}:{queue}:marker`). The vendored add* / promote /
+// moveToFinished Lua scripts add to the marker whenever new work
+// becomes available, so this wakes within ms of a job landing — far
+// tighter than the previous polling-and-sleep approach.
+//
+// Redis BZPOPMIN's protocol-level timeout is second-granularity
+// (Redis 6+ accepts fractional seconds, but go-redis floors anything
+// below 1s with a warning log); we therefore clamp the BZPopMin
+// timeout to at least 1s. Sub-second responsiveness still works in
+// the only case that matters: a real job landing fires a marker
+// push that wakes BZPopMin within ms regardless of the configured
+// ceiling. ctx cancellation is unaffected — go-redis's v9 Cmd.Result
+// returns ctx.Err immediately when the parent context is cancelled,
+// so Worker.Stop's shutdown latency is not bounded by this floor.
+//
+// Any error response (redis.Nil for timeout, context.Canceled for
+// shutdown, transient network glitches) becomes a "wake and retry"
+// signal: tryOnce is idempotent so spurious wakeups are cheap, and a
+// real Redis outage will surface in the next tryOnce call. Returns
+// false when runCtx is cancelled so the dispatcher can exit cleanly.
+//
+// Connection-pool sizing note: each worker slot occupies one Redis
+// connection while blocked here. A WithConcurrency(N) worker plus
+// the queue's own per-call traffic typically wants pool size >= N+8.
+// go-redis defaults to 10*GOMAXPROCS which is comfortable for
+// concurrencies up to a few dozen; very high concurrency callers
+// should bump UniversalOptions.PoolSize.
+func (w *Worker) awaitMarker(timeout time.Duration) bool {
+	if timeout <= 0 {
+		return w.runCtx.Err() == nil
+	}
+	if timeout < time.Second {
+		timeout = time.Second
+	}
+	_ = w.rdb.BZPopMin(w.runCtx, timeout, w.keys.marker).Err()
+	return w.runCtx.Err() == nil
 }
 
 // stalledLoop fires moveStalledJobsToWait at the configured interval.
@@ -262,9 +336,13 @@ func (w *Worker) runStalledCheck() error {
 
 // tryOnce performs one dequeue attempt and, if successful, runs the
 // handler and finalises the job. Returns (processed, expireTimeMs,
-// err): expireTimeMs is the rate-limit cooldown the dispatcher
-// should sleep before its next call (0 = no rate-limit window).
-func (w *Worker) tryOnce(handlerAny any) (bool, int64, error) {
+// nextDelayedTs, err): expireTimeMs is the rate-limit cooldown the
+// dispatcher should sleep before its next call (0 = no rate-limit
+// window); nextDelayedTs is the absolute ms timestamp of the
+// soonest-due delayed job (0 = none queued) so the dispatcher can
+// wake precisely on its target instead of overshooting via the
+// 1-second BZPopMin floor.
+func (w *Worker) tryOnce(handlerAny any) (bool, int64, int64, error) {
 	token := uuid.NewString()
 	now := time.Now().UnixMilli()
 
@@ -281,7 +359,7 @@ func (w *Worker) tryOnce(handlerAny any) (bool, int64, error) {
 	}
 	optsBytes, err := proto.EncodeMoveToActiveOpts(mtaOpts)
 	if err != nil {
-		return false, 0, fmt.Errorf("encode moveToActive opts: %w", err)
+		return false, 0, 0, fmt.Errorf("encode moveToActive opts: %w", err)
 	}
 
 	res, err := w.scripts.Run(
@@ -294,17 +372,17 @@ func (w *Worker) tryOnce(handlerAny any) (bool, int64, error) {
 	)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			return false, 0, nil
+			return false, 0, 0, nil
 		}
-		return false, 0, fmt.Errorf("moveToActive: %w", err)
+		return false, 0, 0, fmt.Errorf("moveToActive: %w", err)
 	}
 
-	jobMap, jobID, ok, expireTimeMs, err := parseMoveToActiveResult(res)
+	jobMap, jobID, ok, expireTimeMs, nextDelayedTs, err := parseMoveToActiveResult(res)
 	if err != nil {
-		return false, 0, fmt.Errorf("parse moveToActive: %w", err)
+		return false, 0, 0, fmt.Errorf("parse moveToActive: %w", err)
 	}
 	if !ok {
-		return false, expireTimeMs, nil
+		return false, expireTimeMs, nextDelayedTs, nil
 	}
 
 	// `defa` (default failed reason) is set by moveStalledJobsToWait
@@ -326,11 +404,11 @@ func (w *Worker) tryOnce(handlerAny any) (bool, int64, error) {
 				w.cfg.lockDuration.Milliseconds(),
 			)
 		}
-		return true, 0, nil
+		return true, 0, 0, nil
 	}
 
 	w.processJob(handlerAny, token, jobID, jobMap)
-	return true, 0, nil
+	return true, 0, 0, nil
 }
 
 // processJob runs the handler for one acquired job, manages the lock
@@ -991,29 +1069,32 @@ func buildJob[T any](jobID string, jobMap map[string]string) (*Job[T], error) {
 //   - {0, 0, 0, 0} when paused / maxed / empty
 //
 // expireTimeMs surfaces the rate-limit cooldown so dispatchLoop can
-// sleep precisely instead of falling through to idlePollInterval.
-func parseMoveToActiveResult(res any) (jobMap map[string]string, jobID string, ok bool, expireTimeMs int64, err error) {
+// sleep precisely. nextDelayedTs surfaces the next delayed job's
+// absolute target ms timestamp so dispatchLoop can sleep until it
+// (BZPopMin's 1s floor would otherwise overshoot sub-1s delays).
+func parseMoveToActiveResult(res any) (jobMap map[string]string, jobID string, ok bool, expireTimeMs int64, nextDelayedTs int64, err error) {
 	arr, isArr := res.([]any)
 	if !isArr || len(arr) < 4 {
-		return nil, "", false, 0, nil
+		return nil, "", false, 0, 0, nil
 	}
 	jobData, isJobData := arr[0].([]any)
 	if !isJobData {
-		// arr[0] が integer (=0) のとき = job 無し。Slot 3 (1-indexed
-		// なら ARGV の解説と同じだが Go では index 2) が rate-limit の
-		// expireTime ms。
+		// arr[0] が integer (=0) のとき = job 無し。Slot 2 (Go index)
+		// は rate-limit の expireTime ms、Slot 3 は次 delayed job の
+		// 絶対時刻 (ms)。dispatchLoop はこれを使って precise sleep する。
 		expireTimeMs, _ = toInt64(arr[2])
-		return nil, "", false, expireTimeMs, nil
+		nextDelayedTs, _ = toInt64(arr[3])
+		return nil, "", false, expireTimeMs, nextDelayedTs, nil
 	}
 	id, idOK := arr[1].(string)
 	if !idOK || id == "" {
-		return nil, "", false, 0, nil
+		return nil, "", false, 0, 0, nil
 	}
 	m, err := flatHashToMap(jobData)
 	if err != nil {
-		return nil, "", false, 0, err
+		return nil, "", false, 0, 0, err
 	}
-	return m, id, true, 0, nil
+	return m, id, true, 0, 0, nil
 }
 
 // toInt64 normalises the integer types go-redis can surface for an

--- a/worker_dispatch_test.go
+++ b/worker_dispatch_test.go
@@ -1,0 +1,58 @@
+package mkq_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestWorker_MarkerDispatch_BeatsIdleInterval proves the
+// marker-based BZPopMin dispatch wakes far faster than a worst-case
+// sleep on WithIdlePollInterval. We register a worker with a
+// deliberately-large 5s idle ceiling; if the dispatcher were still
+// polling, the first job would land near that ceiling. With marker
+// dispatch the wakeup is bounded by the Lua's marker push (~ms),
+// so the handler entry should fire in well under a second.
+func TestWorker_MarkerDispatch_BeatsIdleInterval(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Worker first, then Add. The dispatcher's first BZPopMin call
+	// should be blocked when the Add fires; the marker push wakes it
+	// within ms despite the 5-second timeout ceiling.
+	entered := make(chan time.Time, 1)
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		entered <- time.Now()
+		return nil, nil
+	},
+		mkq.WithIdlePollInterval(5*time.Second),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = worker.Stop(context.Background()) })
+
+	// Give the dispatcher a beat to enter its first BZPopMin call.
+	time.Sleep(100 * time.Millisecond)
+
+	addedAt := time.Now()
+	_, err = queue.Add(ctx, testPayload{Inbox: "fast"})
+	require.NoError(t, err)
+
+	select {
+	case at := <-entered:
+		elapsed := at.Sub(addedAt)
+		assert.Less(t, elapsed, 500*time.Millisecond,
+			"marker dispatch should wake in well under 500ms (idle interval is 5s); got %v", elapsed)
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not run within 2s of Add (marker dispatch broken?)")
+	}
+}

--- a/worker_dispatch_test.go
+++ b/worker_dispatch_test.go
@@ -11,6 +11,55 @@ import (
 	"github.com/shiroha-a/mkq"
 )
 
+// TestWorker_DelayedDispatch_PreciseWakeup proves the dispatchLoop's
+// nextDelayedTs branch interprets the Lua's value as a raw
+// millisecond timestamp (not as BullMQ's packed delayed-ZSET score).
+// The Lua's getNextDelayedTimestamp already divides the packed
+// score by 0x1000 before returning; mkq receives raw ms.
+//
+// Setup: 5s WithIdlePollInterval (would normally cap awaitMarker)
+// + a job with 400ms delay. With correct interpretation, the
+// dispatcher sleeps precisely ~400ms and the handler runs in the
+// 400-600ms window. If the value were instead the packed score
+// (~4096× larger), time.Until would return effectively infinity
+// and the cap would force a 1s+ wakeup, blowing through the
+// upper bound.
+func TestWorker_DelayedDispatch_PreciseWakeup(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	entered := make(chan time.Time, 1)
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		entered <- time.Now()
+		return nil, nil
+	},
+		mkq.WithIdlePollInterval(5*time.Second),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = worker.Stop(context.Background()) })
+
+	const targetDelay = 400 * time.Millisecond
+	addedAt := time.Now()
+	_, err = queue.Add(ctx, testPayload{Inbox: "delayed"}, mkq.WithDelay(targetDelay))
+	require.NoError(t, err)
+
+	select {
+	case at := <-entered:
+		elapsed := at.Sub(addedAt)
+		assert.GreaterOrEqual(t, elapsed, targetDelay-50*time.Millisecond,
+			"handler must not run before the delay (got %v)", elapsed)
+		assert.Less(t, elapsed, 800*time.Millisecond,
+			"handler must run within ~400ms (precise sleep working); got %v. Larger value means nextDelayedTs is being misinterpreted.", elapsed)
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler did not run within 3s of Add (delayed dispatch broken)")
+	}
+}
+
 // TestWorker_MarkerDispatch_BeatsIdleInterval proves the
 // marker-based BZPopMin dispatch wakes far faster than a worst-case
 // sleep on WithIdlePollInterval. We register a worker with a

--- a/worker_options.go
+++ b/worker_options.go
@@ -49,11 +49,25 @@ func WithWorkerName(name string) WorkerOption {
 	return func(c *workerConfig) { c.workerName = name }
 }
 
-// WithIdlePollInterval controls how long the worker sleeps between
-// moveToActive calls when no job is available. A shorter value reduces
-// dequeue latency at the cost of Redis load. The marker-based blocking
-// dequeue (BullMQ's preferred path) is not yet implemented; this knob
-// is the temporary substitute.
+// WithIdlePollInterval bounds how long the worker may block waiting
+// for a marker-key push from the BullMQ Lua side. New jobs wake the
+// dispatcher within ms via BZPopMin on `{prefix}:{queue}:marker`;
+// this knob is the timeout ceiling that fires when nothing has
+// landed (e.g. so a Redis outage doesn't strand a worker indefinitely).
+//
+// Floor: Redis BZPOPMIN takes a second-granularity timeout (Redis 6+
+// supports fractional seconds, but go-redis floors anything below 1s
+// with a warning), so the effective floor is 1s regardless of what
+// you pass here. Sub-second values are harmless — they still drive
+// the dispatch-latency improvement (marker push wakes within ms) but
+// the BZPopMin ceiling stays at 1s. ctx cancellation is unaffected:
+// Worker.Stop returns immediately because go-redis honours ctx on
+// blocking commands.
+//
+// A blocked BZPopMin holds one Redis connection per worker slot, so
+// WithConcurrency(N) callers should ensure their go-redis
+// UniversalOptions.PoolSize is >= N + a few; the default
+// 10*GOMAXPROCS is plenty for concurrencies up to a few dozen.
 func WithIdlePollInterval(d time.Duration) WorkerOption {
 	return func(c *workerConfig) { c.idlePollInterval = d }
 }


### PR DESCRIPTION
## Summary

- Resolves #45. Replaces the worker dispatcher's polling sleep with a BullMQ-marker-aware wakeup so jobs landing on an otherwise-idle queue get picked up within ms instead of within the previous 100ms polling cadence ceiling.
- Honors rate-limit and exponential-backoff retry paths via precise sleep (BZPopMin's 1s protocol-level floor would otherwise overshoot sub-second targets).
- Backlog-drain bench shape is unchanged (polling was never the bottleneck there); the dispatch-latency improvement is proven by a new regression test.

## What changed

\`worker.go\` \`dispatchLoop\` picks the tightest applicable wakeup signal after each empty \`tryOnce\` return:

- **rate-limited** (\`expireTimeMs > 0\`): precise sleep, unchanged.
- **delayed work scheduled** (\`nextDelayedTs > 0\`): precise sleep until that ms timestamp, capped by \`idlePollInterval\`.
- **truly idle**: \`BZPopMin\` against \`{prefix}:{queue}:marker\` with the configured \`idlePollInterval\` as ceiling. Floored to 1s internally because Redis BZPOPMIN takes a second-granularity timeout (Redis 6+ accepts fractional but go-redis floors anything <1s with a warning); ctx cancellation is unaffected because go-redis honors \`ctx.Done\` on blocking commands.

\`parseMoveToActiveResult\` and \`tryOnce\` gain a \`nextDelayedTs\` return (slot 4 of the EVALSHA response) so the dispatcher can sleep precisely on sub-second targets like exponential-backoff retries.

\`awaitMarker\` is a small new helper documenting the BZPopMin call, the 1s floor, the connection-pool sizing implication (\`WithConcurrency(N)\` holds N blocked connections; default \`PoolSize=10*GOMAXPROCS\` is comfortable for tens of slots), and the "any error becomes wake-and-retry" contract.

\`WithIdlePollInterval\` godoc updated to explain marker semantics + 1s floor.

## Testing

\`worker_dispatch_test.go\` adds \`TestWorker_MarkerDispatch_BeatsIdleInterval\`: worker registered with a deliberately-large 5s \`WithIdlePollInterval\`, then a single \`Add\` fires while the dispatcher is in BZPopMin. With polling, dispatch would wait close to 5s; with marker dispatch the handler entry asserts <500ms (real-world wake is single-digit ms). Direct proof of the dispatch-latency improvement.

5× \`go test ./... -count=1 -timeout 120s\` runs all green; interop suite green; existing tests untouched.

## Bench delta

\`bench/run.sh standard\` (10k jobs, concurrency=16) before vs after:

| Metric            | Before  | After   | Delta              |
|-------------------|--------:|--------:|--------------------|
| Producer jobs/sec | 14,193  | 15,505  | +9% (likely noise) |
| Consumer jobs/sec | 10,078  | 10,126  | unchanged          |
| Latency p50       |  853ms  |  839ms  | unchanged          |
| Latency p99       |  991ms  |  993ms  | unchanged          |

The bench's backlog-drain shape never hits the polling path: every \`tryOnce\` returns work, so \`awaitMarker\` is unused. The dispatch-latency improvement only shows when jobs arrive sparsely on an idle queue — the regression test exercises exactly that.

For **consumer throughput** specifically (the BullMQ TS gap that motivated #45), the cap is the per-job \`moveToActive\` + \`moveToFinished\` EVAL latency × Redis single-thread, NOT the dispatch wakeup. Closing that gap requires \`fetchNext=true\` on moveToActive (BullMQ's two-jobs-per-EVALSHA pattern). Separate follow-up.

## Related

- Resolves #45
- Phase 6 perf prep tracked in #1
- Bench harness from PR #46 used to measure delta

## Out of Scope (Deferred)

- Live-mode bench (interleave produce + consume at a controlled rate to surface dispatch-latency win directly).
- moveToActive \`fetchNext=true\` to halve dispatch-side EVALSHAs (would close the consumer-throughput gap visible in the bench).
- \`sync.Pool\` for msgpack/JSON encode buffers (would drop the 6–9 KB per-job alloc visible in latency mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
