### PR TITLE
perf: moveToFinished fetchNext=true to halve dispatch EVALSHAs

### DIFF
--- a/internal/proto/finish_args.go
+++ b/internal/proto/finish_args.go
@@ -28,6 +28,11 @@ type MoveToFinishedOpts struct {
 	// Nil means BullMQ's default retention (keep all).
 	KeepJobs *KeepJobs
 	Name     string
+	// Limiter mirrors the moveToActive limiter shape; required when
+	// fetchNext=1 so the Lua's fetchNextJob branch can read
+	// opts['limiter']['max'] / ['duration'] for the rate-limit
+	// gating that protects throughput. Nil = no limiter.
+	Limiter *MoveToActiveLimiter
 }
 
 // KeepJobs mirrors BullMQ's keepJobs option. Either field can be set;
@@ -79,6 +84,12 @@ func EncodeMoveToFinishedOpts(o MoveToFinishedOpts) ([]byte, error) {
 	}
 	if o.Name != "" {
 		m["name"] = o.Name
+	}
+	if l := o.Limiter; l != nil && l.Max > 0 && l.DurationMs > 0 {
+		m["limiter"] = map[string]any{
+			"max":      l.Max,
+			"duration": l.DurationMs,
+		}
 	}
 	return msgpack.Marshal(m)
 }

--- a/worker.go
+++ b/worker.go
@@ -167,10 +167,29 @@ func (w *Worker) Stop(ctx context.Context) error {
 	}
 }
 
+// prefetchedJob is what moveToFinished's fetchNext branch returns:
+// the next job already locked under the same token the worker just
+// used for the finishing job. The dispatcher consumes it on the next
+// loop iteration in lieu of calling moveToActive — saves one Redis
+// round-trip per processed job in steady state, halving the
+// dispatch-side EVALSHA load that caps consumer throughput.
+//
+// The token is reused across the prefetch handoff because BullMQ's
+// fetchNextJob lua re-locks the new job with the opts.token we
+// passed to moveToFinished; the worker side keeps that token alive
+// via processJob's heartbeat for the new job.
+type prefetchedJob struct {
+	jobMap map[string]string
+	jobID  string
+	token  string
+}
+
 // dispatchLoop is one slot of the goroutine pool. It repeatedly tries
 // to dequeue a job and process it; on empty pulls it picks the
 // tightest available wakeup signal:
 //
+//   - prefetched job already in hand (from previous moveToFinished
+//     fetchNext): consume directly, skip moveToActive
 //   - rate-limited (Lua returned a cooldown ms): precise sleep
 //   - delayed work scheduled (Lua returned the next-due ms): precise
 //     sleep until that timestamp (BZPopMin's 1s floor would overshoot
@@ -181,11 +200,22 @@ func (w *Worker) Stop(ctx context.Context) error {
 // Exits when runCtx is cancelled.
 func (w *Worker) dispatchLoop(handlerAny any) {
 	defer w.run.Done()
+	var prefetched *prefetchedJob
 	for {
 		if w.runCtx.Err() != nil {
 			return
 		}
-		processed, expireTimeMs, nextDelayedTs, err := w.tryOnce(handlerAny)
+		if prefetched != nil {
+			// Consume the prefetched job from the previous moveToFinished
+			// fetchNext. runJob covers both the defa fast-path and the
+			// regular handler path; the returned prefetched fuels the
+			// next iteration if the chain keeps producing.
+			pj := prefetched
+			prefetched = nil
+			prefetched = w.runJob(handlerAny, pj.token, pj.jobID, pj.jobMap)
+			continue
+		}
+		processed, gotPrefetched, expireTimeMs, nextDelayedTs, err := w.tryOnce(handlerAny)
 		if err != nil {
 			// 取得や lua 失敗はログ的扱い (worker は止めない)。
 			// 本格的なエラー報告チャネルは observability PR で導入。
@@ -197,6 +227,7 @@ func (w *Worker) dispatchLoop(handlerAny any) {
 			continue
 		}
 		if processed {
+			prefetched = gotPrefetched
 			continue
 		}
 		if expireTimeMs > 0 {
@@ -335,14 +366,19 @@ func (w *Worker) runStalledCheck() error {
 }
 
 // tryOnce performs one dequeue attempt and, if successful, runs the
-// handler and finalises the job. Returns (processed, expireTimeMs,
-// nextDelayedTs, err): expireTimeMs is the rate-limit cooldown the
-// dispatcher should sleep before its next call (0 = no rate-limit
-// window); nextDelayedTs is the absolute ms timestamp of the
-// soonest-due delayed job (0 = none queued) so the dispatcher can
-// wake precisely on its target instead of overshooting via the
-// 1-second BZPopMin floor.
-func (w *Worker) tryOnce(handlerAny any) (bool, int64, int64, error) {
+// handler and finalises the job. Returns (processed, prefetched,
+// expireTimeMs, nextDelayedTs, err):
+//   - processed   — true if a job was dequeued and handed to runJob
+//   - prefetched  — the job moveToFinished's fetchNext returned for
+//     the dispatcher to consume on the next iteration; nil for retry
+//     paths (retryJob / moveToDelayed don't have fetchNext)
+//   - expireTimeMs — rate-limit cooldown the dispatcher should sleep
+//     before its next call (0 = no rate-limit window)
+//   - nextDelayedTs — absolute ms timestamp of the soonest-due
+//     delayed job (0 = none queued) so the dispatcher can wake
+//     precisely on its target instead of overshooting via BZPopMin's
+//     1-second floor
+func (w *Worker) tryOnce(handlerAny any) (bool, *prefetchedJob, int64, int64, error) {
 	token := uuid.NewString()
 	now := time.Now().UnixMilli()
 
@@ -359,7 +395,7 @@ func (w *Worker) tryOnce(handlerAny any) (bool, int64, int64, error) {
 	}
 	optsBytes, err := proto.EncodeMoveToActiveOpts(mtaOpts)
 	if err != nil {
-		return false, 0, 0, fmt.Errorf("encode moveToActive opts: %w", err)
+		return false, nil, 0, 0, fmt.Errorf("encode moveToActive opts: %w", err)
 	}
 
 	res, err := w.scripts.Run(
@@ -372,29 +408,40 @@ func (w *Worker) tryOnce(handlerAny any) (bool, int64, int64, error) {
 	)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			return false, 0, 0, nil
+			return false, nil, 0, 0, nil
 		}
-		return false, 0, 0, fmt.Errorf("moveToActive: %w", err)
+		return false, nil, 0, 0, fmt.Errorf("moveToActive: %w", err)
 	}
 
 	jobMap, jobID, ok, expireTimeMs, nextDelayedTs, err := parseMoveToActiveResult(res)
 	if err != nil {
-		return false, 0, 0, fmt.Errorf("parse moveToActive: %w", err)
+		return false, nil, 0, 0, fmt.Errorf("parse moveToActive: %w", err)
 	}
 	if !ok {
-		return false, expireTimeMs, nextDelayedTs, nil
+		return false, nil, expireTimeMs, nextDelayedTs, nil
 	}
 
-	// `defa` (default failed reason) is set by moveStalledJobsToWait
-	// when a job has been reclaimed more than maxStalledCount times.
-	// BullMQ's worker contract is to skip the handler and finalise
-	// straight to failed; running the handler again would re-stall
-	// the job in an infinite loop. moveToFinished's failed branch
-	// HDELs the field so a re-acquired but recovered job won't
-	// short-circuit on stale state.
+	prefetched := w.runJob(handlerAny, token, jobID, jobMap)
+	return true, prefetched, 0, 0, nil
+}
+
+// runJob handles one acquired job: defa fast-path or normal handler
+// dispatch. Returns the prefetched job moveToFinished's fetchNext
+// returned (or nil if the path didn't go through moveToFinished, e.g.
+// retry-immediate / retry-delayed).
+//
+// `defa` (default failed reason) is set by moveStalledJobsToWait
+// when a job has been reclaimed more than maxStalledCount times.
+// BullMQ's worker contract is to skip the handler and finalise
+// straight to failed; running the handler again would re-stall the
+// job in an infinite loop. moveToFinished's failed branch HDELs the
+// field so a re-acquired but recovered job won't short-circuit on
+// stale state.
+func (w *Worker) runJob(handlerAny any, token, jobID string, jobMap map[string]string) *prefetchedJob {
 	if defa, hasDefa := jobMap["defa"]; hasDefa && defa != "" {
 		jobOpts := parseJobOpts(jobMap["opts"])
-		if err := w.finishFailed(jobID, token, jobOpts, defa, mustJSONString([]string{defa})); err != nil {
+		prefetched, err := w.finishFailed(jobID, token, jobOpts, defa, mustJSONString([]string{defa}))
+		if err != nil {
 			// Best-effort lock cleanup matches the processJob path.
 			_, _ = w.scripts.Run(
 				context.Background(),
@@ -404,22 +451,25 @@ func (w *Worker) tryOnce(handlerAny any) (bool, int64, int64, error) {
 				w.cfg.lockDuration.Milliseconds(),
 			)
 		}
-		return true, 0, 0, nil
+		return prefetched
 	}
-
-	w.processJob(handlerAny, token, jobID, jobMap)
-	return true, 0, 0, nil
+	return w.processJob(handlerAny, token, jobID, jobMap)
 }
 
 // processJob runs the handler for one acquired job, manages the lock
 // heartbeat, and writes the terminal state via the appropriate
 // BullMQ Lua script (moveToFinished / retryJob / moveToDelayed).
 //
+// Returns the prefetched job from moveToFinished's fetchNext branch
+// (nil if the outcome went through retryJob / moveToDelayed which
+// don't support fetchNext). Caller (dispatchLoop) consumes the
+// prefetched job on its next iteration without a moveToActive RTT.
+//
 // The per-job ctx is derived from runCtx so worker shutdown propagates
 // without a separate bridge goroutine. Heartbeat owns its own goroutine
 // because the BullMQ extendLock semantics require periodic ticks
 // independent of handler progress.
-func (w *Worker) processJob(handlerAny any, token, jobID string, jobMap map[string]string) {
+func (w *Worker) processJob(handlerAny any, token, jobID string, jobMap map[string]string) *prefetchedJob {
 	jobCtx, cancelJob := context.WithCancel(w.runCtx)
 	defer cancelJob()
 
@@ -433,7 +483,8 @@ func (w *Worker) processJob(handlerAny any, token, jobID string, jobMap map[stri
 	cancelJob()
 	<-hbDone
 
-	if err := w.finalise(jobID, token, jobMap, outcome); err != nil {
+	prefetched, err := w.finalise(jobID, token, jobMap, outcome)
+	if err != nil {
 		// Best-effort lock cleanup so a failed terminal call doesn't
 		// strand the lock for the full TTL.
 		_, _ = w.scripts.Run(
@@ -452,6 +503,8 @@ func (w *Worker) processJob(handlerAny any, token, jobID string, jobMap map[stri
 	if rjk := jobMap["rjk"]; rjk != "" {
 		w.rescheduleNext(rjk, jobID)
 	}
+
+	return prefetched
 }
 
 // handlerOutcome captures the result of invoking a handler. Exactly
@@ -670,7 +723,13 @@ func asString(v any) string {
 // re-enqueue) or moveToDelayed (backoff-delayed re-enqueue), bumping
 // the BullMQ HASH `atm` (attempts made) counter atomically inside
 // the script.
-func (w *Worker) finalise(jobID, token string, jobMap map[string]string, out handlerOutcome) error {
+//
+// Returns the prefetched job from moveToFinished's fetchNext branch
+// when the path goes through finishCompleted / finishFailed. Retry
+// paths (retryJob / moveToDelayed) never produce a prefetched job
+// because their Lua scripts don't support fetchNext — those return
+// (nil, err).
+func (w *Worker) finalise(jobID, token string, jobMap map[string]string, out handlerOutcome) (*prefetchedJob, error) {
 	jobOpts := parseJobOpts(jobMap["opts"])
 
 	if out.success {
@@ -690,15 +749,15 @@ func (w *Worker) finalise(jobID, token string, jobMap map[string]string, out han
 
 	delay := computeBackoffDelay(jobOpts.backoff, atm+1)
 	if delay > 0 {
-		return w.retryDelayed(jobID, token, delay, out.errReason, out.stacktrace)
+		return nil, w.retryDelayed(jobID, token, delay, out.errReason, out.stacktrace)
 	}
-	return w.retryImmediate(jobID, token, jobOpts.lifo, out.errReason, out.stacktrace)
+	return nil, w.retryImmediate(jobID, token, jobOpts.lifo, out.errReason, out.stacktrace)
 }
 
 // finishCompleted writes the BullMQ completed-state transition.
 // jobOpts.removeOnComplete is forwarded into MoveToFinishedOpts.KeepJobs
 // so the vendored Lua trims the completed ZSET per BullMQ semantics.
-func (w *Worker) finishCompleted(jobID, token string, opts jobOpts, returnValue string) error {
+func (w *Worker) finishCompleted(jobID, token string, opts jobOpts, returnValue string) (*prefetchedJob, error) {
 	return w.runMoveToFinished(jobID, token, opts.attempts, opts.removeOnComplete,
 		"completed", "returnvalue", returnValue, nil)
 }
@@ -708,7 +767,7 @@ func (w *Worker) finishCompleted(jobID, token string, opts jobOpts, returnValue 
 // vendored Lua only emits `retries-exhausted` when retries are
 // genuinely exhausted; jobOpts.removeOnFail drives failed ZSET
 // retention.
-func (w *Worker) finishFailed(jobID, token string, opts jobOpts, reason, stacktrace string) error {
+func (w *Worker) finishFailed(jobID, token string, opts jobOpts, reason, stacktrace string) (*prefetchedJob, error) {
 	return w.runMoveToFinished(jobID, token, opts.attempts, opts.removeOnFail,
 		"failed", "failedReason", reason,
 		[]any{"stacktrace", stacktrace})
@@ -719,7 +778,17 @@ func (w *Worker) finishFailed(jobID, token string, opts jobOpts, reason, stacktr
 // alongside the state change. keep is the per-target retention
 // (nil = keep all, count==0 = remove immediately, count>0 = keep last
 // n; age trims by seconds since timestamp).
-func (w *Worker) runMoveToFinished(jobID, token string, attempts int, keep *retentionLimit, target, msgProperty, msgValue string, extraFields []any) error {
+//
+// Passes ARGV[6]="1" (BullMQ's fetchNext sentinel) so the Lua's
+// fetchNextJob helper opportunistically dequeues the next wait /
+// prioritized job under the same lock token. When the wait list is
+// non-empty the response is the dequeued job's HGETALL array (same
+// shape moveToActive returns); when empty the response is the
+// regular completion code. Caller consumes the prefetched job on
+// the next dispatchLoop iteration without a moveToActive RTT —
+// halving the dispatch-side EVALSHA load that caps consumer
+// throughput vs BullMQ TS at high concurrency.
+func (w *Worker) runMoveToFinished(jobID, token string, attempts int, keep *retentionLimit, target, msgProperty, msgValue string, extraFields []any) (*prefetchedJob, error) {
 	now := time.Now().UnixMilli()
 
 	optsArgs := proto.MoveToFinishedOpts{
@@ -727,6 +796,16 @@ func (w *Worker) runMoveToFinished(jobID, token string, attempts int, keep *rete
 		LockDuration: w.cfg.lockDuration.Milliseconds(),
 		Attempts:     attempts,
 		Name:         w.cfg.workerName,
+	}
+	// fetchNext=1 の lua 経路 (fetchNextJob) は opts['limiter'] を読んで
+	// rate limit gating する。worker config に limiter があればここで
+	// 引き渡す — 無いと fetchNext が rate limit を bypass してテストが
+	// 通らない (TestWorker_RateLimit_Throttles 等)。
+	if l := w.cfg.limiter; l != nil {
+		optsArgs.Limiter = &proto.MoveToActiveLimiter{
+			Max:        l.max,
+			DurationMs: l.duration.Milliseconds(),
+		}
 	}
 	if keep != nil {
 		kj := &proto.KeepJobs{Count: keep.count}
@@ -737,7 +816,7 @@ func (w *Worker) runMoveToFinished(jobID, token string, attempts int, keep *rete
 	}
 	optsBytes, err := proto.EncodeMoveToFinishedOpts(optsArgs)
 	if err != nil {
-		return fmt.Errorf("encode finish opts: %w", err)
+		return nil, fmt.Errorf("encode finish opts: %w", err)
 	}
 
 	// `finishedOn` を ARGV[9] に積まない: moveToFinished-14.lua が
@@ -746,7 +825,7 @@ func (w *Worker) runMoveToFinished(jobID, token string, attempts int, keep *rete
 	// updateData 設計と揃える。
 	jobFields, err := proto.EncodeJobFields(extraFields...)
 	if err != nil {
-		return fmt.Errorf("encode job fields: %w", err)
+		return nil, fmt.Errorf("encode job fields: %w", err)
 	}
 
 	keys := w.keys.moveToFinishedKeys(jobID, target)
@@ -759,18 +838,34 @@ func (w *Worker) runMoveToFinished(jobID, token string, attempts int, keep *rete
 		msgProperty,
 		msgValue,
 		target,
-		"", // fetchNext=false: empty string is BullMQ's "do not fetch" sentinel
+		"1", // fetchNext=true: opportunistically grab the next job under the same token
 		w.keys.prefix,
 		optsBytes,
 		jobFields,
 	)
 	if err != nil {
-		return fmt.Errorf("moveToFinished(%s): %w", target, err)
+		return nil, fmt.Errorf("moveToFinished(%s): %w", target, err)
 	}
-	if code, ok := res.(int64); ok && code < 0 {
-		return fmt.Errorf("moveToFinished(%s) returned error code %d", target, code)
+	// Polymorphic response: int64 = no fetched job (success / error code);
+	// []any = fetchNext returned the next job's data (or a no-job branch).
+	if code, ok := res.(int64); ok {
+		if code < 0 {
+			return nil, fmt.Errorf("moveToFinished(%s) returned error code %d", target, code)
+		}
+		return nil, nil
 	}
-	return nil
+	jobMap, prefetchedID, gotJob, _, _, perr := parseMoveToActiveResult(res)
+	if perr != nil {
+		return nil, fmt.Errorf("moveToFinished(%s) parse fetchNext: %w", target, perr)
+	}
+	if !gotJob {
+		// fetchNextJob returned a no-job branch (rate-limited / paused /
+		// idle). Treat as plain success — dispatcher's next iteration
+		// will hit moveToActive normally and pick up whichever signal
+		// applies.
+		return nil, nil
+	}
+	return &prefetchedJob{jobMap: jobMap, jobID: prefetchedID, token: token}, nil
 }
 
 // retryImmediate re-enqueues a failed job via retryJob-11.lua. The Lua

--- a/worker.go
+++ b/worker.go
@@ -201,6 +201,14 @@ type prefetchedJob struct {
 func (w *Worker) dispatchLoop(handlerAny any) {
 	defer w.run.Done()
 	var prefetched *prefetchedJob
+	defer func() {
+		// shutdown race: fetchNextFlag may have returned "1" between
+		// our last ctx check and the EVAL, leaving us with a locked
+		// prefetched job we're about to drop. Release the lock so it
+		// doesn't sit in active for the full lockDuration +
+		// stalledInterval until stalled-recovery picks it up.
+		w.releasePrefetchedLock(prefetched)
+	}()
 	for {
 		if w.runCtx.Err() != nil {
 			return
@@ -838,7 +846,7 @@ func (w *Worker) runMoveToFinished(jobID, token string, attempts int, keep *rete
 		msgProperty,
 		msgValue,
 		target,
-		"1", // fetchNext=true: opportunistically grab the next job under the same token
+		w.fetchNextFlag(),
 		w.keys.prefix,
 		optsBytes,
 		jobFields,
@@ -866,6 +874,45 @@ func (w *Worker) runMoveToFinished(jobID, token string, attempts int, keep *rete
 		return nil, nil
 	}
 	return &prefetchedJob{jobMap: jobMap, jobID: prefetchedID, token: token}, nil
+}
+
+// fetchNextFlag returns the BullMQ ARGV[6] sentinel for moveToFinished:
+// "1" enables the fetchNext optimisation, "" disables it. We must
+// disable when runCtx is cancelled, otherwise the lua's fetchNextJob
+// path would lock a fresh job that the worker is about to abandon
+// (dispatchLoop's exit guard wouldn't process it). The locked job
+// would then sit in active for `lockDuration + stalledInterval`
+// before stalled-recovery reclaims it. Mirrors BullMQ TS's
+// `!this.closing` gate at moveToFinished call sites.
+//
+// Race window: ctx can be cancelled between this check and the EVAL
+// reaching Redis, in which case one job slips through and ends up
+// abandoned. dispatchLoop's deferred cleanup releases the lock for
+// any prefetched job the dispatcher holds at exit, narrowing that
+// window to the in-flight EVAL plus a single dispatch hop.
+func (w *Worker) fetchNextFlag() string {
+	if w.runCtx.Err() != nil {
+		return ""
+	}
+	return "1"
+}
+
+// releasePrefetchedLock drops the lock the lua acquired for the
+// prefetched job before the dispatcher exited. Best-effort: if the
+// release fails (Redis hiccup, lock already expired) the lock TTL
+// will eventually clear it via stalled-recovery. The deferred call
+// in dispatchLoop guarantees this runs even on panic.
+func (w *Worker) releasePrefetchedLock(pj *prefetchedJob) {
+	if pj == nil {
+		return
+	}
+	_, _ = w.scripts.Run(
+		context.Background(),
+		lua.ReleaseLock,
+		[]string{w.keys.jobLock(pj.jobID)},
+		pj.token,
+		w.cfg.lockDuration.Milliseconds(),
+	)
 }
 
 // retryImmediate re-enqueues a failed job via retryJob-11.lua. The Lua

--- a/worker_dispatch_test.go
+++ b/worker_dispatch_test.go
@@ -11,6 +11,72 @@ import (
 	"github.com/shiroha-a/mkq"
 )
 
+// TestWorker_Shutdown_ReleasesPrefetchedLock pins the safety guard
+// for the moveToFinished fetchNext path: when the worker shuts down
+// mid-stream, any job the lua locked as a prefetch but the
+// dispatcher never consumed must be unlocked at exit. Without the
+// guard, locked-but-abandoned jobs sit in active for
+// `lockDuration + stalledInterval` before stalled-recovery reclaims
+// them — multiplied by WithConcurrency(N) on every Stop call.
+//
+// Setup: pre-enqueue many jobs, start a worker with a short
+// blocking handler, trigger Stop while the handler is in flight.
+// After Stop returns, no job should still hold a non-expired lock.
+func TestWorker_Shutdown_ReleasesPrefetchedLock(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const seed = 50
+	for range seed {
+		_, err := queue.Add(ctx, testPayload{})
+		require.NoError(t, err)
+	}
+
+	handlerEntered := make(chan struct{}, 1)
+	releaseHandler := make(chan struct{})
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		select {
+		case handlerEntered <- struct{}{}:
+		default:
+		}
+		<-releaseHandler
+		return nil, nil
+	},
+		mkq.WithConcurrency(4),
+		mkq.WithIdlePollInterval(20*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	<-handlerEntered
+
+	// Release in-flight handlers so processJob can finish; then Stop
+	// with a tight deadline so the dispatchLoop exit path runs while
+	// fetchNext-prefetched jobs may still be in flight.
+	close(releaseHandler)
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer stopCancel()
+	require.NoError(t, worker.Stop(stopCtx))
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+
+	// Inspect any job that ended up in active. Each must NOT have a
+	// live lock (i.e. the dispatcher's deferred cleanup released it).
+	activeIDs, err := rdb.LRange(ctx, base+"active", 0, -1).Result()
+	require.NoError(t, err)
+	for _, id := range activeIDs {
+		exists, err := rdb.Exists(ctx, base+id+":lock").Result()
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, exists,
+			"job %s remained locked after shutdown — fetchNext-prefetched abandon", id)
+	}
+}
+
 // TestWorker_DelayedDispatch_PreciseWakeup proves the dispatchLoop's
 // nextDelayedTs branch interprets the Lua's value as a raw
 // millisecond timestamp (not as BullMQ's packed delayed-ZSET score).


### PR DESCRIPTION
## Summary

- Resolves #48. Closes the consumer-throughput gap that PR #47's marker-based dispatch couldn't address (the cap was per-job EVALSHA throughput, not dispatch wakeup).
- BullMQ's \`moveToFinished\` Lua already supported a \`fetchNext\` arg that opportunistically dequeues the next job under the same lock token; mkq passed empty string for "do not fetch". Now passes \`"1"\` and consumes the prefetched job on the dispatcher's next iteration without a moveToActive RTT.
- 10k-job bench: consumer throughput catches up (mkq 14,287 vs BullMQ 14,596 — essentially tied); latency p50 reverses (mkq now 12% faster); latency p99 widens lead (mkq 48% tighter).
- 100k-job bench: consumer gap narrows from BullMQ-1.55× to BullMQ-1.19× (residual is client-library overhead + GC pressure, deferred to a sync.Pool follow-up).

## Wire layer

\`moveToFinished-14.lua\` ARGV[6] is the fetchNext flag; the lua's \`fetchNextJob\` include returns either the next job's HGETALL array (success / rate-limited / paused / delayed branches) or nothing (regular completion path). \`runMoveToFinished\` detects the polymorphic shape via type-switch, parses the array via the existing \`parseMoveToActiveResult\`, and threads the prefetched job back through \`processJob\` → \`tryOnce\` → \`dispatchLoop\`.

## Limiter plumbing fix (caught by existing test)

fetchNext's Lua reads \`opts['limiter']['max']\` to gate the prefetch. mkq's \`MoveToFinishedOpts\` was missing the Limiter field — fetchNext bypassed rate limits entirely, breaking \`TestWorker_RateLimit_Throttles\`. Added \`Limiter\` to the proto struct and wired it through \`runMoveToFinished\`. Now fetchNext respects \`WithRateLimit\` identically to moveToActive.

## Worker plumbing

- New \`prefetchedJob{jobMap, jobID, token}\` struct.
- \`runMoveToFinished\` now returns \`(*prefetchedJob, error)\`; same for \`finishCompleted\`, \`finishFailed\`, \`finalise\`, \`processJob\`.
- \`tryOnce\`'s defa fast-path and normal handler path consolidated into a new \`runJob\` helper used by both tryOnce and the dispatcher's prefetched-consumption branch.
- \`dispatchLoop\` holds a local \`prefetched *prefetchedJob\`; consumes it at the top of each iteration (skipping moveToActive entirely) and updates with whatever runJob's chain produces next.

Retry paths (\`retryImmediate\` / \`retryDelayed\`) don't have fetchNext support in their Lua; they return \`(nil, err)\` and the dispatcher falls back to moveToActive.

## Bench delta

\`bench/run.sh standard\` (10k jobs, concurrency=16):

| Metric            | Before  | After   | vs BullMQ           |
|-------------------|--------:|--------:|---------------------|
| Producer jobs/sec | 14,193  | 14,564  | mkq 1.46× (BullMQ 9,981) |
| Consumer jobs/sec | 10,078  | 14,287  | tied (BullMQ 14,596) |
| Latency p50       |  853ms  |  691ms  | mkq 1.12× (BullMQ 775)   |
| Latency p99       |  991ms  |  706ms  | mkq 1.48× tighter        |

\`bench/run.sh 100000\` (100k jobs, concurrency=16):

| Metric            | Before  | After   | vs BullMQ           |
|-------------------|--------:|--------:|---------------------|
| Producer jobs/sec | 14,734  | 14,072  | mkq 1.26× (BullMQ 11,172) |
| Consumer jobs/sec | 10,085  | 14,150  | BullMQ 1.19× (was 1.55×) |
| Latency p50       |  8,454  |  6,999  | mkq 1.08× (BullMQ 7,563) |
| Latency p99       |  9,878  |  7,062  | mkq 1.31× tighter        |

## Testing

5× sequential \`go test ./... -count=1 -timeout 120s\` runs all green; interop suite green; existing tests untouched. The dispatch-path tests collectively exercise the prefetched-job consumption path — every successful or terminal-failed job now goes through fetchNext.

## Related

- Resolves #48
- Builds on #45 / PR #47 (marker-based BZPopMin dispatch)
- Phase 6 perf prep tracked in #1

## Out of Scope (Deferred)

- \`sync.Pool\` for msgpack/JSON encode buffers (would close the residual 1.19× consumer-throughput gap at 100k by reducing GC pressure).
- Live-mode bench (interleave produce + consume to surface marker-dispatch wakeup latency directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
