### PR TITLE
test(interop): close BullMQ TS compat coverage gaps from #1 audit

### DIFF
--- a/tests/interop/dedup_test.go
+++ b/tests/interop/dedup_test.go
@@ -1,0 +1,73 @@
+//go:build interop
+
+// Cross-language deduplication: a second Queue.add carrying the same
+// dedup id within the TTL window must NOT create a new job. mkq and
+// BullMQ TS share the dedup key shape (`{prefix}:{queue}:de:<id>`)
+// and the lua's deduplicateJob include enforces the wire-level
+// invariant — this test pins both directions stay honest.
+
+package interop_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestInterop_Dedup_MkqThenBullMQ: mkq Adds with a dedup id, then
+// BullMQ TS Adds the same dedup id within ttl. BullMQ TS's
+// deduplicateJob lua returns the existing job id rather than
+// creating a new one — visible as the second add reporting the
+// first add's job id.
+func TestInterop_Dedup_MkqThenBullMQ(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "dd"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	first, err := queue.Add(ctx, interopPayload{Inbox: "first"},
+		mkq.WithDeduplication("xlang", 10*time.Second),
+	)
+	require.NoError(t, err)
+
+	// BullMQ TS Adds with the same dedup id; deduplicateJob lua
+	// short-circuits and returns the existing job id.
+	bullmqID := runNodeEnqueuerOpts(t, prefix, queueName, `{"inbox":"second"}`,
+		nodeEnqueuerOpts{
+			OptsJSON: `{"deduplication":{"id":"xlang","ttl":10000}}`,
+		})
+	assert.Equal(t, first.ID, bullmqID, "second BullMQ Add must surface the existing job id")
+}
+
+// TestInterop_Dedup_BullMQThenMkq: inverse direction — BullMQ TS
+// Adds first; mkq Add with the same id observes the existing id and
+// returns ErrDuplicateJob.
+func TestInterop_Dedup_BullMQThenMkq(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "dd"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	bullmqID := runNodeEnqueuerOpts(t, prefix, queueName, `{"inbox":"first"}`,
+		nodeEnqueuerOpts{
+			OptsJSON: `{"deduplication":{"id":"xlang2","ttl":10000}}`,
+		})
+
+	second, err := queue.Add(ctx, interopPayload{Inbox: "second"},
+		mkq.WithDeduplication("xlang2", 10*time.Second),
+	)
+	require.Error(t, err, "mkq must return ErrDuplicateJob when foreign-added job exists in dedup window")
+	assert.ErrorIs(t, err, mkq.ErrDuplicateJob)
+	assert.Equal(t, bullmqID, second.ID, "returned Job.ID must point at the existing BullMQ-side job")
+}

--- a/tests/interop/dedup_test.go
+++ b/tests/interop/dedup_test.go
@@ -67,7 +67,11 @@ func TestInterop_Dedup_BullMQThenMkq(t *testing.T) {
 	second, err := queue.Add(ctx, interopPayload{Inbox: "second"},
 		mkq.WithDeduplication("xlang2", 10*time.Second),
 	)
-	require.Error(t, err, "mkq must return ErrDuplicateJob when foreign-added job exists in dedup window")
-	assert.ErrorIs(t, err, mkq.ErrDuplicateJob)
+	// require.ErrorIs both stops on a non-dedup error AND validates
+	// the sentinel. `require.Error + assert.ErrorIs + second.ID`
+	// would panic with a nil deref if a real error (Redis hiccup,
+	// Lua failure) slipped through unnoticed.
+	require.ErrorIs(t, err, mkq.ErrDuplicateJob, "mkq must return ErrDuplicateJob when foreign-added job exists in dedup window")
+	require.NotNil(t, second, "ErrDuplicateJob path must still return the existing Job[T] handle")
 	assert.Equal(t, bullmqID, second.ID, "returned Job.ID must point at the existing BullMQ-side job")
 }

--- a/tests/interop/events_extra_test.go
+++ b/tests/interop/events_extra_test.go
@@ -64,11 +64,16 @@ func TestInterop_Events_BullMQReadsMkqEmissions(t *testing.T) {
 	// Path 3: removing a wait/delayed job triggers the `removed` event.
 	require.NoError(t, queue.RemoveJob(ctx, delayedJob.ID))
 
+	// Every Path 1/2/3 trigger maps to an event we explicitly assert.
+	// Without this list the delayed-add and remove setup steps would
+	// be unverified work — Devin's PR #52 round-1 review caught that.
 	required := map[string]bool{
 		"added":     false,
 		"waiting":   false,
 		"active":    false,
 		"completed": false,
+		"delayed":   false,
+		"removed":   false,
 	}
 	deadline := time.After(8 * time.Second)
 	allSeen := func() bool {

--- a/tests/interop/events_extra_test.go
+++ b/tests/interop/events_extra_test.go
@@ -1,0 +1,100 @@
+//go:build interop
+
+// Event-stream coverage beyond completed/failed (which are pinned by
+// queue_events_test.go in PR #31). Two scenarios:
+//
+//   1. mkq emits a variety of events (delayed, removed, progress);
+//      a BullMQ TS QueueEvents listener subscribes and asserts each
+//      event arrives. Direction: mkq→BullMQ (the inverse of PR #31).
+//
+//   2. mkq enqueues + processes; mkq's own QueueEvents subscriber
+//      observes the variety. Direction: in-process, but exercises
+//      the same wire format the listener does.
+//
+// The cross-language "BullMQ reads mkq" path is the one that wasn't
+// covered before.
+
+package interop_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestInterop_Events_BullMQReadsMkqEmissions confirms a BullMQ TS
+// QueueEvents listener observes the wire-format events mkq's
+// vendored Lua emits when an mkq client adds + processes jobs. Pins
+// the "inverse direction" half of the events stream interop matrix.
+func TestInterop_Events_BullMQReadsMkqEmissions(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "evx"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Subscribe BEFORE any enqueue so the BullMQ listener catches
+	// added/waiting/active/completed for the upcoming run.
+	events := startEventsListener(t, prefix, queueName,
+		"added", "waiting", "active", "completed", "delayed", "removed")
+	// Tiny pause so the listener's XREAD position settles.
+	time.Sleep(100 * time.Millisecond)
+
+	// Path 1: a happy-path job exercises added → waiting → active → completed.
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[interopPayload]) (any, error) {
+		return nil, nil
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = worker.Stop(context.Background()) })
+
+	immediateJob, err := queue.Add(ctx, interopPayload{Inbox: "happy"})
+	require.NoError(t, err)
+
+	// Path 2: a delayed job exercises the `delayed` event.
+	delayedJob, err := queue.Add(ctx, interopPayload{Inbox: "later"}, mkq.WithDelay(10*time.Minute))
+	require.NoError(t, err)
+
+	// Path 3: removing a wait/delayed job triggers the `removed` event.
+	require.NoError(t, queue.RemoveJob(ctx, delayedJob.ID))
+
+	required := map[string]bool{
+		"added":     false,
+		"waiting":   false,
+		"active":    false,
+		"completed": false,
+	}
+	deadline := time.After(8 * time.Second)
+	allSeen := func() bool {
+		for _, v := range required {
+			if !v {
+				return false
+			}
+		}
+		return true
+	}
+	for !allSeen() {
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				t.Fatalf("events listener closed before all required events seen; got %v", required)
+			}
+			name, _ := ev["event"].(string)
+			if _, ok := required[name]; ok {
+				required[name] = true
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for events; got %v", required)
+		}
+	}
+	for name, ok := range required {
+		assert.True(t, ok, "BullMQ listener should observe `%s` event", name)
+	}
+	_ = immediateJob
+}

--- a/tests/interop/events_extra_test.go
+++ b/tests/interop/events_extra_test.go
@@ -64,9 +64,9 @@ func TestInterop_Events_BullMQReadsMkqEmissions(t *testing.T) {
 	// Path 3: removing a wait/delayed job triggers the `removed` event.
 	require.NoError(t, queue.RemoveJob(ctx, delayedJob.ID))
 
-	// Every Path 1/2/3 trigger maps to an event we explicitly assert.
-	// Without this list the delayed-add and remove setup steps would
-	// be unverified work — Devin's PR #52 round-1 review caught that.
+	// Path 1/2/3 で発火させた event は全て assertion 対象に入れる。
+	// これがないと delayed Add / Remove の setup が「動いただけ」で
+	// wire compat の検証になっていない (PR #52 round-1 review 指摘)。
 	required := map[string]bool{
 		"added":     false,
 		"waiting":   false,

--- a/tests/interop/helpers_test.go
+++ b/tests/interop/helpers_test.go
@@ -1,0 +1,258 @@
+//go:build interop
+
+package interop_test
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// nodeWorkerOpts customises a startNodeWorker call beyond the
+// defaults baked into worker.js. Pass a zero value for the basic
+// happy-path worker; populate fields to opt into failure injection,
+// custom concurrency, rate limiting, or extended hold time.
+type nodeWorkerOpts struct {
+	// Fail makes the handler always throw — useful for cross-language
+	// retry / failed-state interop scenarios.
+	Fail bool
+	// Concurrency overrides the BullMQ Worker concurrency (default 1).
+	Concurrency int
+	// LimiterMax / LimiterDurationMs configure the Worker's per-worker
+	// rate limiter. Both must be >0 for the limiter to apply.
+	LimiterMax        int
+	LimiterDurationMs int
+	// LockDurationMs overrides the BullMQ Worker.lockDuration (default
+	// 30s). Set short (e.g. 1s) to test lock interop scenarios.
+	LockDurationMs int
+	// HoldMs makes the handler sleep before returning. Combined with
+	// LockDurationMs short and INTEROP_FAIL=0 it's how the test rig
+	// keeps a job locked for stalled / lock interop.
+	HoldMs int
+}
+
+// startNodeWorkerOpts is the option-bearing variant of
+// startNodeWorker. The original startNodeWorker delegates to this
+// with a zero opts struct.
+func startNodeWorkerOpts(t *testing.T, prefix, queueName string, opts nodeWorkerOpts) {
+	t.Helper()
+	dir := nodeDir(t)
+	cmd := exec.Command("node", "worker.js")
+	cmd.Dir = dir
+	env := append(os.Environ(),
+		"INTEROP_REDIS="+redisAddr(),
+		"INTEROP_PREFIX="+prefix,
+		"INTEROP_QUEUE="+queueName,
+	)
+	if opts.Fail {
+		env = append(env, "INTEROP_FAIL=1")
+	}
+	if opts.Concurrency > 0 {
+		env = append(env, "INTEROP_CONCURRENCY="+strconv.Itoa(opts.Concurrency))
+	}
+	if opts.LimiterMax > 0 && opts.LimiterDurationMs > 0 {
+		env = append(env, "INTEROP_LIMITER="+
+			`{"max":`+strconv.Itoa(opts.LimiterMax)+`,"duration":`+strconv.Itoa(opts.LimiterDurationMs)+`}`)
+	}
+	if opts.LockDurationMs > 0 {
+		env = append(env, "INTEROP_LOCK_DURATION_MS="+strconv.Itoa(opts.LockDurationMs))
+	}
+	if opts.HoldMs > 0 {
+		env = append(env, "INTEROP_HOLD_MS="+strconv.Itoa(opts.HoldMs))
+	}
+	cmd.Env = env
+	startWorkerProcess(t, cmd)
+}
+
+// runNodeEnqueuerOpts is the option-bearing variant of runNodeEnqueuer.
+// Pass an empty nodeEnqueuerOpts for the basic happy-path Add.
+type nodeEnqueuerOpts struct {
+	// Name overrides Job.name (default: queue name).
+	Name string
+	// OptsJSON is the BullMQ JobsOptions object as JSON, forwarded
+	// verbatim to queue.add(name, data, opts). Empty = no opts.
+	OptsJSON string
+}
+
+func runNodeEnqueuerOpts(t *testing.T, prefix, queueName, payloadJSON string, opts nodeEnqueuerOpts) string {
+	t.Helper()
+	dir := nodeDir(t)
+	cmd := exec.Command("node", "enqueuer.js")
+	cmd.Dir = dir
+	env := append(os.Environ(),
+		"INTEROP_REDIS="+redisAddr(),
+		"INTEROP_PREFIX="+prefix,
+		"INTEROP_QUEUE="+queueName,
+		"INTEROP_PAYLOAD="+payloadJSON,
+	)
+	if opts.Name != "" {
+		env = append(env, "INTEROP_NAME="+opts.Name)
+	}
+	if opts.OptsJSON != "" {
+		env = append(env, "INTEROP_OPTS="+opts.OptsJSON)
+	}
+	cmd.Env = env
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	require.NoError(t, err, "enqueuer.js failed")
+
+	var msg struct {
+		JobID string `json:"jobId"`
+	}
+	require.NoError(t, json.Unmarshal(out, &msg), "enqueuer.js stdout: %s", string(out))
+	require.NotEmpty(t, msg.JobID)
+	return msg.JobID
+}
+
+// runNodeInspector invokes inspector.js with a subcommand and parses
+// the single-line JSON result into out. Synchronous: returns after the
+// subprocess exits.
+func runNodeInspector(t *testing.T, prefix, queueName string, out any, args ...string) {
+	t.Helper()
+	dir := nodeDir(t)
+	cmd := exec.Command("node", append([]string{"inspector.js"}, args...)...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"INTEROP_REDIS="+redisAddr(),
+		"INTEROP_PREFIX="+prefix,
+		"INTEROP_QUEUE="+queueName,
+	)
+	cmd.Stderr = os.Stderr
+	stdout, err := cmd.Output()
+	require.NoError(t, err, "inspector.js %v failed", args)
+	require.NoError(t, json.Unmarshal(stdout, out), "inspector.js %v stdout: %s", args, string(stdout))
+}
+
+// startWorkerProcess starts the given subprocess, drains stdout for
+// its lifetime, and blocks until a JSON line `{"event":"ready"}` is
+// emitted (or fails the test on timeout). Cleanup registered on t.
+//
+// Kept in this file so the original startNodeWorker (in
+// interop_test.go) and the option-bearing startNodeWorkerOpts share
+// a single ready/cleanup state machine.
+func startWorkerProcess(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Start())
+
+	ready := make(chan struct{})
+	var readyOnce sync.Once
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			line := scanner.Text()
+			var msg struct {
+				Event string `json:"event"`
+			}
+			if json.Unmarshal([]byte(line), &msg) == nil && msg.Event == "ready" {
+				readyOnce.Do(func() { close(ready) })
+			}
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(os.Interrupt)
+		done := make(chan struct{})
+		go func() { _ = cmd.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			_ = cmd.Process.Kill()
+			<-done
+		}
+	})
+
+	select {
+	case <-ready:
+	case <-time.After(15 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatal("node subprocess never printed ready")
+	}
+}
+
+// startEventsListener spins up events-listener.js and returns a
+// channel that receives every event line as a parsed map. The channel
+// closes when the subprocess exits or t cleans up. The "ready"
+// beacon is consumed internally so callers see only data events.
+//
+// optionalEvents narrows the listener's emission set (default all).
+func startEventsListener(t *testing.T, prefix, queueName string, optionalEvents ...string) <-chan map[string]any {
+	t.Helper()
+	dir := nodeDir(t)
+	cmd := exec.Command("node", "events-listener.js")
+	cmd.Dir = dir
+	env := append(os.Environ(),
+		"INTEROP_REDIS="+redisAddr(),
+		"INTEROP_PREFIX="+prefix,
+		"INTEROP_QUEUE="+queueName,
+	)
+	if len(optionalEvents) > 0 {
+		env = append(env, "INTEROP_EVENTS="+joinComma(optionalEvents))
+	}
+	cmd.Env = env
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Start())
+
+	out := make(chan map[string]any, 32)
+	ready := make(chan struct{})
+	var readyOnce sync.Once
+
+	go func() {
+		defer close(out)
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			line := scanner.Text()
+			var msg map[string]any
+			if json.Unmarshal([]byte(line), &msg) != nil {
+				continue
+			}
+			if e, _ := msg["event"].(string); e == "ready" {
+				readyOnce.Do(func() { close(ready) })
+				continue
+			}
+			out <- msg
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(os.Interrupt)
+		done := make(chan struct{})
+		go func() { _ = cmd.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			_ = cmd.Process.Kill()
+			<-done
+		}
+	})
+
+	select {
+	case <-ready:
+	case <-time.After(15 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatal("events-listener.js never printed ready")
+	}
+	return out
+}
+
+func joinComma(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += ","
+		}
+		out += p
+	}
+	return out
+}

--- a/tests/interop/interop_test.go
+++ b/tests/interop/interop_test.go
@@ -15,7 +15,6 @@
 package interop_test
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -23,7 +22,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -105,62 +103,16 @@ func waitFor(t *testing.T, ctx context.Context, step time.Duration, cond func() 
 	}
 }
 
-// startNodeWorker spawns the BullMQ TS worker as a subprocess. Returns
-// once worker.js prints {"event":"ready"} so callers can race the next
-// job submission without a fixed sleep. Cleanup is registered on t.
+// startNodeWorker spawns the BullMQ TS worker as a subprocess with
+// default options. Returns once worker.js prints {"event":"ready"}
+// so callers can race the next job submission without a fixed sleep.
+// Cleanup is registered on t.
+//
+// Thin wrapper over startNodeWorkerOpts so the ready-channel /
+// stdout-drain / cleanup machinery lives in exactly one place.
 func startNodeWorker(t *testing.T, prefix, queueName string) {
 	t.Helper()
-	dir := nodeDir(t)
-	cmd := exec.Command("node", "worker.js")
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
-		"INTEROP_REDIS="+redisAddr(),
-		"INTEROP_PREFIX="+prefix,
-		"INTEROP_QUEUE="+queueName,
-	)
-	stdout, err := cmd.StdoutPipe()
-	require.NoError(t, err)
-	cmd.Stderr = os.Stderr
-	require.NoError(t, cmd.Start())
-
-	// Drain stdout for the lifetime of the subprocess. We listen for
-	// {"event":"ready"} to release the caller, then keep draining
-	// (silently discarding) until EOF so any incidental console
-	// output BullMQ might emit later doesn't fill the OS pipe buffer
-	// (~64KB on Linux) and deadlock the worker on its next write.
-	ready := make(chan struct{})
-	var readyOnce sync.Once
-	go func() {
-		scanner := bufio.NewScanner(stdout)
-		for scanner.Scan() {
-			line := scanner.Text()
-			var msg struct {
-				Event string `json:"event"`
-			}
-			if json.Unmarshal([]byte(line), &msg) == nil && msg.Event == "ready" {
-				readyOnce.Do(func() { close(ready) })
-			}
-		}
-	}()
-
-	t.Cleanup(func() {
-		_ = cmd.Process.Signal(os.Interrupt)
-		done := make(chan struct{})
-		go func() { _ = cmd.Wait(); close(done) }()
-		select {
-		case <-done:
-		case <-time.After(3 * time.Second):
-			_ = cmd.Process.Kill()
-			<-done
-		}
-	})
-
-	select {
-	case <-ready:
-	case <-time.After(15 * time.Second):
-		_ = cmd.Process.Kill()
-		t.Fatal("BullMQ worker never printed ready")
-	}
+	startNodeWorkerOpts(t, prefix, queueName, nodeWorkerOpts{})
 }
 
 // runNodeEnqueuer runs enqueuer.js once and returns the Job ID it

--- a/tests/interop/interop_test.go
+++ b/tests/interop/interop_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sync/atomic"
@@ -115,29 +114,16 @@ func startNodeWorker(t *testing.T, prefix, queueName string) {
 	startNodeWorkerOpts(t, prefix, queueName, nodeWorkerOpts{})
 }
 
-// runNodeEnqueuer runs enqueuer.js once and returns the Job ID it
-// reported. Synchronous: returns after the subprocess exits.
+// runNodeEnqueuer runs enqueuer.js once with default options and
+// returns the Job ID it reported. Synchronous: returns after the
+// subprocess exits.
+//
+// Thin wrapper over runNodeEnqueuerOpts so the exec / env / JSON-parse
+// machinery lives in exactly one place; PR #5–#46's existing tests
+// keep using this short signature.
 func runNodeEnqueuer(t *testing.T, prefix, queueName, payloadJSON string) string {
 	t.Helper()
-	dir := nodeDir(t)
-	cmd := exec.Command("node", "enqueuer.js")
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
-		"INTEROP_REDIS="+redisAddr(),
-		"INTEROP_PREFIX="+prefix,
-		"INTEROP_QUEUE="+queueName,
-		"INTEROP_PAYLOAD="+payloadJSON,
-	)
-	cmd.Stderr = os.Stderr
-	out, err := cmd.Output()
-	require.NoError(t, err, "enqueuer.js failed")
-
-	var msg struct {
-		JobID string `json:"jobId"`
-	}
-	require.NoError(t, json.Unmarshal(out, &msg), "enqueuer.js stdout: %s", string(out))
-	require.NotEmpty(t, msg.JobID)
-	return msg.JobID
+	return runNodeEnqueuerOpts(t, prefix, queueName, payloadJSON, nodeEnqueuerOpts{})
 }
 
 type interopPayload struct {

--- a/tests/interop/mutation_test.go
+++ b/tests/interop/mutation_test.go
@@ -1,0 +1,243 @@
+//go:build interop
+
+// Mutation + admin interop coverage. Each subtest runs an mkq-side
+// state-change (UpdateProgress, UpdateData, Log, RemoveJob,
+// PromoteJob, RetryJob, DrainPending) and asserts BullMQ TS observes
+// the outcome via Job / Queue accessors. Direction is mkq→BullMQ.
+
+package interop_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestInterop_Mutation_Progress: mkq writes progress; BullMQ TS
+// Job.fromId returns the same value via job.progress.
+func TestInterop_Mutation_Progress(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "mut"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, interopPayload{Inbox: "x"})
+	require.NoError(t, err)
+	require.NoError(t, queue.UpdateJobProgress(ctx, job.ID, 0.42))
+
+	var got struct {
+		Progress float64 `json:"progress"`
+	}
+	runNodeInspector(t, prefix, queueName, &got, "getJob", job.ID)
+	assert.InDelta(t, 0.42, got.Progress, 0.0001)
+}
+
+// TestInterop_Mutation_Data: mkq rewrites data; BullMQ TS reads the
+// new payload via job.data.
+func TestInterop_Mutation_Data(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "mut"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, interopPayload{Inbox: "old"})
+	require.NoError(t, err)
+	require.NoError(t, queue.UpdateJobData(ctx, job.ID, interopPayload{Inbox: "new", Body: "rewritten"}))
+
+	var got struct {
+		Data interopPayload `json:"data"`
+	}
+	runNodeInspector(t, prefix, queueName, &got, "getJob", job.ID)
+	assert.Equal(t, "new", got.Data.Inbox)
+	assert.Equal(t, "rewritten", got.Data.Body)
+}
+
+// TestInterop_Mutation_Log: mkq appends two log lines; BullMQ TS
+// Queue.getJobLogs returns them in submission order.
+func TestInterop_Mutation_Log(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "mut"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, interopPayload{})
+	require.NoError(t, err)
+	require.NoError(t, queue.AppendJobLog(ctx, job.ID, "first"))
+	require.NoError(t, queue.AppendJobLog(ctx, job.ID, "second"))
+
+	var got struct {
+		Logs  []string `json:"logs"`
+		Count int      `json:"count"`
+	}
+	runNodeInspector(t, prefix, queueName, &got, "getJobLogs", job.ID)
+	assert.Equal(t, []string{"first", "second"}, got.Logs)
+}
+
+// TestInterop_Mutation_RemoveJob: mkq removes a wait job; BullMQ TS
+// Queue.getJob returns null (= state "missing" in the inspector
+// helper).
+func TestInterop_Mutation_RemoveJob(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "mut"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, interopPayload{Inbox: "doomed"})
+	require.NoError(t, err)
+	require.NoError(t, queue.RemoveJob(ctx, job.ID))
+
+	var got struct {
+		State string `json:"state"`
+	}
+	runNodeInspector(t, prefix, queueName, &got, "getState", job.ID)
+	// BullMQ TS Job.getState returns "unknown" when the HASH is gone.
+	assert.Contains(t, []string{"missing", "unknown"}, got.State)
+}
+
+// TestInterop_Mutation_PromoteJob: mkq promotes a delayed job;
+// BullMQ TS observes the new state as "waiting".
+func TestInterop_Mutation_PromoteJob(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "mut"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, interopPayload{Inbox: "promoted"}, mkq.WithDelay(time.Hour))
+	require.NoError(t, err)
+
+	var before struct {
+		State string `json:"state"`
+	}
+	runNodeInspector(t, prefix, queueName, &before, "getState", job.ID)
+	require.Equal(t, "delayed", before.State)
+
+	require.NoError(t, queue.PromoteJob(ctx, job.ID))
+
+	var after struct {
+		State string `json:"state"`
+	}
+	runNodeInspector(t, prefix, queueName, &after, "getState", job.ID)
+	assert.Equal(t, "waiting", after.State, "BullMQ Job.getState must reflect mkq's promote")
+}
+
+// TestInterop_Mutation_RetryJob exercises the failed→wait state
+// transition mkq's RetryJob triggers, with BullMQ TS Job.getState
+// confirming the new state. We deliberately keep the entire job
+// lifecycle on the mkq side (failing handler → RetryJob) so the
+// observable invariant is "BullMQ reads the wire state mkq mutated"
+// rather than "two foreign workers race over the same job."
+//
+// Phase 1: mkq processor fails the job once (no WithAttempts → one
+// shot to failed).
+// Phase 2: BullMQ TS Job.getState confirms "failed".
+// Phase 3: mkq RetryJob re-enqueues to wait.
+// Phase 4: BullMQ TS Job.getState confirms "waiting".
+func TestInterop_Mutation_RetryJob(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "mut"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	addedJob, err := queue.Add(ctx, interopPayload{Inbox: "retry-target"})
+	require.NoError(t, err)
+
+	// Phase 1: drive to failed via an mkq handler that always errors.
+	failed := make(chan struct{})
+	w1, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[interopPayload]) (any, error) {
+		select {
+		case failed <- struct{}{}:
+		default:
+		}
+		return nil, assertionErr("intentional fail")
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	<-failed
+	rdb := rawClient(t)
+	base := prefix + ":" + queueName + ":"
+	waitFor(t, ctx, 50*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"failed", addedJob.ID).Result()
+		return v > 0
+	})
+	require.NoError(t, w1.Stop(context.Background()))
+
+	// Phase 2: BullMQ confirms failed.
+	var beforeRetry struct {
+		State string `json:"state"`
+	}
+	runNodeInspector(t, prefix, queueName, &beforeRetry, "getState", addedJob.ID)
+	require.Equal(t, "failed", beforeRetry.State)
+
+	// Phase 3: RetryJob re-enqueues.
+	require.NoError(t, queue.RetryJob(ctx, addedJob.ID))
+
+	// Phase 4: BullMQ observes "waiting" (no worker is running so the
+	// state stays put for the assertion window).
+	var afterRetry struct {
+		State string `json:"state"`
+	}
+	runNodeInspector(t, prefix, queueName, &afterRetry, "getState", addedJob.ID)
+	assert.Equal(t, "waiting", afterRetry.State, "BullMQ Job.getState must reflect mkq's RetryJob")
+}
+
+// assertionErr is a tiny error helper kept outside the test to avoid
+// allocation churn in the failing-handler hot loop.
+type assertionErr string
+
+func (e assertionErr) Error() string { return string(e) }
+
+// TestInterop_Mutation_DrainPending: mkq drains 3 wait jobs; BullMQ
+// TS Queue.getJobCounts confirms wait went to 0 while delayed (10
+// minutes out) survived.
+func TestInterop_Mutation_DrainPending(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "mut"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for range 3 {
+		_, err := queue.Add(ctx, interopPayload{})
+		require.NoError(t, err)
+	}
+	for range 2 {
+		_, err := queue.Add(ctx, interopPayload{}, mkq.WithDelay(10*time.Minute))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, queue.DrainPending(ctx))
+
+	var got struct {
+		Counts struct {
+			Wait    int64 `json:"wait"`
+			Delayed int64 `json:"delayed"`
+		} `json:"counts"`
+	}
+	runNodeInspector(t, prefix, queueName, &got, "counts", "wait", "delayed")
+	assert.EqualValues(t, 0, got.Counts.Wait, "wait must be empty after Drain")
+	assert.EqualValues(t, 2, got.Counts.Delayed, "delayed must survive Drain (default WithoutDrainDelayed)")
+}

--- a/tests/interop/node/enqueuer.js
+++ b/tests/interop/node/enqueuer.js
@@ -2,10 +2,14 @@
 // "BullMQ TS Add -> mkq Process" direction. Adds one job and exits.
 //
 // Env:
-//   INTEROP_REDIS    e.g. 127.0.0.1:6379
-//   INTEROP_PREFIX   BullMQ keyPrefix
-//   INTEROP_QUEUE    queue name
-//   INTEROP_PAYLOAD  JSON-encoded job data (default: {"hello":"from-bullmq"})
+//   INTEROP_REDIS     e.g. 127.0.0.1:6379
+//   INTEROP_PREFIX    BullMQ keyPrefix
+//   INTEROP_QUEUE     queue name
+//   INTEROP_PAYLOAD   JSON-encoded job data (default: {"hello":"from-bullmq"})
+//   INTEROP_NAME      Job.name override (default: queue name)
+//   INTEROP_OPTS      JSON-encoded BullMQ JobsOptions (delay / priority /
+//                     attempts / removeOnComplete / removeOnFail /
+//                     deduplication / lifo / etc.). Forwarded verbatim.
 //
 // Output:
 //   single line of JSON on stdout: {"jobId":"<id>"}
@@ -17,6 +21,8 @@ const redisAddr = process.env.INTEROP_REDIS;
 const prefix    = process.env.INTEROP_PREFIX;
 const queueName = process.env.INTEROP_QUEUE;
 const payload   = process.env.INTEROP_PAYLOAD || JSON.stringify({ hello: "from-bullmq" });
+const jobName   = process.env.INTEROP_NAME || queueName;
+const jobOpts   = process.env.INTEROP_OPTS ? JSON.parse(process.env.INTEROP_OPTS) : undefined;
 
 if (!redisAddr || !prefix || !queueName) {
   console.error("missing env: INTEROP_REDIS / INTEROP_PREFIX / INTEROP_QUEUE");
@@ -32,7 +38,7 @@ const queue = new Queue(queueName, {
 });
 
 try {
-  const job = await queue.add(queueName, JSON.parse(payload));
+  const job = await queue.add(jobName, JSON.parse(payload), jobOpts);
   process.stdout.write(JSON.stringify({ jobId: job.id }) + "\n");
 } finally {
   await queue.close();

--- a/tests/interop/node/events-listener.js
+++ b/tests/interop/node/events-listener.js
@@ -1,0 +1,68 @@
+// events-listener.js — subscribes to BullMQ TS QueueEvents on the
+// target queue and prints each event as a JSON line to stdout. Used
+// by the Go interop tests to verify that mkq-emitted events on the
+// Redis Stream are consumable by a BullMQ TS reader (= mkq's wire
+// format for the events stream is correct in the inverse direction).
+//
+// Env: INTEROP_REDIS / INTEROP_PREFIX / INTEROP_QUEUE
+// Optional INTEROP_EVENTS: comma-separated list of event names to
+// emit; defaults to all (added/waiting/active/completed/failed/
+// delayed/stalled/drained/progress/removed/retries-exhausted).
+//
+// Output (per event):
+//   {"event":"ready"}                 once subscribed
+//   {"event":"<name>","jobId":...,...} per emitted event
+//
+// Exits cleanly on SIGTERM.
+
+import { QueueEvents } from "bullmq";
+
+const redisAddr = process.env.INTEROP_REDIS;
+const prefix    = process.env.INTEROP_PREFIX;
+const queueName = process.env.INTEROP_QUEUE;
+const eventsArg = process.env.INTEROP_EVENTS;
+
+if (!redisAddr || !prefix || !queueName) {
+  console.error("missing env: INTEROP_REDIS / INTEROP_PREFIX / INTEROP_QUEUE");
+  process.exit(2);
+}
+
+const [host, portStr] = redisAddr.split(":");
+const wanted = eventsArg
+  ? new Set(eventsArg.split(","))
+  : null;
+
+const qe = new QueueEvents(queueName, {
+  connection: { host, port: Number(portStr) },
+  prefix,
+});
+
+const emit = (name, payload) => {
+  if (wanted && !wanted.has(name)) return;
+  process.stdout.write(JSON.stringify({ event: name, ...payload }) + "\n");
+};
+
+qe.on("waiting",          (data) => emit("waiting",          data));
+qe.on("active",           (data) => emit("active",           data));
+qe.on("completed",        (data) => emit("completed",        data));
+qe.on("failed",           (data) => emit("failed",           data));
+qe.on("delayed",          (data) => emit("delayed",          data));
+qe.on("stalled",          (data) => emit("stalled",          data));
+qe.on("drained",          ()      => emit("drained",         {}));
+qe.on("progress",         (data) => emit("progress",         data));
+qe.on("removed",          (data) => emit("removed",          data));
+qe.on("retries-exhausted",(data) => emit("retries-exhausted",data));
+qe.on("added",            (data) => emit("added",            data));
+
+await qe.waitUntilReady();
+process.stdout.write(JSON.stringify({ event: "ready" }) + "\n");
+
+const shutdown = async () => {
+  try {
+    await qe.close();
+  } finally {
+    process.exit(0);
+  }
+};
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/tests/interop/node/inspector.js
+++ b/tests/interop/node/inspector.js
@@ -1,0 +1,68 @@
+// inspector.js — read-only BullMQ TS Queue inspections used by Go
+// interop tests to assert state mkq produced.
+//
+// Subcommands (first argv after the script):
+//   getJob <jobId>             — Job.fromId; emits the full Job JSON
+//   getState <jobId>           — Job.getState; emits {state}
+//   counts <s1> [s2 ...]       — Queue.getJobCounts(states...); emits {counts}
+//   getJobs <state> <start> <end> — Queue.getJobs([state], start, end); emits {ids}
+//   getJobLogs <jobId>         — Queue.getJobLogs(jobId); emits {logs, count}
+//
+// Env: INTEROP_REDIS / INTEROP_PREFIX / INTEROP_QUEUE
+// Output: single JSON line on stdout. Non-zero exit on error.
+
+import { Queue } from "bullmq";
+
+const redisAddr = process.env.INTEROP_REDIS;
+const prefix    = process.env.INTEROP_PREFIX;
+const queueName = process.env.INTEROP_QUEUE;
+const [sub, ...args] = process.argv.slice(2);
+
+if (!redisAddr || !prefix || !queueName || !sub) {
+  console.error("usage: inspector.js <sub> [args...]; needs INTEROP_REDIS / PREFIX / QUEUE env");
+  process.exit(2);
+}
+
+const [host, portStr] = redisAddr.split(":");
+const queue = new Queue(queueName, {
+  connection: { host, port: Number(portStr) },
+  prefix,
+});
+
+try {
+  let result;
+  switch (sub) {
+    case "getJob": {
+      const job = await queue.getJob(args[0]);
+      result = job ? job.toJSON() : null;
+      break;
+    }
+    case "getState": {
+      const job = await queue.getJob(args[0]);
+      result = { state: job ? await job.getState() : "missing" };
+      break;
+    }
+    case "counts": {
+      result = { counts: await queue.getJobCounts(...args) };
+      break;
+    }
+    case "getJobs": {
+      const [state, startStr, endStr] = args;
+      const start = parseInt(startStr ?? "0", 10);
+      const end   = parseInt(endStr ?? "-1", 10);
+      const jobs = await queue.getJobs([state], start, end);
+      result = { ids: jobs.map((j) => j.id) };
+      break;
+    }
+    case "getJobLogs": {
+      result = await queue.getJobLogs(args[0]);
+      break;
+    }
+    default:
+      console.error(`unknown subcommand: ${sub}`);
+      process.exit(2);
+  }
+  process.stdout.write(JSON.stringify(result) + "\n");
+} finally {
+  await queue.close();
+}

--- a/tests/interop/node/worker.js
+++ b/tests/interop/node/worker.js
@@ -3,23 +3,37 @@
 // "mkq Add -> BullMQ TS Process" direction.
 //
 // Env:
-//   INTEROP_REDIS    e.g. 127.0.0.1:6379  (host:port)
-//   INTEROP_PREFIX   BullMQ keyPrefix (e.g. mkqtest-foo)
-//   INTEROP_QUEUE    queue name (e.g. deliver)
+//   INTEROP_REDIS         e.g. 127.0.0.1:6379  (host:port)
+//   INTEROP_PREFIX        BullMQ keyPrefix (e.g. mkqtest-foo)
+//   INTEROP_QUEUE         queue name (e.g. deliver)
+//   INTEROP_FAIL          if "1", handler always throws (for retry interop)
+//   INTEROP_CONCURRENCY   integer concurrency (default 1)
+//   INTEROP_LIMITER       JSON {"max": N, "duration": ms} (optional)
+//   INTEROP_LOCK_DURATION_MS  worker.lockDuration override (optional ms)
+//   INTEROP_HOLD_MS       handler sleep before returning (default 0). Used
+//                         to keep a job locked for stalled / lock interop.
 //
 // Behaviour:
-//   - Echoes the input payload as the return value, plus a "by"
-//     marker so the Go side can verify which side handled it.
-//   - Logs a single line of JSON to stdout once the worker is
-//     fully ready, so the Go side can wait deterministically:
+//   - Default handler echoes the payload + a "by" marker.
+//   - INTEROP_FAIL throws an Error with a fixed message so the
+//     dispatcher records `failedReason`.
+//   - Logs a single line of JSON to stdout once ready:
 //       {"event":"ready"}
+//   - For each processed job (success OR failure), writes:
+//       {"event":"processed","jobId":"<id>","ok":true|false}
 //   - Exits cleanly on SIGTERM.
 
 import { Worker } from "bullmq";
 
-const redisAddr = process.env.INTEROP_REDIS;
-const prefix    = process.env.INTEROP_PREFIX;
-const queueName = process.env.INTEROP_QUEUE;
+const redisAddr        = process.env.INTEROP_REDIS;
+const prefix           = process.env.INTEROP_PREFIX;
+const queueName        = process.env.INTEROP_QUEUE;
+const fail             = process.env.INTEROP_FAIL === "1";
+const concurrency      = parseInt(process.env.INTEROP_CONCURRENCY ?? "1", 10);
+const limiter          = process.env.INTEROP_LIMITER ? JSON.parse(process.env.INTEROP_LIMITER) : undefined;
+const lockDurationOpt  = process.env.INTEROP_LOCK_DURATION_MS;
+const lockDuration     = lockDurationOpt ? parseInt(lockDurationOpt, 10) : undefined;
+const holdMs           = parseInt(process.env.INTEROP_HOLD_MS ?? "0", 10);
 
 if (!redisAddr || !prefix || !queueName) {
   console.error("missing env: INTEROP_REDIS / INTEROP_PREFIX / INTEROP_QUEUE");
@@ -29,19 +43,36 @@ if (!redisAddr || !prefix || !queueName) {
 const [host, portStr] = redisAddr.split(":");
 const port = Number(portStr);
 
+const workerOpts = {
+  connection: { host, port },
+  prefix,
+  concurrency,
+};
+if (limiter) workerOpts.limiter = limiter;
+if (lockDuration) workerOpts.lockDuration = lockDuration;
+
 const worker = new Worker(
   queueName,
   async (job) => {
+    if (holdMs > 0) {
+      await new Promise((r) => setTimeout(r, holdMs));
+    }
+    if (fail) {
+      throw new Error(`bullmq-ts handler intentional failure for job ${job.id}`);
+    }
     return { by: "bullmq-ts", echo: job.data, jobId: job.id };
   },
-  {
-    connection: { host, port },
-    prefix,
-  }
+  workerOpts
 );
 
 worker.on("ready", () => {
   process.stdout.write(JSON.stringify({ event: "ready" }) + "\n");
+});
+worker.on("completed", (job) => {
+  process.stdout.write(JSON.stringify({ event: "processed", jobId: job.id, ok: true }) + "\n");
+});
+worker.on("failed", (job, err) => {
+  process.stdout.write(JSON.stringify({ event: "processed", jobId: job?.id, ok: false, err: err?.message }) + "\n");
 });
 
 const shutdown = async () => {

--- a/tests/interop/ratelimit_test.go
+++ b/tests/interop/ratelimit_test.go
@@ -1,0 +1,82 @@
+//go:build interop
+
+// Cross-language rate limiter: an mkq Worker and a BullMQ TS Worker
+// process the same queue concurrently with the same limiter config
+// (max=2 jobs / 500ms). They share the limiter:<groupKey> ZSET
+// state via the vendored Lua's getRateLimitTTL, so the combined
+// throughput must respect the limit regardless of which worker pulls.
+//
+// Pre-enqueue 6 jobs, run both workers concurrently, assert total
+// wall time stays >= ~1s (= 3 cooldown windows). If the limiter
+// state weren't shared, both workers would drain in <300ms.
+
+package interop_test
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+func TestInterop_RateLimitShared(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "rl"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const total = 6
+	for i := range total {
+		_, err := queue.Add(ctx, interopPayload{Inbox: strconv.Itoa(i)})
+		require.NoError(t, err)
+	}
+
+	// BullMQ TS Worker with limiter — it'll INCR rateLimiterKey and
+	// observe the cooldown via getRateLimitTTL.
+	startNodeWorkerOpts(t, prefix, queueName, nodeWorkerOpts{
+		Concurrency:       1,
+		LimiterMax:        2,
+		LimiterDurationMs: 500,
+	})
+
+	// mkq Worker with the same limiter config.
+	var mkqDone atomic.Int64
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[interopPayload]) (any, error) {
+		mkqDone.Add(1)
+		return nil, nil
+	},
+		mkq.WithConcurrency(1),
+		mkq.WithRateLimit(2, 500*time.Millisecond),
+		mkq.WithIdlePollInterval(50*time.Millisecond),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = worker.Stop(context.Background()) })
+
+	rdb := rawClient(t)
+	base := prefix + ":" + queueName + ":"
+	start := time.Now()
+	waitFor(t, ctx, 100*time.Millisecond, func() bool {
+		n, _ := rdb.ZCard(ctx, base+"completed").Result()
+		return n == int64(total)
+	})
+	elapsed := time.Since(start)
+
+	// 6 jobs / 2 per 500ms = 3 windows. Allow generous lower bound
+	// for CI jitter; the strict invariant is "noticeably slower than
+	// unlimited" — without the shared limiter, two concurrent workers
+	// drain the queue in well under 500ms.
+	assert.GreaterOrEqual(t, elapsed, 700*time.Millisecond,
+		"shared rate limit must throttle the combined throughput (got %v)", elapsed)
+	// Both workers should have contributed, so mkq processed > 0 jobs.
+	assert.Greater(t, mkqDone.Load(), int64(0),
+		"mkq Worker should have processed at least one job (got %d)", mkqDone.Load())
+}

--- a/tests/interop/retry_test.go
+++ b/tests/interop/retry_test.go
@@ -1,0 +1,61 @@
+//go:build interop
+
+// TestInterop_RetryBackoff: mkq Add with WithAttempts + WithBackoff;
+// BullMQ TS Worker fails the handler each time. The vendored
+// retryJob-11.lua + moveToDelayed-12.lua wire path drives the job
+// through 3 attempts before landing in failed, and BullMQ TS
+// observes the final HASH state (atm = attempts, processedOn /
+// finishedOn populated, failedReason set).
+//
+// This pins that mkq's worker contract for handing failed-but-
+// retryable jobs back to the lua matches what BullMQ TS produces
+// (= a foreign worker can take over an mkq-added job mid-retry-cycle).
+
+package interop_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+func TestInterop_RetryBackoff(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "retry"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const attempts = 3
+	addedJob, err := queue.Add(ctx, interopPayload{Inbox: "retry"},
+		mkq.WithAttempts(attempts),
+		mkq.WithBackoff(mkq.FixedBackoff(50*time.Millisecond)),
+	)
+	require.NoError(t, err)
+
+	// Failing BullMQ TS worker drives the job through all attempts.
+	startNodeWorkerOpts(t, prefix, queueName, nodeWorkerOpts{Fail: true})
+
+	rdb := rawClient(t)
+	base := prefix + ":" + queueName + ":"
+	waitFor(t, ctx, 50*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"failed", addedJob.ID).Result()
+		return v > 0
+	})
+
+	atm, err := rdb.HGet(ctx, base+addedJob.ID, "atm").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "3", atm, "BullMQ-driven retries must converge on attemptsMade=attempts")
+
+	failedReason, err := rdb.HGet(ctx, base+addedJob.ID, "failedReason").Result()
+	require.NoError(t, err)
+	assert.Contains(t, failedReason, "intentional failure",
+		"failedReason must surface the BullMQ-side handler error verbatim")
+}

--- a/tests/interop/schedule_options_test.go
+++ b/tests/interop/schedule_options_test.go
@@ -1,0 +1,89 @@
+//go:build interop
+
+// Schedule-options coverage for the cross-language scheduler interop.
+// PR #33/#35 already pin the every / pattern + WithScheduleImmediately
+// paths; this file fills in WithScheduleLimit / WithScheduleEndDate /
+// WithScheduleTimezone — each verified by reading the schedule HASH
+// from BullMQ TS's perspective (Queue.getJobScheduler isn't exposed
+// in mkq's npm pin, so we assert via raw HGETALL via a small helper).
+//
+// Direction is mkq→BullMQ; the schedule HASH must match BullMQ's
+// expected field shape so a foreign worker continues iteration.
+
+package interop_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+func TestInterop_ScheduleOptions_Limit(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "tick"
+	const scheduleID = "limit"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, queue.UpsertScheduleEvery(ctx,
+		scheduleID, time.Hour, interopPayload{Inbox: "x"},
+		mkq.WithScheduleLimit(5),
+	))
+
+	rdb := rawClient(t)
+	got, err := rdb.HGetAll(ctx, prefix+":"+queueName+":repeat:"+scheduleID).Result()
+	require.NoError(t, err)
+	assert.Equal(t, "5", got["limit"], "BullMQ-readable HASH must record `limit` field")
+}
+
+func TestInterop_ScheduleOptions_EndDate(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "tick"
+	const scheduleID = "endd"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	end := time.Now().Add(2 * time.Hour)
+	require.NoError(t, queue.UpsertScheduleEvery(ctx,
+		scheduleID, time.Minute, interopPayload{},
+		mkq.WithScheduleEndDate(end),
+	))
+
+	rdb := rawClient(t)
+	got, err := rdb.HGetAll(ctx, prefix+":"+queueName+":repeat:"+scheduleID).Result()
+	require.NoError(t, err)
+	assert.NotEmpty(t, got["endDate"], "BullMQ-readable HASH must record `endDate`")
+}
+
+func TestInterop_ScheduleOptions_Timezone(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "tick"
+	const scheduleID = "tz"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, queue.UpsertSchedulePattern(ctx,
+		scheduleID, "0 9 * * *", interopPayload{},
+		mkq.WithScheduleTimezone("Asia/Tokyo"),
+	))
+
+	rdb := rawClient(t)
+	got, err := rdb.HGetAll(ctx, prefix+":"+queueName+":repeat:"+scheduleID).Result()
+	require.NoError(t, err)
+	assert.Equal(t, "Asia/Tokyo", got["tz"], "BullMQ-readable HASH must record `tz`")
+	assert.Equal(t, "0 9 * * *", got["pattern"])
+}

--- a/tests/interop/stalled_test.go
+++ b/tests/interop/stalled_test.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -139,5 +138,4 @@ func TestInterop_StalledRecovery(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, 0, exists, "lock key should be released after stalled-recovery flow")
 
-	_ = strconv.Itoa // silence unused-import false positive across Go versions
 }

--- a/tests/interop/stalled_test.go
+++ b/tests/interop/stalled_test.go
@@ -59,6 +59,13 @@ func TestInterop_StalledRecovery(t *testing.T) {
 	})
 
 	// Hard-kill BullMQ TS so its heartbeat stops extending the lock.
+	// startWorkerProcess registered a t.Cleanup that will SIGINT and
+	// re-Wait this same process; that's intentional and safe — Wait
+	// after a successful Wait returns "exec: Wait was already called",
+	// the cleanup discards the error via `_`. If a future change adds
+	// strict error checking to the cleanup path, this kill-then-wait
+	// dance must be relocated into its own Cleanup that fires before
+	// the helper's.
 	require.NoError(t, bullCmd.Process.Kill())
 	_ = bullCmd.Wait()
 

--- a/tests/interop/stalled_test.go
+++ b/tests/interop/stalled_test.go
@@ -1,0 +1,136 @@
+//go:build interop
+
+// Cross-language stalled recovery: a BullMQ TS Worker takes a job
+// (short lockDuration + long handler hold), gets killed mid-flight,
+// and an mkq Worker's stalled scanner reclaims the orphaned job.
+// Pins the lock-key wire format compatibility — same `:lock` STRING
+// shape, same stalled SET membership, same maxStalledCount handling.
+
+package interop_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+func TestInterop_StalledRecovery(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "stl"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	addedJob, err := queue.Add(ctx, interopPayload{Inbox: "stalled"})
+	require.NoError(t, err)
+
+	// BullMQ TS Worker with short lockDuration + 30s handler hold —
+	// designed to be killed mid-handler so the lock doesn't get
+	// extended.
+	dir := nodeDir(t)
+	bullCmd := exec.Command("node", "worker.js")
+	bullCmd.Dir = dir
+	bullCmd.Env = append(os.Environ(),
+		"INTEROP_REDIS="+redisAddr(),
+		"INTEROP_PREFIX="+prefix,
+		"INTEROP_QUEUE="+queueName,
+		"INTEROP_LOCK_DURATION_MS=1500", // short, so lock expires after kill
+		"INTEROP_HOLD_MS=30000",         // handler holds 30s = far longer than test budget
+	)
+	startWorkerProcess(t, bullCmd)
+
+	// Wait for the job to land in active under BullMQ's lock.
+	rdb := rawClient(t)
+	base := prefix + ":" + queueName + ":"
+	waitFor(t, ctx, 50*time.Millisecond, func() bool {
+		exists, _ := rdb.Exists(ctx, base+addedJob.ID+":lock").Result()
+		return exists == 1
+	})
+
+	// Hard-kill BullMQ TS so its heartbeat stops extending the lock.
+	require.NoError(t, bullCmd.Process.Kill())
+	_ = bullCmd.Wait()
+
+	// Wait > lockDuration + a generous margin so the lock is reliably
+	// gone before mkq's stalled scanner starts looking. With
+	// lockDuration=1500ms the worst-case expiry is ~1.5s after kill.
+	time.Sleep(3 * time.Second)
+	// Sanity: lock must be gone by now.
+	lockExists, err := rdb.Exists(ctx, base+addedJob.ID+":lock").Result()
+	require.NoError(t, err)
+	require.EqualValues(t, 0, lockExists, "BullMQ lock did not expire within the test budget")
+
+	// BullMQ's worker writes the stalled-check key with its own
+	// (much longer) interval — TTL of ~30s by default. Both libraries
+	// share this key, so mkq's scanner short-circuits if BullMQ's
+	// stamp is still alive. Clear it so mkq's scanner can run.
+	_ = rdb.Del(ctx, base+"stalled-check").Err()
+
+	// Diagnostic: confirm the job is still in active (BullMQ left it
+	// behind when killed) so mkq's stalled scanner has something to find.
+	activeIDs, _ := rdb.LRange(ctx, base+"active", 0, -1).Result()
+	t.Logf("active list after kill+sleep: %v", activeIDs)
+	stalledIDs, _ := rdb.SMembers(ctx, base+"stalled").Result()
+	t.Logf("stalled set after kill+sleep: %v", stalledIDs)
+
+	// mkq Worker with WithStalledInterval short enough to fire within
+	// the test budget. The `defa` (default failed reason) field gets
+	// set after maxStalledCount reclaim attempts; with WithMaxStalledCount(1)
+	// the worker reclaims on the first scan and finalises straight to failed.
+	var processed atomic.Int64
+	mkqWorker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[interopPayload]) (any, error) {
+		processed.Add(1)
+		return nil, nil
+	},
+		mkq.WithIdlePollInterval(50*time.Millisecond),
+		mkq.WithStalledInterval(500*time.Millisecond),
+		mkq.WithMaxStalledCount(2), // allow one re-acquire so handler runs
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mkqWorker.Stop(context.Background()) })
+
+	// Job either ends up processed (handler ran after stalled-recovery
+	// re-acquired) or in failed (maxStalledCount tripped first). Either
+	// outcome proves mkq's stalled scanner sees the BullMQ-orphaned
+	// job; we accept both since the exact path depends on scan timing.
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		if processed.Load() > 0 {
+			break
+		}
+		fz, _ := rdb.ZScore(ctx, base+"failed", addedJob.ID).Result()
+		if fz > 0 {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if processed.Load() == 0 {
+		fz, _ := rdb.ZScore(ctx, base+"failed", addedJob.ID).Result()
+		if fz == 0 {
+			activeNow, _ := rdb.LRange(ctx, base+"active", 0, -1).Result()
+			stalledNow, _ := rdb.SMembers(ctx, base+"stalled").Result()
+			waitNow, _ := rdb.LRange(ctx, base+"wait", 0, -1).Result()
+			scTTL, _ := rdb.PTTL(ctx, base+"stalled-check").Result()
+			t.Fatalf("mkq did not reclaim BullMQ-orphaned job after 20s: active=%v stalled=%v wait=%v stalled-check ttl=%v",
+				activeNow, stalledNow, waitNow, scTTL)
+		}
+	}
+
+	// Lock key must be released either way (no orphaned lock).
+	exists, err := rdb.Exists(ctx, base+addedJob.ID+":lock").Result()
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, exists, "lock key should be released after stalled-recovery flow")
+
+	_ = strconv.Itoa // silence unused-import false positive across Go versions
+}

--- a/tests/interop/wire_test.go
+++ b/tests/interop/wire_test.go
@@ -1,0 +1,251 @@
+//go:build interop
+
+// Wire-format interop coverage. Each subtest pins one BullMQ-shaped
+// wire surface mkq writes — Job HASH fields, priority/delay/lifo
+// queues, retention shape, custom name — and asserts BullMQ TS reads
+// it correctly via Job.fromId / Queue.getJobs / Queue.getJobCounts.
+//
+// Direction is mkq→BullMQ for every subtest in this file; the
+// inverse direction (BullMQ-Add → mkq-Get) is covered in
+// interop_test.go's existing TestInterop_BullMQAddMkqProcess.
+
+package interop_test
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestInterop_Wire_HashParity confirms the Job HASH fields mkq writes
+// (name, data, opts, timestamp) round-trip through BullMQ TS's
+// Job.fromId. Without this, a future opts JSON-encoding tweak in
+// proto/opts.go could silently break BullMQ's reader.
+func TestInterop_Wire_HashParity(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "wire"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, interopPayload{Inbox: "x", Body: "hash-parity"},
+		mkq.WithAttempts(3),
+	)
+	require.NoError(t, err)
+
+	var got struct {
+		ID        string         `json:"id"`
+		Name      string         `json:"name"`
+		Data      interopPayload `json:"data"`
+		Opts      map[string]any `json:"opts"`
+		Timestamp int64          `json:"timestamp"`
+	}
+	runNodeInspector(t, prefix, queueName, &got, "getJob", job.ID)
+	assert.Equal(t, job.ID, got.ID)
+	assert.Equal(t, queueName, got.Name)
+	assert.Equal(t, "x", got.Data.Inbox)
+	assert.Equal(t, "hash-parity", got.Data.Body)
+	assert.EqualValues(t, 3, got.Opts["attempts"])
+	assert.NotZero(t, got.Timestamp)
+}
+
+// TestInterop_Wire_Priority confirms BullMQ TS dequeues mkq-added
+// priority jobs in priority order: lower numeric priority runs first
+// (matching BullMQ's documented semantics).
+func TestInterop_Wire_Priority(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "wire"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	low, err := queue.Add(ctx, interopPayload{Inbox: "low"}, mkq.WithPriority(10))
+	require.NoError(t, err)
+	high, err := queue.Add(ctx, interopPayload{Inbox: "high"}, mkq.WithPriority(1))
+	require.NoError(t, err)
+
+	startNodeWorker(t, prefix, queueName)
+
+	rdb := rawClient(t)
+	base := prefix + ":" + queueName + ":"
+	waitFor(t, ctx, 50*time.Millisecond, func() bool {
+		n, _ := rdb.ZCard(ctx, base+"completed").Result()
+		return n >= 2
+	})
+
+	processedAt := func(id string) float64 {
+		s, _ := rdb.ZScore(ctx, base+"completed", id).Result()
+		return s
+	}
+	assert.Less(t, processedAt(high.ID), processedAt(low.ID),
+		"priority=1 (high) must finish before priority=10 (low)")
+}
+
+// TestInterop_Wire_DelayPickup confirms BullMQ TS Worker honours
+// mkq's delayed ZSET score: a WithDelay(t) job is not picked up
+// before t and is then promoted normally.
+func TestInterop_Wire_DelayPickup(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "wire"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const delay = 600 * time.Millisecond
+	addedAt := time.Now()
+	job, err := queue.Add(ctx, interopPayload{Inbox: "delayed"}, mkq.WithDelay(delay))
+	require.NoError(t, err)
+
+	startNodeWorker(t, prefix, queueName)
+
+	rdb := rawClient(t)
+	base := prefix + ":" + queueName + ":"
+	waitFor(t, ctx, 50*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"completed", job.ID).Result()
+		return v > 0
+	})
+
+	finishedScore, err := rdb.ZScore(ctx, base+"completed", job.ID).Result()
+	require.NoError(t, err)
+	finishedAt := time.UnixMilli(int64(finishedScore))
+	assert.GreaterOrEqual(t, finishedAt.Sub(addedAt), delay-100*time.Millisecond,
+		"delayed job must not be picked up before its target time")
+}
+
+// TestInterop_Wire_RetentionCountAge confirms BullMQ TS observes
+// mkq's WithKeepCompleted(N)+WithKeepCompletedAge(...) settings as
+// the canonical {count, age} shape in opts.removeOnComplete.
+func TestInterop_Wire_RetentionCountAge(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "wire"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, interopPayload{Inbox: "retention"},
+		mkq.WithKeepCompleted(3),
+		mkq.WithKeepCompletedAge(60*time.Second),
+	)
+	require.NoError(t, err)
+
+	var got struct {
+		Opts struct {
+			RemoveOnComplete struct {
+				Count int `json:"count"`
+				Age   int `json:"age"`
+			} `json:"removeOnComplete"`
+		} `json:"opts"`
+	}
+	runNodeInspector(t, prefix, queueName, &got, "getJob", job.ID)
+	assert.Equal(t, 3, got.Opts.RemoveOnComplete.Count, "count field must round-trip")
+	assert.Equal(t, 60, got.Opts.RemoveOnComplete.Age, "age field must round-trip")
+}
+
+// TestInterop_Wire_JobName confirms BullMQ TS reads the per-Add
+// Job.name override mkq sets via WithJobName. mk-go's MkqDriver
+// adapter dispatches on this field, so the round-trip must stay tight.
+func TestInterop_Wire_JobName(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "wire"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, interopPayload{}, mkq.WithJobName("system:retention"))
+	require.NoError(t, err)
+
+	var got struct {
+		Name string `json:"name"`
+	}
+	runNodeInspector(t, prefix, queueName, &got, "getJob", job.ID)
+	assert.Equal(t, "system:retention", got.Name)
+}
+
+// TestInterop_Wire_ListJobs confirms BullMQ TS Queue.getJobs returns
+// the same id set mkq's Queue.ListJobs would, for the same wait
+// bucket. Range bounds use BullMQ semantics (start, end inclusive).
+func TestInterop_Wire_ListJobs(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "wire"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const seed = 5
+	addedIDs := make([]string, seed)
+	for i := range seed {
+		j, err := queue.Add(ctx, interopPayload{Inbox: strconv.Itoa(i)})
+		require.NoError(t, err)
+		addedIDs[i] = j.ID
+	}
+
+	var got struct {
+		IDs []string `json:"ids"`
+	}
+	runNodeInspector(t, prefix, queueName, &got, "getJobs", "wait", "0", "-1")
+	want := append([]string(nil), addedIDs...)
+	sort.Strings(want)
+	gotIDs := append([]string(nil), got.IDs...)
+	sort.Strings(gotIDs)
+	assert.Equal(t, want, gotIDs, "BullMQ Queue.getJobs must return every mkq-added job")
+}
+
+// TestInterop_Wire_Counts confirms BullMQ TS Queue.getJobCounts
+// matches mkq's Queue.Counts on the same backing keys: 3 wait + 2
+// delayed should report 3/2 from both libraries.
+func TestInterop_Wire_Counts(t *testing.T) {
+	prefix := uniquePrefix(t)
+	const queueName = "wire"
+	c := newClient(t, prefix)
+	queue := mkq.Define[interopPayload](c, queueName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for range 3 {
+		_, err := queue.Add(ctx, interopPayload{})
+		require.NoError(t, err)
+	}
+	for range 2 {
+		_, err := queue.Add(ctx, interopPayload{}, mkq.WithDelay(10*time.Minute))
+		require.NoError(t, err)
+	}
+
+	mkqCounts, err := queue.Counts(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 3, mkqCounts.Wait)
+	require.EqualValues(t, 2, mkqCounts.Delayed)
+
+	var bullCounts struct {
+		Counts struct {
+			Wait    int64 `json:"wait"`
+			Delayed int64 `json:"delayed"`
+		} `json:"counts"`
+	}
+	runNodeInspector(t, prefix, queueName, &bullCounts, "counts", "wait", "delayed")
+	assert.EqualValues(t, 3, bullCounts.Counts.Wait)
+	assert.EqualValues(t, 2, bullCounts.Counts.Delayed)
+}
+
+// _ ensures json import survives if a subtest is later commented out.
+var _ = json.Unmarshal


### PR DESCRIPTION
## Summary

- Adds 22 cross-language interop scenarios + 3 new node helpers, addressing every actionable gap in the BullMQ TS compatibility audit.
- Total interop suite goes from **6 → 29 tests** (~15s sweep, all PASS).
- Covers wire format, Job mutations, admin ops, retry/backoff, stalled recovery, shared rate limit, inverse events, schedule options, dedup — both directions.
- No mkq source change; interop suite extension only.

## What changed

### New test files (22 subtests)

| File | Subtests | Coverage |
|---|---:|---|
| \`wire_test.go\` | 7 | Job HASH parity, Priority, Delay pickup, Retention {count,age}, JobName, ListJobs vs Queue.getJobs, Counts vs Queue.getJobCounts |
| \`mutation_test.go\` | 7 | Update Progress/Data/Log read by BullMQ, Remove/Promote/Retry observed via Job.getState, Drain via getJobCounts |
| \`retry_test.go\` | 1 | mkq Add WithAttempts+WithBackoff under failing BullMQ Worker; atm + failedReason convergence |
| \`stalled_test.go\` | 1 | BullMQ Worker SIGKILL'd mid-handler, mkq stalled scanner reclaims |
| \`ratelimit_test.go\` | 1 | mkq + BullMQ Workers concurrent on same queue + same WithRateLimit; combined throughput throttled |
| \`events_extra_test.go\` | 1 | BullMQ TS QueueEvents listener observes mkq-emitted wire frames (inverse of PR #31) |
| \`schedule_options_test.go\` | 3 | Schedule HASH \`limit\` / \`endDate\` / \`tz\` field shapes |
| \`dedup_test.go\` | 2 | mkq→BullMQ and BullMQ→mkq dedup; existing job ID surfaces without dup enqueue |

### New node helpers (in \`tests/interop/node/\`)

- **\`inspector.js\`** — subcommand-driven JSON dumper for Queue.getJob / getState / getJobCounts / getJobs / getJobLogs. Used everywhere a test verifies "BullMQ reads what mkq wrote".
- **\`events-listener.js\`** — QueueEvents subscriber streaming JSON lines for the inverse-events scenario.
- **\`helpers_test.go\`** (Go side) — \`nodeWorkerOpts\` / \`nodeEnqueuerOpts\` for parameterised invocations + \`startEventsListener\` factored out of the new event coverage. Existing \`startNodeWorker\` (in \`interop_test.go\`) unchanged so PR #5–#51's interop tests still pass on the same harness.

### Helper extensions

- \`worker.js\` accepts optional \`INTEROP_FAIL\` / \`CONCURRENCY\` / \`LIMITER\` / \`LOCK_DURATION_MS\` / \`HOLD_MS\` env. Defaults preserve PR #24's behaviour.
- \`enqueuer.js\` accepts optional \`INTEROP_NAME\` / \`INTEROP_OPTS\` (full BullMQ JobsOptions JSON forwarded verbatim).

## Notable finding (test-side workaround, not an mkq bug)

\`stalled_test.go\` caught a deployment-relevant point: BullMQ TS's worker writes the queue-shared \`stalled-check\` key with a long TTL (~30s), which blocks the equivalent scanner in **any** other worker — including mkq's. Production deployments mixing mkq + BullMQ workers should configure them to use the same stalled-check cadence; the test works around it by DEL'ing the stalled-check key after killing BullMQ. The mkq wire path matches BullMQ's exactly.

## Verification

- \`go test -tags=interop ./tests/interop/...\` — 29 PASS, 0 FAIL.
- 3× sequential sweep stable (~15s per sweep).
- Default \`go test ./... -count=1 -timeout 120s\` still green.
- \`gofmt\` clean.

## Out of Scope (audit confirmed deferred)

Section 3 of the audit confirmed these are intentionally out-of-scope-by-design (no public mkq API surface, no vendored Lua):

- Flow producer / parent-child orchestration
- Sandboxed processors
- Pause / resume / global concurrency / global rate limit
- Clean / obliterate / changeDelay / changePriority / addBulk / getWorkers / getRateLimitTtl
- Explicit telemetry hooks (Phase 6 observability follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
