### PR TITLE
Phase 6 docs: README + asynq migration guide + godoc audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,299 @@
+# mkq
+
+BullMQ-compatible Go-native job queue. Drop-in replacement for
+[asynq](https://github.com/hibiken/asynq) with a Redis layout that
+[bull-board](https://github.com/felixmosh/bull-board), Misskey admin
+UIs, and BullMQ workers in any language can share without translation.
+
+```go
+import "github.com/shiroha-a/mkq"
+
+queue := mkq.Define[Email](client, "email")
+queue.Add(ctx, Email{To: "alice@example.com"}, mkq.WithAttempts(3))
+
+mkq.Process(queue, func(ctx context.Context, job *mkq.Job[Email]) (any, error) {
+    return nil, send(job.Data)
+})
+```
+
+## Why mkq
+
+- **Wire-compatible with BullMQ v5+.** Foreign workers, bull-board,
+  and other-language tooling read mkq's queues as ordinary BullMQ
+  queues — no shim, no translation. Cross-language interop is covered
+  by 29 integration tests against the real BullMQ TS library.
+- **Go-native API.** Generics for typed payloads, context-aware
+  handlers, structured options. No mirroring of BullMQ's JS class
+  hierarchy.
+- **Engineered for throughput.** Marker-based BZPopMin dispatch,
+  fetchNext prefetch, msgpack encoder pooling. Beats BullMQ TS on
+  consume throughput at concurrency ≥ 64; competitive at lower
+  concurrencies. p99 handler-to-completion latency is mkq-favored
+  1.33–1.48× across configurations.
+- **Observability-ready.** Logger / Metrics / Tracer interfaces with
+  opt-in slog / Prometheus / OTel adapters. Default = noop, no
+  third-party deps in core.
+
+## Status
+
+Pre-1.0. Wire format is stable. API surface is stable for everything
+in this README; observability adapters and Inspector API may gain
+methods (additive only) before the 1.0 tag. See [#1] for the
+roadmap.
+
+[#1]: https://github.com/shiroha-a/mkq/issues/1
+
+## Install
+
+```sh
+go get github.com/shiroha-a/mkq
+```
+
+Requires Go 1.25+ and Redis 7+ (Redis 6.2+ also works; tested against
+the official `redis:7-alpine` container).
+
+## Quickstart
+
+### Producer
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+    "time"
+
+    "github.com/redis/go-redis/v9"
+    "github.com/shiroha-a/mkq"
+)
+
+type Email struct {
+    To      string `json:"to"`
+    Subject string `json:"subject"`
+}
+
+func main() {
+    ctx := context.Background()
+
+    client, err := mkq.NewClient(ctx, mkq.Config{
+        Redis: redis.UniversalOptions{Addrs: []string{"localhost:6379"}},
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer client.Close()
+
+    queue := mkq.Define[Email](client, "email")
+
+    // Standard add.
+    _, err = queue.Add(ctx, Email{To: "alice@example.com", Subject: "hi"})
+
+    // Delayed + retry-on-failure with exponential backoff.
+    _, err = queue.Add(ctx,
+        Email{To: "bob@example.com", Subject: "later"},
+        mkq.WithDelay(5*time.Second),
+        mkq.WithAttempts(5),
+        mkq.WithBackoff(mkq.ExponentialBackoff(time.Second)),
+    )
+
+    // Idempotent enqueue (dedup hit returns ErrDuplicateJob).
+    _, err = queue.Add(ctx,
+        Email{To: "carol@example.com"},
+        mkq.WithUnique("welcome:carol", time.Hour),
+    )
+    _ = err
+}
+```
+
+### Consumer
+
+```go
+worker, err := mkq.Process(queue,
+    func(ctx context.Context, job *mkq.Job[Email]) (any, error) {
+        if err := send(job.Data); err != nil {
+            return nil, err // counts toward WithAttempts; retries respect WithBackoff
+        }
+        return nil, nil
+    },
+    mkq.WithConcurrency(16),
+    mkq.WithLockDuration(30*time.Second),
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer worker.Stop(context.Background())
+```
+
+### Recurring schedule
+
+```go
+// Every 5 minutes.
+err := queue.UpsertScheduleEvery(ctx, "metrics-cron", 5*time.Minute, Email{})
+
+// Cron pattern (5-field, Vixie syntax via robfig/cron/v3).
+err = queue.UpsertSchedulePattern(ctx, "midnight-job", "0 0 * * *", Email{},
+    mkq.WithScheduleTimezone("Asia/Tokyo"),
+    mkq.WithScheduleLimit(30),
+)
+```
+
+### Inspector
+
+Read-only admin lookup (cross-compatible with bull-board's view of
+the same queues):
+
+```go
+counts, _   := queue.Counts(ctx) // {Wait, Active, Completed, Failed, Delayed, ...}
+listed, _   := queue.ListJobs(ctx, mkq.JobBucketWait, 0, 99, true) // ascending=true
+job, st, _  := queue.Get(ctx, listed[0].Job.ID)
+_ = st // post-finalisation snapshot (returnvalue, processedOn, etc.)
+```
+
+Mutations:
+
+```go
+queue.RetryJob(ctx, jobID)
+queue.PromoteJob(ctx, jobID)
+queue.RemoveJob(ctx, jobID)
+queue.DrainPending(ctx, mkq.WithDrainDelayed(true))
+```
+
+### Job mutation from inside a handler
+
+```go
+mkq.Process(queue, func(ctx context.Context, job *mkq.Job[Upload]) (any, error) {
+    for i, chunk := range job.Data.Chunks {
+        upload(chunk)
+        _ = job.UpdateProgress(ctx, float64(i+1)/float64(len(job.Data.Chunks)))
+        _ = job.Log(ctx, fmt.Sprintf("chunk %d done", i))
+    }
+    return nil, nil
+})
+```
+
+## Observability
+
+Three optional interfaces — Logger / Metrics / Tracer — default to
+noop. Wire any combination via `Config`:
+
+```go
+import (
+    "log/slog"
+
+    "github.com/prometheus/client_golang/prometheus"
+    "go.opentelemetry.io/otel"
+
+    "github.com/shiroha-a/mkq"
+    "github.com/shiroha-a/mkq/observability/oteladapter"
+    "github.com/shiroha-a/mkq/observability/promadapter"
+    "github.com/shiroha-a/mkq/observability/slogadapter"
+)
+
+client, _ := mkq.NewClient(ctx, mkq.Config{
+    Redis:   redis.UniversalOptions{Addrs: []string{"localhost:6379"}},
+    Logger:  slogadapter.New(slog.Default()),
+    Metrics: promadapter.New(prometheus.DefaultRegisterer),
+    Tracer:  oteladapter.New(otel.Tracer("mkq")),
+})
+```
+
+The adapters live in dedicated sub-packages so importers of core mkq
+do not pull in `prometheus/client_golang` or the OTel SDK unless they
+opt in.
+
+Metrics emitted (initial set):
+
+| Name | Type | Labels |
+|---|---|---|
+| `mkq_jobs_added_total` | counter | queue, name |
+| `mkq_jobs_processed_total` | counter | queue, name, status |
+| `mkq_handler_duration_seconds` | histogram | queue, name |
+| `mkq_dispatch_wait_seconds` | histogram | queue |
+| `mkq_jobs_in_flight` | gauge | queue |
+
+Spans:
+
+- `mkq.queue.add` — around `Queue.Add`
+- `mkq.worker.process` — parent of any user spans created inside the
+  handler
+
+## Cross-language interop with BullMQ
+
+mkq's Redis layout is a strict subset of BullMQ v5+'s. A typical
+mixed-runtime deployment looks like:
+
+- **Go services** use mkq for producers and consumers.
+- **Node services** keep using BullMQ TS for producers and consumers
+  on the same queues (no flag, no migration).
+- **Operators** point bull-board / Misskey admin / other dashboards
+  at the same Redis instance.
+
+mkq's interop test suite continuously validates the directions both
+ways: BullMQ TS Add → mkq Process and mkq Add → BullMQ TS Process,
+plus admin paths (Inspector mutations, QueueEvents subscriptions,
+shared rate-limit windows, dedup, schedulers, retry/backoff,
+stalled-job recovery).
+
+See [docs/MIGRATING_FROM_ASYNQ.md](docs/MIGRATING_FROM_ASYNQ.md) for
+the asynq → mkq migration walkthrough.
+
+## Features
+
+- **Job lifecycle**: Add / Process / retry-on-error / WithAttempts /
+  WithBackoff (Fixed, Exponential) / panic recovery / ErrUnrecoverable.
+- **Job options**: WithDelay, WithPriority, WithLifo,
+  WithKeepCompleted/Failed (count + age), WithDeduplication / WithUnique,
+  WithJobName, WithJobID.
+- **Worker options**: WithConcurrency, WithLockDuration,
+  WithStalledInterval, WithMaxStalledCount, WithIdlePollInterval,
+  WithRateLimit, WithWorkerName.
+- **Recurring schedules**: every-mode and cron-pattern mode, with
+  WithScheduleLimit / StartDate / EndDate / Timezone / Immediately.
+- **QueueEvents**: subscribe to BullMQ's `events` stream
+  (added / active / completed / failed / progress / stalled / drained).
+- **Inspector** (read): `Queue.Counts`, `Queue.ListJobs`,
+  `Queue.Get`, `Client.Queues`.
+- **Inspector** (admin): `Queue.RemoveJob`, `Queue.DrainPending`,
+  `Queue.PromoteJob`, `Queue.RetryJob`.
+- **Job mutation from handler**: `Job.UpdateProgress`,
+  `Job.UpdateData`, `Job.Log`; out-of-band `Queue.UpdateJobProgress`,
+  `Queue.UpdateJobData`, `Queue.AppendJobLog`.
+- **Observability**: Logger / Metrics / Tracer interfaces, slog /
+  Prometheus / OTel adapters.
+- **Stalled detection**: cross-language compatible (mkq's scanner
+  recovers BullMQ-orphaned jobs and vice versa).
+
+## Compatibility caveats
+
+- **Cluster mode**: tested against go-redis cluster clients;
+  cross-slot operations are avoided as in BullMQ.
+- **Pool sizing**: BZPopMin holds a connection per worker slot.
+  Set `Config.Redis.PoolSize` to at least `concurrency + 8`. mkq
+  warns at startup when the configured pool is below this.
+- **Redis 6.0 and earlier**: untested. The vendored Lua scripts use
+  Redis 7-shaped command paths in places.
+
+## Documentation
+
+- Package godoc: https://pkg.go.dev/github.com/shiroha-a/mkq
+- Migration from asynq: [docs/MIGRATING_FROM_ASYNQ.md](docs/MIGRATING_FROM_ASYNQ.md)
+- Authoritative design (mk-go repo):
+  https://github.com/shiroha-a/mk/blob/develop/docs/design/mkq-design.md
+
+## Development
+
+- `go test ./...` (requires a local Redis on `127.0.0.1:6379` or
+  `MKQ_TEST_REDIS_ADDR`).
+- `go test -tags interop ./tests/interop/...` runs the cross-language
+  test suite against a vendored BullMQ TS and Node 20+.
+- `bench/run.sh` runs the throughput / latency / memory benchmark
+  vs BullMQ TS.
+
+Contributions: file an issue first, branch off `develop`, follow
+`CLAUDE.md` for commit / PR conventions.
+
+## License
+
+mkq is released under the MIT License. See `THIRD_PARTY_NOTICES.md`
+for the BullMQ Lua scripts vendored under the same terms.

--- a/docs/MIGRATING_FROM_ASYNQ.md
+++ b/docs/MIGRATING_FROM_ASYNQ.md
@@ -1,0 +1,313 @@
+# Migrating from asynq to mkq
+
+mkq is designed as a drop-in replacement for asynq when the
+underlying queue needs to interoperate with BullMQ — for example,
+when an admin UI like bull-board, or workers in another language,
+need to share queues with the Go side.
+
+This guide assumes a working asynq deployment and walks through the
+mechanical replacements. mkq's API is intentionally close to
+asynq's where the semantics line up, so most call sites change a
+package import and an option name.
+
+## When to migrate
+
+Reach for mkq when **any** of the following apply:
+
+- You operate a polyglot stack and want a single Redis-backed queue
+  visible to Go (mkq), Node (BullMQ), and admin UIs (bull-board) —
+  asynq's wire format is internal-only and cannot be read by
+  cross-language tools.
+- You want to plug an existing BullMQ deployment (Misskey, etc.)
+  into a Go service without writing a translation layer.
+- You need BullMQ-only features that asynq does not expose, such
+  as recurring schedulers (every / cron) with limit + endDate, the
+  job-mutation API (`UpdateProgress` / `Log`), or the QueueEvents
+  stream.
+
+If you only need a Go-only queue and have no BullMQ in your stack,
+asynq is fine — there is no functional reason to migrate purely for
+its own sake.
+
+## Conceptual mapping
+
+| Asynq concept | mkq equivalent | Notes |
+|---|---|---|
+| `asynq.Client` | `mkq.Client` | Constructed via `mkq.NewClient(ctx, mkq.Config{...})`. |
+| `asynq.NewTask("name", payload)` | `mkq.Define[T](client, "queue")` + `Queue.Add(ctx, payload, ...)` | mkq is generic over the payload type — no manual `[]byte` marshal. |
+| `client.Enqueue(task, opts...)` | `queue.Add(ctx, payload, opts...)` | Same shape; options listed below. |
+| `asynq.Server` + `mux` | `mkq.Process(queue, handler)` | One handler per queue. Use multiple `Process` calls if you have multiple queues; use a switch on `job.Name` for per-task-type fan-out within one queue. |
+| `srv.Run(mux)` | (n/a — `mkq.Process` returns immediately, runs in goroutines) | mkq does not block the calling goroutine; call `worker.Stop(ctx)` to drain. |
+| `asynq.Inspector` | `mkq.Queue` (`Counts`, `ListJobs`, `Get`, `RemoveJob`, `RetryJob`, `PromoteJob`, `DrainPending`) | Methods land on the typed `Queue` itself, not a separate Inspector handle. |
+| `*asynq.Task.ID` | `*mkq.Job[T].ID` | Plain string in both. |
+| `task.ResultWriter()` | `Job.UpdateProgress` / `Job.UpdateData` / `Job.Log` | mkq mirrors BullMQ's job-mutation API, which has overlapping but not identical semantics. |
+| `asynq.MaxRetry(n)` | `mkq.WithAttempts(n)` | Same meaning. |
+| `asynq.Retention(d)` | `mkq.WithKeepCompletedAge(d)` + `mkq.WithKeepFailedAge(d)` | mkq splits completed and failed retention because BullMQ does. |
+| `asynq.Unique(d)` | `mkq.WithUnique(id, d)` | mkq requires an explicit dedup id. The id can be a hash of the payload — see the producer example below. |
+| `asynq.ProcessIn(d)` | `mkq.WithDelay(d)` | Same. |
+| `asynq.ProcessAt(t)` | `mkq.WithDelay(time.Until(t))` | mkq encodes delay relative to enqueue time, like BullMQ. |
+| `asynq.Queue("critical")` | `mkq.Define[T](client, "critical")` | The queue name lives on the typed handle, not on each Add. |
+| `asynq.Group("...")` (Pro) | (no direct equivalent) | Group aggregation is asynq-specific. |
+| `asynq.PeriodicTaskManager` | `Queue.UpsertScheduleEvery` / `UpsertSchedulePattern` | mkq schedules live in Redis (BullMQ-compatible), not in a Go-side manager. |
+
+## Producer
+
+### Asynq
+
+```go
+client := asynq.NewClient(asynq.RedisClientOpt{Addr: "localhost:6379"})
+defer client.Close()
+
+payload, _ := json.Marshal(EmailPayload{To: "a@example.com"})
+task := asynq.NewTask("email:welcome", payload)
+
+_, err := client.Enqueue(task,
+    asynq.MaxRetry(3),
+    asynq.ProcessIn(5*time.Second),
+    asynq.Unique(time.Hour),
+)
+```
+
+### mkq
+
+```go
+client, _ := mkq.NewClient(ctx, mkq.Config{
+    Redis: redis.UniversalOptions{Addrs: []string{"localhost:6379"}},
+})
+defer client.Close()
+
+queue := mkq.Define[EmailPayload](client, "email")
+
+_, err := queue.Add(ctx,
+    EmailPayload{To: "a@example.com"},
+    mkq.WithJobName("email:welcome"),       // optional, used for per-task-type dispatch in Process
+    mkq.WithAttempts(3),
+    mkq.WithDelay(5*time.Second),
+    mkq.WithUnique("welcome:a@example.com", time.Hour),
+)
+```
+
+Differences worth noting:
+
+- mkq is generic over the payload — no manual `json.Marshal`.
+- `WithJobName` is the BullMQ-side `name` field. It is optional;
+  default is the queue name. Use it to fan out one queue across
+  multiple task types in `Process`.
+- `WithUnique` requires an explicit dedup id (asynq derives one
+  from the payload). The id is your call — common choices: hash of
+  the payload, the user/inbox id, a logical operation key.
+
+## Consumer
+
+### Asynq
+
+```go
+srv := asynq.NewServer(
+    asynq.RedisClientOpt{Addr: "localhost:6379"},
+    asynq.Config{Concurrency: 16},
+)
+
+mux := asynq.NewServeMux()
+mux.HandleFunc("email:welcome", func(ctx context.Context, t *asynq.Task) error {
+    var p EmailPayload
+    _ = json.Unmarshal(t.Payload(), &p)
+    return send(p)
+})
+
+if err := srv.Run(mux); err != nil { log.Fatal(err) }
+```
+
+### mkq
+
+```go
+queue := mkq.Define[EmailPayload](client, "email")
+
+worker, _ := mkq.Process(queue,
+    func(ctx context.Context, job *mkq.Job[EmailPayload]) (any, error) {
+        switch job.Name {
+        case "email:welcome":
+            return nil, send(job.Data)
+        case "email:reset":
+            return nil, sendReset(job.Data)
+        default:
+            return nil, fmt.Errorf("unknown task: %s", job.Name)
+        }
+    },
+    mkq.WithConcurrency(16),
+)
+
+defer worker.Stop(context.Background())
+```
+
+`Process` returns immediately; the worker runs in goroutines. Call
+`Stop` to drain. There is no `srv.Run(mux)` blocker — wire the
+graceful shutdown to your service lifecycle of choice (e.g. an
+errgroup or signal handler).
+
+## Retry and backoff
+
+### Asynq
+
+```go
+client.Enqueue(task,
+    asynq.MaxRetry(5),
+    asynq.RetryUntil(time.Now().Add(1*time.Hour)),
+)
+```
+
+Asynq backoff is fixed exponential by default; override via
+`asynq.Config.RetryDelayFunc`.
+
+### mkq
+
+```go
+queue.Add(ctx, payload,
+    mkq.WithAttempts(5),
+    mkq.WithBackoff(mkq.ExponentialBackoff(time.Second)), // or FixedBackoff(d)
+)
+```
+
+Backoff strategy lives on each Add (BullMQ semantics) rather than
+the server config. To force a non-retryable error from inside the
+handler:
+
+```go
+return nil, fmt.Errorf("payment declined: %w", mkq.ErrUnrecoverable)
+```
+
+## Unique / deduplication
+
+### Asynq
+
+```go
+client.Enqueue(task, asynq.Unique(time.Hour)) // id derived from payload
+```
+
+### mkq
+
+```go
+queue.Add(ctx, payload, mkq.WithUnique("unique-id", time.Hour))
+// returns ErrDuplicateJob (with the existing job ptr) on hit
+```
+
+If you want the asynq-style "hash of payload" behavior, hash the
+payload yourself:
+
+```go
+h := sha256.Sum256(mustJSON(payload))
+mkq.WithUnique(hex.EncodeToString(h[:]), time.Hour)
+```
+
+## Recurring schedules
+
+Asynq exposes `PeriodicTaskManager` (Go-side manager that re-enqueues
+on a tick). mkq stores schedules in Redis using BullMQ's wire format,
+so they survive Go process restarts and are visible to bull-board.
+
+### mkq
+
+```go
+// Every 30 minutes.
+queue.UpsertScheduleEvery(ctx, "metrics-cron", 30*time.Minute, MetricsPayload{})
+
+// Cron pattern (Vixie 5-field, parsed via robfig/cron/v3).
+queue.UpsertSchedulePattern(ctx, "midnight-summary", "0 0 * * *", SummaryPayload{},
+    mkq.WithScheduleTimezone("Asia/Tokyo"),
+    mkq.WithScheduleLimit(30),
+    mkq.WithScheduleEndDate(time.Now().Add(30*24*time.Hour)),
+)
+
+// Stop a schedule.
+queue.RemoveSchedule(ctx, "metrics-cron")
+```
+
+There is no asynq equivalent to `WithScheduleLimit` (cap N
+iterations) or `WithScheduleEndDate` (stop at T). These are BullMQ
+features.
+
+## Inspector
+
+### Asynq
+
+```go
+inspector := asynq.NewInspector(asynq.RedisClientOpt{Addr: ...})
+inspector.GetQueueInfo("email")
+inspector.ListPendingTasks("email")
+inspector.DeleteTask("email", taskID)
+```
+
+### mkq
+
+```go
+counts, _   := queue.Counts(ctx)                                       // QueueCounts{Wait, Active, Completed, Failed, Delayed, Prioritized, Paused}
+listed, _   := queue.ListJobs(ctx, mkq.JobBucketWait, 0, 99, true)     // ascending=true
+job, st, _  := queue.Get(ctx, listed[0].Job.ID)                        // *Job[T] + *JobState
+
+queue.RetryJob(ctx, job.ID)                                            // failed -> wait
+queue.PromoteJob(ctx, job.ID)                                          // delayed -> wait
+queue.RemoveJob(ctx, job.ID)
+queue.DrainPending(ctx, mkq.WithDrainDelayed(true))
+_ = st
+```
+
+The Inspector methods live on the typed `Queue` directly. There is
+no separate Inspector handle.
+
+## Job mutation from inside a handler
+
+```go
+mkq.Process(queue, func(ctx context.Context, job *mkq.Job[Upload]) (any, error) {
+    for i, chunk := range job.Data.Chunks {
+        upload(chunk)
+        _ = job.UpdateProgress(ctx, float64(i+1)/float64(len(job.Data.Chunks)))
+        _ = job.Log(ctx, fmt.Sprintf("chunk %d done", i))
+    }
+    return nil, nil
+})
+```
+
+Asynq has `task.ResultWriter()` for return-value streaming; mkq's
+job-mutation API is BullMQ-shaped and emits `progress` events on
+QueueEvents (for live UI updates).
+
+## What does not migrate
+
+mkq deliberately does not implement these asynq-specific features:
+
+- **Group aggregation** (`asynq.Group("...")`). asynq-Pro feature
+  with no BullMQ analogue.
+- **Server-side scheduler manager** (`PeriodicTaskManager`). mkq's
+  schedules live in Redis — see Recurring Schedules above.
+- **Per-server middleware** (`asynq.MiddlewareFunc`). Wrap your
+  handler manually if you need this; mkq does not provide a chain.
+- **Result writer for streaming partial outputs.** Use
+  `Job.UpdateData` to overwrite the data field with intermediate
+  state if you need similar functionality.
+
+## Driver swap in mk-go
+
+mk-go's queue layer is an `asynq` interface today. The migration
+plan replaces `AsynqDriver` with a new `MkqDriver` that implements
+the same interface against this library. The mk-go-side PR is
+tracked separately; on the mkq side, the API is stable enough that
+the driver implementation has no remaining blockers.
+
+If you are integrating mkq into a code base that previously used
+asynq, the mechanical recipe is:
+
+1. Replace `asynq.NewClient(...)` with `mkq.NewClient(ctx, ...)`.
+2. Replace `asynq.NewTask("name", payload)` + `client.Enqueue(...)`
+   with `queue.Add(ctx, payload, mkq.WithJobName("name"), ...)`.
+3. Replace the `asynq.Server` + `mux` setup with one or more
+   `mkq.Process(queue, handler)` calls; switch on `job.Name`
+   inside the handler if you previously used a mux.
+4. Translate options per the table at the top of this doc.
+5. Replace `asynq.Inspector` calls with the equivalent
+   `Queue.Counts` / `Queue.ListJobs` / `Queue.Get` /
+   `Queue.RemoveJob` / `Queue.RetryJob` / `Queue.PromoteJob` /
+   `Queue.DrainPending` calls.
+
+For ops, the largest change is that bull-board (or any BullMQ-aware
+admin UI) now sees the Go-side queues. asynq's web UI no longer
+applies — but bull-board is more capable, so this is generally a
+gain.

--- a/job.go
+++ b/job.go
@@ -19,8 +19,9 @@ type Job[T any] struct {
 	// ID is the BullMQ job id. Numeric for auto-allocated jobs;
 	// arbitrary string when WithJobID is used.
 	ID string
-	// Name is the BullMQ job name. mkq sets this to the queue name
-	// today; future work may expose per-Add naming.
+	// Name is the BullMQ job name. Defaults to the queue name; can
+	// be overridden per Add via WithJobName, which is the recommended
+	// way to fan one queue out across multiple task types.
 	Name string
 	// Data is the user payload, as it was passed to Add.
 	Data T


### PR DESCRIPTION
## Summary

Closes #55. Last functional item before the 1.0 tag. Adds:
1. **README.md** — first-impression doc with overview, install, quickstart, observability example, interop notes, feature checklist.
2. **docs/MIGRATING_FROM_ASYNQ.md** — API mapping table + side-by-side code samples for the patterns mk-go uses; "what does not migrate" list.
3. **Godoc audit pass** — light fix to one stale Job.Name comment; spot-checked the rest of the public surface.

## Key Changes

**README.md** (~250 lines)
- Quickstart covers producer (3 patterns), consumer with `job.Name` dispatch, recurring schedule (every + cron), inspector (read + admin), in-handler mutation.
- Observability section shows the full `Config` with all three opt-in adapters, plus metric table and span list.
- Feature checklist enumerates everything mkq exposes for 1.0.
- Compatibility caveats covering cluster mode, pool sizing, and Redis 6.

**docs/MIGRATING_FROM_ASYNQ.md** (~270 lines)
- "When to migrate" gate at the top so Go-only stacks don't migrate unnecessarily.
- Conceptual mapping table (Client/Task/Inspector/MaxRetry/Unique/etc.).
- Side-by-side asynq vs mkq for producer / consumer / retry / unique / scheduler / inspector / in-handler mutation.
- Explicit "what does not migrate" list (group aggregation, periodic-task-manager, middleware, result writer).
- Driver swap recipe for mk-go integration.

**Godoc audit**
- `Job.Name` comment said "future work may expose per-Add naming" — `WithJobName` has shipped; rewritten.
- Spot-checked Logger / Metrics / Tracer / Queue / Worker / QueueEvents / JobBucket / BackoffStrategy — all already comprehensive.

## Out of scope (deferred)

- BullMQ wire format documentation (mk-go design doc is authoritative).
- Standalone "Usage Guide" — covered by README quickstart + godoc + migration guide together.
- Per-feature deep-dive guides (cron syntax, rate-limiter tuning) — defer until ops asks.

## Testing

```
go test -count=1 ./...
```
All 8 packages green. No code-level changes beyond the one Job.Name godoc fix.

## Related Issue

#55. Tracking: #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
