### PR TITLE
chore: bump Version to 1.0.1-dev (post-v1.0.0)

### DIFF
--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ package mkq
 // runtime/debug.ReadBuildInfo so it stays meaningful in unit tests
 // and in users who vendor mkq via tooling that doesn't preserve
 // build info. Bump it on every release.
-const Version = "1.0.0"
+const Version = "1.0.1-dev"
 
 // versionTag is the value written to meta.version. BullMQ TS writes
 // `bullmq:<semver>`; mkq mirrors the convention with a `mkq:` prefix


### PR DESCRIPTION
## Summary

Post-release version bump. Reverts the version literal back to a \`-dev\` marker now that v1.0.0 has been tagged on main. Subsequent feature / fix PRs flow through develop under the \`1.0.1-dev\` marker; the next release bumps it again.

## Testing

\`\`\`
go build ./...
\`\`\`
The const ships into the BullMQ \`meta\` HASH at \`Queue.Define\` time as \`mkq:1.0.1-dev\`, identifying queues touched by the in-development branch versus the released v1.0.0 client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
