### PR TITLE
release: v1.0.1 — CHANGELOG + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-04-27
+
+### Added
+
+- BullMQ-compatible per-queue metrics (#59, #60). Enables the
+  previously-disabled write path inside the vendored
+  `moveToFinished-14.lua` so per-minute completed/failed buckets
+  land in the BullMQ-spec keys (`bull:<q>:metrics:<target>` HASH +
+  `...:data` LIST). bull-board / Misskey admin / mk-go admin
+  charts that LRANGE the BullMQ key now see real data. Adopts
+  BullMQ TS's API shape exactly:
+  - `WithJobMetrics(maxDataPoints int) WorkerOption` — opt-in
+    write path; mirrors BullMQ TS `WorkerOptions.metrics:
+    { maxDataPoints }`.
+  - `Queue[T].GetMetrics(ctx, kind, start, end) (QueueMetrics, error)`
+    — atomic read via vendored `getMetrics-2.lua`.
+  - `QueueMetrics{Meta: QueueMetricsMeta{Count, PrevTS, PrevCount},
+    Data, Count}` matches BullMQ TS `Metrics` interface.
+  - `ErrInvalidMetricsBucket` for non-completed/failed kinds.
+
+### Notes
+
+- This release is a strict additive minor under semver (no
+  breaking changes); kept on the patch line per the project's
+  early-stage `1.0.x` cadence.
+
 ## [1.0.0] - 2026-04-27
 
 Initial stable release. Wire format and public API are stable from
@@ -117,5 +143,6 @@ fix bugs without breaking existing callers.
   TS pull ahead 1.24× at concurrency=16. Documented as the
   Redis-client-level gap in `bench/README.md`.
 
-[Unreleased]: https://github.com/shiroha-a/mkq/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/shiroha-a/mkq/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/shiroha-a/mkq/releases/tag/v1.0.1
 [1.0.0]: https://github.com/shiroha-a/mkq/releases/tag/v1.0.0

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ package mkq
 // runtime/debug.ReadBuildInfo so it stays meaningful in unit tests
 // and in users who vendor mkq via tooling that doesn't preserve
 // build info. Bump it on every release.
-const Version = "1.0.1-dev"
+const Version = "1.0.1"
 
 // versionTag is the value written to meta.version. BullMQ TS writes
 // `bullmq:<semver>`; mkq mirrors the convention with a `mkq:` prefix


### PR DESCRIPTION
## Summary

Patch release adding BullMQ-compatible per-queue metrics on top of 1.0.0. Strict semver would treat the additive surface as a minor bump (1.1.0); kept on the 1.0.x patch line per the project's early-stage cadence.

## Key Changes

- \`version.go\` — bump from \`1.0.1-dev\` to \`1.0.1\`. The const ships into the BullMQ \`meta\` HASH at \`Queue.Define\` time as \`mkq:1.0.1\`.
- \`CHANGELOG.md\` — adds a 1.0.1 section pointing at #59 / #60 and the new public surface (\`WithJobMetrics\`, \`Queue.GetMetrics\`, \`QueueMetrics\` / \`QueueMetricsMeta\`, \`ErrInvalidMetricsBucket\`).

## Post-merge plan

1. Fast-forward \`main\` to \`develop\`'s tip.
2. Tag \`v1.0.1\` on the merged commit.
3. Cut a GitHub release with notes mirroring \`CHANGELOG.md\`.
4. Follow-up PR on \`develop\`: bump \`Version\` to \`1.0.2-dev\`.

## Testing

\`\`\`
go build ./...
\`\`\`
The version literal is the only behaviourally-visible change.

## Related

#59 / #60 — BullMQ-compatible per-queue metrics, the sole feature folded into this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mkq/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
