### PR TITLE
feat: custom / jittered backoff strategy (Misskey httpRelatedBackoff parity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,13 +241,14 @@ the asynq → mkq migration walkthrough.
 ## Features
 
 - **Job lifecycle**: Add / Process / retry-on-error / WithAttempts /
-  WithBackoff (Fixed, Exponential) / panic recovery / ErrUnrecoverable.
+  WithBackoff (Fixed, Exponential, jitter, custom strategy) / panic
+  recovery / ErrUnrecoverable.
 - **Job options**: WithDelay, WithPriority, WithLifo,
   WithKeepCompleted/Failed (count + age), WithDeduplication / WithUnique,
   WithJobName, WithJobID.
 - **Worker options**: WithConcurrency, WithLockDuration,
   WithStalledInterval, WithMaxStalledCount, WithIdlePollInterval,
-  WithRateLimit, WithWorkerName.
+  WithRateLimit, WithWorkerName, WithBackoffStrategy, WithJobMetrics.
 - **Recurring schedules**: every-mode and cron-pattern mode, with
   WithScheduleLimit / StartDate / EndDate / Timezone / Immediately.
 - **QueueEvents**: subscribe to BullMQ's `events` stream

--- a/backoff.go
+++ b/backoff.go
@@ -6,41 +6,88 @@ import (
 )
 
 // BackoffStrategy describes a BullMQ-compatible backoff. The on-Redis
-// JSON shape is {"type": "...", "delay": <ms>}; mkq mirrors it
-// verbatim.
+// JSON shape is {"type": "...", "delay": <ms>, "jitter": <0..1>};
+// mkq mirrors it verbatim.
 type BackoffStrategy struct {
-	// Type is "fixed" or "exponential" — the values BullMQ recognises
-	// out of the box. Custom strategies (BullMQ's "custom" type) are
-	// out of scope for the initial release.
+	// Type is "fixed", "exponential" (the values BullMQ recognises out
+	// of the box), or "custom" (BullMQ's settings.backoffStrategy
+	// path). For "custom", register the computation on the Worker via
+	// WithBackoffStrategy.
 	Type string
 	// Delay is the base delay; Type controls how it scales between
-	// retries.
+	// retries. Ignored for "custom".
 	Delay time.Duration
+	// Jitter is the BullMQ jitter fraction (0..1) applied to fixed /
+	// exponential delays to spread retries and ease thundering herds.
+	// 0 disables jitter. Ignored for "custom" (the registered strategy
+	// owns any jitter it wants).
+	Jitter float64
 }
+
+// CustomBackoffFunc computes the retry delay for a job whose backoff
+// Type is not a BullMQ built-in (e.g. "custom"). attemptsMade is the
+// post-bump attempt count (i.e. "this is attempt N"), matching the
+// argument BullMQ passes to settings.backoffStrategy.
+//
+// This is where a caller reproduces an arbitrary formula plus cap plus
+// jitter Go-side. mkq never persists a cap to Redis (BullMQ has no cap
+// field, so a foreign worker would ignore it); capping belongs here.
+type CustomBackoffFunc func(attemptsMade int) time.Duration
 
 // FixedBackoff retries on the same delay every attempt.
 func FixedBackoff(d time.Duration) BackoffStrategy {
 	return BackoffStrategy{Type: "fixed", Delay: d}
 }
 
-// ExponentialBackoff doubles the delay each attempt. BullMQ's built-in
-// exponential strategy does not accept a cap; callers that want a
-// ceiling will need a custom strategy in a follow-up release.
+// FixedBackoffWithJitter is FixedBackoff with a BullMQ jitter fraction
+// (0..1). The effective delay lands in [d*(1-jitter), d).
+func FixedBackoffWithJitter(d time.Duration, jitter float64) BackoffStrategy {
+	return BackoffStrategy{Type: "fixed", Delay: d, Jitter: jitter}
+}
+
+// ExponentialBackoff doubles the delay each attempt (delay * 2^(n-1)).
+// BullMQ's built-in exponential strategy does not accept a cap; callers
+// that want a ceiling should use a custom strategy (see CustomBackoff /
+// WithBackoffStrategy).
 func ExponentialBackoff(d time.Duration) BackoffStrategy {
 	return BackoffStrategy{Type: "exponential", Delay: d}
 }
 
+// ExponentialBackoffWithJitter is ExponentialBackoff with a BullMQ
+// jitter fraction (0..1). For attempt n the un-jittered delay is
+// delay*2^(n-1); the jittered result lands in [delay*2^(n-1)*(1-jitter),
+// delay*2^(n-1)).
+func ExponentialBackoffWithJitter(d time.Duration, jitter float64) BackoffStrategy {
+	return BackoffStrategy{Type: "exponential", Delay: d, Jitter: jitter}
+}
+
+// CustomBackoff marks a job as using the Worker-registered backoff
+// strategy (BullMQ's settings.backoffStrategy path). The on-Redis opts
+// store backoff as {"type": "custom"}; the actual delay is computed by
+// the CustomBackoffFunc registered via WithBackoffStrategy on the Worker
+// that processes the job.
+//
+// This is the most flexible option: arbitrary formula, cap, and jitter
+// all live in the registered Go function, so mk-go can reproduce
+// Misskey's httpRelatedBackoff ((2^n-1)*base, capped at 8h, +0..20%
+// jitter) verbatim.
+func CustomBackoff() BackoffStrategy {
+	return BackoffStrategy{Type: "custom"}
+}
+
 // computeBackoffDelay mirrors BullMQ's Backoffs.calculate worker-side
-// computation: the chosen delay is passed to Lua as a plain integer
-// so the wire-level retry script (retryJob / moveToDelayed) does not
-// know about strategy types.
+// computation for the built-in fixed / exponential strategies. It
+// returns the un-jittered base delay; jitter (and custom strategies)
+// are layered on by Worker.computeRetryDelay. The chosen delay is
+// passed to Lua as a plain integer so the wire-level retry script
+// (retryJob / moveToDelayed) does not know about strategy types.
 //
 // attemptsMade is the post-bump count (i.e. "this is attempt N");
 // BullMQ's exponential formula is `delay * 2^(attemptsMade-1)`.
 //
-// Returns 0 for an unset / nil strategy. Overflow is clamped to
-// math.MaxInt64 nanoseconds so a misconfigured exponential never
-// wraps negative.
+// Returns 0 for an unset / nil strategy or any non-built-in type.
+// Overflow is clamped to math.MaxInt64 nanoseconds so a misconfigured
+// exponential never wraps negative.
 func computeBackoffDelay(b *BackoffStrategy, attemptsMade int) time.Duration {
 	if b == nil || attemptsMade < 1 {
 		return 0
@@ -63,4 +110,27 @@ func computeBackoffDelay(b *BackoffStrategy, attemptsMade int) time.Duration {
 	default:
 		return 0
 	}
+}
+
+// applyJitter reproduces BullMQ's built-in jitter formula:
+//
+//	floor(random() * base * jitter + base * (1 - jitter))
+//
+// base is the un-jittered delay (delay for fixed, delay*2^(n-1) for
+// exponential), r is a random value in [0, 1), and jitter is the
+// fraction in (0, 1]. The result lands in [base*(1-jitter), base).
+// BullMQ's Math.floor is reproduced by the float64 -> time.Duration
+// truncation.
+//
+// jitter values outside (0, 1] are clamped so a misconfigured fraction
+// never produces a negative or above-base delay.
+func applyJitter(base time.Duration, jitter, r float64) time.Duration {
+	if jitter <= 0 {
+		return base
+	}
+	if jitter > 1 {
+		jitter = 1
+	}
+	minDelay := float64(base) * (1 - jitter)
+	return time.Duration(r*float64(base)*jitter + minDelay)
 }

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -76,3 +76,140 @@ func TestComputeBackoffDelay_AttemptsZeroOrNegative(t *testing.T) {
 		t.Errorf("attempt=-1 should return 0, got %v", got)
 	}
 }
+
+func TestBackoffConstructors(t *testing.T) {
+	t.Parallel()
+	if b := FixedBackoffWithJitter(2*time.Second, 0.3); b.Type != "fixed" || b.Delay != 2*time.Second || b.Jitter != 0.3 {
+		t.Errorf("FixedBackoffWithJitter: got %+v", b)
+	}
+	if b := ExponentialBackoffWithJitter(time.Second, 0.2); b.Type != "exponential" || b.Delay != time.Second || b.Jitter != 0.2 {
+		t.Errorf("ExponentialBackoffWithJitter: got %+v", b)
+	}
+	if b := CustomBackoff(); b.Type != "custom" || b.Delay != 0 || b.Jitter != 0 {
+		t.Errorf("CustomBackoff: got %+v", b)
+	}
+}
+
+func TestApplyJitter(t *testing.T) {
+	t.Parallel()
+	base := time.Duration(1000)
+	cases := []struct {
+		name   string
+		jitter float64
+		r      float64
+		want   time.Duration
+	}{
+		// floor(r*base*jitter + base*(1-jitter))
+		{"r=0 yields minDelay", 0.2, 0.0, 800},
+		{"r=0.5 mid", 0.2, 0.5, 900},
+		{"jitter=0 returns base", 0.0, 0.99, 1000},
+		{"jitter clamped above 1", 5.0, 0.0, 0}, // base*(1-1)=0
+		{"full jitter r=0", 1.0, 0.0, 0},
+	}
+	for _, c := range cases {
+		if got := applyJitter(base, c.jitter, c.r); got != c.want {
+			t.Errorf("%s: applyJitter(%v,%v,%v)=%v want %v", c.name, base, c.jitter, c.r, got, c.want)
+		}
+	}
+
+	// r in [0,1) keeps the result within [minDelay, base) for jitter in (0,1].
+	for _, r := range []float64{0, 0.25, 0.5, 0.75, 0.999} {
+		got := applyJitter(10000, 0.2, r)
+		if got < 8000 || got >= 10000 {
+			t.Errorf("jittered delay out of range for r=%v: got %v", r, got)
+		}
+	}
+}
+
+func TestComputeRetryDelay_BuiltinNoJitter(t *testing.T) {
+	t.Parallel()
+	// rng must not be consulted when Jitter == 0.
+	w := &Worker{rng: func() float64 { t.Fatal("rng called without jitter"); return 0 }}
+	fixed := FixedBackoff(150 * time.Millisecond)
+	if got := w.computeRetryDelay(&fixed, 5); got != 150*time.Millisecond {
+		t.Errorf("fixed: got %v", got)
+	}
+	exp := ExponentialBackoff(20 * time.Millisecond)
+	if got := w.computeRetryDelay(&exp, 3); got != 80*time.Millisecond {
+		t.Errorf("exp attempt=3: got %v want 80ms", got)
+	}
+}
+
+func TestComputeRetryDelay_BuiltinJitter(t *testing.T) {
+	t.Parallel()
+	w := &Worker{rng: func() float64 { return 0.5 }}
+	exp := ExponentialBackoffWithJitter(100*time.Millisecond, 0.2)
+	// attempt 3: base = 100ms * 2^2 = 400ms.
+	// jitter: 0.5*400*0.2 + 400*0.8 = 40 + 320 = 360ms.
+	if got := w.computeRetryDelay(&exp, 3); got != 360*time.Millisecond {
+		t.Errorf("exp+jitter: got %v want 360ms", got)
+	}
+}
+
+func TestComputeRetryDelay_Custom(t *testing.T) {
+	t.Parallel()
+	w := &Worker{backoffStrategy: func(attemptsMade int) time.Duration {
+		return time.Duration(attemptsMade) * time.Second
+	}}
+	b := CustomBackoff()
+	if got := w.computeRetryDelay(&b, 4); got != 4*time.Second {
+		t.Errorf("custom: got %v want 4s", got)
+	}
+
+	// Unregistered custom strategy falls back to immediate retry.
+	w2 := &Worker{}
+	if got := w2.computeRetryDelay(&b, 4); got != 0 {
+		t.Errorf("unregistered custom: got %v want 0", got)
+	}
+
+	// Unknown (non-built-in) type with no strategy also returns 0.
+	unknown := BackoffStrategy{Type: "polynomial", Delay: time.Second}
+	if got := w2.computeRetryDelay(&unknown, 3); got != 0 {
+		t.Errorf("unknown type: got %v want 0", got)
+	}
+}
+
+func TestComputeRetryDelay_NilAndZeroAttempts(t *testing.T) {
+	t.Parallel()
+	w := &Worker{}
+	if got := w.computeRetryDelay(nil, 3); got != 0 {
+		t.Errorf("nil strategy: got %v", got)
+	}
+	b := ExponentialBackoff(time.Second)
+	if got := w.computeRetryDelay(&b, 0); got != 0 {
+		t.Errorf("attempt=0: got %v", got)
+	}
+}
+
+// TestComputeRetryDelay_MisskeyHttpRelatedBackoff verifies a Worker can
+// reproduce Misskey's httpRelatedBackoff ((2^n - 1) * base, capped at
+// 8h) via a registered custom strategy. Jitter is exercised separately;
+// here r is fixed to 0 so the assertions are deterministic.
+func TestComputeRetryDelay_MisskeyHttpRelatedBackoff(t *testing.T) {
+	t.Parallel()
+	const base = time.Minute
+	const cap = 8 * time.Hour
+	w := &Worker{backoffStrategy: func(attemptsMade int) time.Duration {
+		d := time.Duration(math.Pow(2, float64(attemptsMade))-1) * base
+		if d > cap {
+			d = cap
+		}
+		return d
+	}}
+	b := CustomBackoff()
+	cases := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{1, 1 * time.Minute}, // (2^1-1)*60s = 60s
+		{2, 3 * time.Minute}, // (2^2-1)*60s = 180s
+		{3, 7 * time.Minute}, // (2^3-1)*60s = 420s
+		{12, 8 * time.Hour},  // (2^12-1)*60s = 68.25h -> capped 8h
+		{20, 8 * time.Hour},  // well past the cap
+	}
+	for _, c := range cases {
+		if got := w.computeRetryDelay(&b, c.attempt); got != c.want {
+			t.Errorf("attempt=%d: got %v want %v", c.attempt, got, c.want)
+		}
+	}
+}

--- a/internal/proto/opts.go
+++ b/internal/proto/opts.go
@@ -71,12 +71,14 @@ type RetentionLimit struct {
 	AgeSeconds *int
 }
 
-// Backoff matches BullMQ's BackoffOptions shape ({type, delay}).
+// Backoff matches BullMQ's BackoffOptions shape ({type, delay, jitter}).
 type Backoff struct {
-	// Type is "fixed" or "exponential".
+	// Type is "fixed", "exponential", or "custom".
 	Type string
 	// Delay is the base delay in milliseconds.
 	Delay int64
+	// Jitter is BullMQ's jitter fraction (0..1). 0 omits the field.
+	Jitter float64
 }
 
 // EncodeAddOpts returns the msgpack-encoded ARGV[3] payload.
@@ -95,10 +97,16 @@ func EncodeAddOpts(o AddOpts) ([]byte, error) {
 		m["attempts"] = o.Attempts
 	}
 	if o.Backoff != nil {
-		m["backoff"] = map[string]any{
+		backoff := map[string]any{
 			"type":  o.Backoff.Type,
 			"delay": o.Backoff.Delay,
 		}
+		// jitter は BullMQ でも optional。0 のときは出力しない
+		// ことで、jitter 未使用ジョブの opts JSON を従来どおりに保つ。
+		if o.Backoff.Jitter > 0 {
+			backoff["jitter"] = o.Backoff.Jitter
+		}
+		m["backoff"] = backoff
 	}
 	if o.Lifo {
 		m["lifo"] = true

--- a/queue.go
+++ b/queue.go
@@ -255,8 +255,9 @@ func toProtoOpts(cfg addConfig, delayMs int64) proto.AddOpts {
 	}
 	if cfg.backoff != nil {
 		o.Backoff = &proto.Backoff{
-			Type:  cfg.backoff.Type,
-			Delay: cfg.backoff.Delay.Milliseconds(),
+			Type:   cfg.backoff.Type,
+			Delay:  cfg.backoff.Delay.Milliseconds(),
+			Jitter: cfg.backoff.Jitter,
 		}
 	}
 	if cfg.dedupID != "" {

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ package mkq
 // runtime/debug.ReadBuildInfo so it stays meaningful in unit tests
 // and in users who vendor mkq via tooling that doesn't preserve
 // build info. Bump it on every release.
-const Version = "1.0.1"
+const Version = "1.0.2-dev"
 
 // versionTag is the value written to meta.version. BullMQ TS writes
 // `bullmq:<semver>`; mkq mirrors the convention with a `mkq:` prefix

--- a/worker.go
+++ b/worker.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"os"
 	"runtime"
 	"runtime/debug"
@@ -55,6 +56,16 @@ type Worker struct {
 	logger    Logger
 	metrics   Metrics
 	tracer    Tracer
+
+	// backoffStrategy is the BullMQ settings.backoffStrategy analogue:
+	// invoked for jobs whose backoff Type is not a built-in (fixed /
+	// exponential). nil means custom-typed jobs fall back to immediate
+	// retry. See WithBackoffStrategy.
+	backoffStrategy CustomBackoffFunc
+	// rng returns a random float64 in [0, 1) for jitter. Defaults to
+	// math/rand/v2's package source; overridable in tests for
+	// deterministic jitter assertions.
+	rng func() float64
 
 	// runCtx is cancelled by Stop to break dispatch goroutines out of
 	// the dequeue loop. Each in-flight handler derives its job ctx
@@ -124,17 +135,19 @@ func Process[T any](q *Queue[T], h Handler[T], opts ...WorkerOption) (*Worker, e
 
 	ctx, cancel := context.WithCancel(context.Background())
 	w := &Worker{
-		cfg:       cfg,
-		keys:      newQueueKeys(q),
-		queueName: q.name,
-		scripts:   q.client.scripts,
-		rdb:       q.client.rdb,
-		logger:    q.client.logger,
-		metrics:   q.client.metrics,
-		tracer:    q.client.tracer,
-		runCtx:    ctx,
-		runCancel: cancel,
-		stopDone:  make(chan struct{}),
+		cfg:             cfg,
+		keys:            newQueueKeys(q),
+		queueName:       q.name,
+		scripts:         q.client.scripts,
+		rdb:             q.client.rdb,
+		logger:          q.client.logger,
+		metrics:         q.client.metrics,
+		tracer:          q.client.tracer,
+		runCtx:          ctx,
+		runCancel:       cancel,
+		stopDone:        make(chan struct{}),
+		backoffStrategy: cfg.backoffStrategy,
+		rng:             rand.Float64,
 	}
 
 	// BZPopMin の awaitMarker は worker slot ごとに 1 connection を専有
@@ -903,7 +916,7 @@ func (w *Worker) finalise(jobID, token string, jobMap map[string]string, out han
 		return pf, finaliseStatusFailed, nil
 	}
 
-	delay := computeBackoffDelay(jobOpts.backoff, atm+1)
+	delay := w.computeRetryDelay(jobOpts.backoff, atm+1)
 	if delay > 0 {
 		if err := w.retryDelayed(jobID, token, delay, out.errReason, out.stacktrace); err != nil {
 			return nil, finaliseStatusError, err
@@ -1152,6 +1165,36 @@ func (w *Worker) retryDelayed(jobID, token string, delay time.Duration, reason, 
 	return nil
 }
 
+// computeRetryDelay resolves the per-attempt retry delay for a job,
+// layering jitter and the custom strategy on top of the built-in
+// fixed / exponential base computed by computeBackoffDelay.
+//
+// For built-in types the un-jittered base is computed wire-faithfully
+// and, when BackoffStrategy.Jitter > 0, spread via applyJitter using
+// the BullMQ formula. For any non-built-in type ("custom") the
+// Worker-registered CustomBackoffFunc owns the entire computation
+// (formula + cap + jitter); with no strategy registered the job falls
+// back to immediate retry (delay 0) rather than panicking, so foreign
+// custom-typed jobs never wedge the worker.
+func (w *Worker) computeRetryDelay(b *BackoffStrategy, attemptsMade int) time.Duration {
+	if b == nil || attemptsMade < 1 {
+		return 0
+	}
+	switch b.Type {
+	case "fixed", "exponential":
+		base := computeBackoffDelay(b, attemptsMade)
+		if b.Jitter > 0 {
+			return applyJitter(base, b.Jitter, w.rng())
+		}
+		return base
+	default:
+		if w.backoffStrategy != nil {
+			return w.backoffStrategy(attemptsMade)
+		}
+		return 0
+	}
+}
+
 // jobOpts is the subset of the per-job opts JSON that the worker
 // needs after dequeue. The on-Redis HASH `opts` field is the JSON
 // shape produced by Job.optsAsJSON in BullMQ TS.
@@ -1247,13 +1290,14 @@ func parseRemoveOpt(raw json.RawMessage) *retentionLimit {
 	return nil
 }
 
-// parseBackoffOpt accepts BullMQ's `number | {type, delay}` shape:
+// parseBackoffOpt accepts BullMQ's `number | {type, delay, jitter}`
+// shape:
 //
-//	number N           -> &BackoffStrategy{Type:"fixed", Delay: N ms}
-//	{type, delay}      -> &BackoffStrategy{Type, Delay}
+//	number N                   -> &BackoffStrategy{Type:"fixed", Delay: N ms}
+//	{type, delay, jitter?}     -> &BackoffStrategy{Type, Delay, Jitter}
 //
-// Empty / null / unrecognised shapes return nil so callers fall back
-// to the no-backoff default.
+// jitter is optional (defaults to 0). Empty / null / unrecognised
+// shapes return nil so callers fall back to the no-backoff default.
 func parseBackoffOpt(raw json.RawMessage) *BackoffStrategy {
 	if len(raw) == 0 || string(raw) == "null" {
 		return nil
@@ -1266,13 +1310,15 @@ func parseBackoffOpt(raw json.RawMessage) *BackoffStrategy {
 		}
 	}
 	var obj struct {
-		Type  string `json:"type"`
-		Delay int64  `json:"delay"`
+		Type   string  `json:"type"`
+		Delay  int64   `json:"delay"`
+		Jitter float64 `json:"jitter"`
 	}
 	if err := json.Unmarshal(raw, &obj); err == nil && obj.Type != "" {
 		return &BackoffStrategy{
-			Type:  obj.Type,
-			Delay: time.Duration(obj.Delay) * time.Millisecond,
+			Type:   obj.Type,
+			Delay:  time.Duration(obj.Delay) * time.Millisecond,
+			Jitter: obj.Jitter,
 		}
 	}
 	return nil

--- a/worker_options.go
+++ b/worker_options.go
@@ -14,6 +14,7 @@ type workerConfig struct {
 	maxStalledCount  int
 	limiter          *workerLimiter
 	maxDataPoints    int // 0 = disabled (BullMQ-spec metrics off)
+	backoffStrategy  CustomBackoffFunc
 }
 
 type workerLimiter struct {
@@ -115,6 +116,26 @@ func WithRateLimit(max int, duration time.Duration) WorkerOption {
 		}
 		c.limiter = &workerLimiter{max: max, duration: duration}
 	}
+}
+
+// WithBackoffStrategy registers the computation for jobs whose backoff
+// Type is not a BullMQ built-in (i.e. "custom"). It is the analogue of
+// BullMQ's `new Worker(..., { settings: { backoffStrategy } })`.
+//
+// Pair it with CustomBackoff() on the Add side: the job is stored with
+// {"type":"custom"} and this function computes the per-attempt delay.
+// Because the cap / jitter / formula all live here, mk-go can reproduce
+// Misskey's httpRelatedBackoff verbatim, e.g.:
+//
+//	mkq.WithBackoffStrategy(func(attemptsMade int) time.Duration {
+//		const base = time.Minute
+//		const cap = 8 * time.Hour
+//		d := time.Duration(math.Pow(2, float64(attemptsMade))-1) * base
+//		d = min(d, cap)
+//		return d + time.Duration(rand.Float64()*0.2*float64(d))
+//	})
+func WithBackoffStrategy(fn CustomBackoffFunc) WorkerOption {
+	return func(c *workerConfig) { c.backoffStrategy = fn }
 }
 
 // WithJobMetrics enables BullMQ-spec per-minute job-count metrics

--- a/worker_retry_test.go
+++ b/worker_retry_test.go
@@ -103,6 +103,68 @@ func TestWorker_Retry_ExponentialBackoffSchedules(t *testing.T) {
 	assert.Greater(t, gap2, gap1, "second gap should exceed first")
 }
 
+// TestWorker_Retry_CustomBackoffSchedules verifies the end-to-end wire
+// path for a custom backoff strategy: CustomBackoff() on Add marks the
+// job {"type":"custom"}, WithBackoffStrategy registers the Go-side
+// computation, and the worker honours the returned per-attempt delay
+// when re-enqueuing onto the delayed ZSET. This is the path mk-go uses
+// to reproduce Misskey's httpRelatedBackoff.
+func TestWorker_Retry_CustomBackoffSchedules(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	job, err := queue.Add(ctx, testPayload{},
+		mkq.WithAttempts(3),
+		mkq.WithBackoff(mkq.CustomBackoff()),
+	)
+	require.NoError(t, err)
+
+	var times []int64
+	mu := make(chan struct{}, 1)
+	mu <- struct{}{}
+	// Strategy: attempt 1 -> 40ms, attempt 2 -> 120ms (distinct, growing,
+	// and not matching the built-in exponential doubling so we know the
+	// custom func actually drives the schedule).
+	strategy := func(attemptsMade int) time.Duration {
+		return time.Duration(attemptsMade*attemptsMade) * 40 * time.Millisecond
+	}
+	worker, err := mkq.Process(queue, func(_ context.Context, _ *mkq.Job[testPayload]) (any, error) {
+		<-mu
+		times = append(times, time.Now().UnixMilli())
+		mu <- struct{}{}
+		return nil, errors.New("nope")
+	}, mkq.WithIdlePollInterval(10*time.Millisecond), mkq.WithBackoffStrategy(strategy))
+	require.NoError(t, err)
+	defer worker.Stop(context.Background())
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+	waitFor(t, ctx, 20*time.Millisecond, func() bool {
+		v, _ := rdb.ZScore(ctx, base+"failed", job.ID).Result()
+		return v > 0
+	})
+
+	require.Len(t, times, 3, "expected 3 attempts")
+	gap1 := times[1] - times[0]
+	gap2 := times[2] - times[1]
+	// 1st retry: strategy(1) = 1*40 = 40ms; 2nd retry: strategy(2) = 4*40 = 160ms.
+	// 寛容な下限 (poll/scheduling 揺らぎを吸収) でassertする。
+	assert.GreaterOrEqual(t, gap1, int64(30), "first retry should wait ~40ms (got %dms)", gap1)
+	assert.GreaterOrEqual(t, gap2, int64(140), "second retry should wait ~160ms (got %dms)", gap2)
+	assert.Greater(t, gap2, gap1, "second gap should exceed first (custom strategy grows)")
+
+	// opts.backoff must persist as the BullMQ custom wire shape so a
+	// foreign worker / dashboard reads {"type":"custom"}.
+	h, err := rdb.HGet(ctx, base+job.ID, "opts").Result()
+	require.NoError(t, err)
+	assert.Contains(t, h, `"type":"custom"`, "opts.backoff must persist type=custom")
+}
+
 // TestWorker_Retry_NoAttemptsDefaultIsOneShot ensures the existing
 // no-WithAttempts behaviour (1 attempt -> failed) is preserved.
 func TestWorker_Retry_NoAttemptsDefaultIsOneShot(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #66. mk-go の deliver / inbox retry backoff を Misskey TS と drop-in 一致させるため、BullMQ 互換の **custom backoff strategy** と **jitter** を追加した。Issue の「要望1(custom)」「要望2(cap/jitter)」の両方に対応しつつ、cap は wire 互換性を守るため custom strategy 内で実現する方針を採った。

## 実装前の重要な発見 (vendored BullMQ ソース確認)

実装に着手する前に `third_party/bullmq/src/classes/backoffs.ts` / `interfaces/backoff-options.ts` を読み込み、Issue の前提に対して以下を確認した。設計判断に直結するため記録する。

1. **backoff 計算は worker-side で、Lua は整数 ms を受け取るだけ**
   `Backoffs.calculate` は TS(worker) 側で実行され、`moveToDelayed` には計算済み整数 delay が渡る。mkq も同構造 (`worker.go` の `computeRetryDelay` → 整数 ms を Lua へ)。
   → **custom / cap / jitter はすべて client(worker) 側の計算であり、Redis wire format には影響しない。** これは本リポジトリの設計哲学 (compat=wire, optimization=client) に合致する。

2. **Misskey の `httpRelatedBackoff` は実は custom strategy**
   Misskey は `settings.backoffStrategy` を使っており、opts JSON には `backoff: {type: 'custom'}` が保存される。`(2^n-1)*base` は BullMQ 組み込み exponential (`delay*2^(n-1)`) とは別物。
   → drop-in 一致には **custom strategy のサポートが必須**。exponential 拡張だけでは wire 上の `type` が食い違う。

3. **jitter は BullMQ に既存フィールド**
   `BackoffOptions.jitter?: number` が存在し、組み込み exponential/fixed が対応済み。式は `floor(random() * base * jitter + base * (1-jitter))`(範囲 `[base*(1-jitter), base)`)。
   → jitter を built-in に足すのは **wire-faithful**。`{type, delay, jitter}` として永続化され foreign worker も再現可能。

4. **cap (MaxDelay) は BullMQ に存在しないフィールド**
   exponential に cap を足しても foreign BullMQ worker は無視するため retry スケジュールが乖離する。
   → **decision: exponential に cap は入れない。cap は custom strategy 内で実現する** (Issue で確認済み)。Misskey の 8h cap は登録関数内で `min()` して再現する。

## Key Changes

- `backoff.go`
  - `BackoffStrategy.Jitter float64` フィールド追加。
  - `CustomBackoffFunc func(attemptsMade int) time.Duration` 型。
  - constructor: `FixedBackoffWithJitter` / `ExponentialBackoffWithJitter` / `CustomBackoff()`。
  - `applyJitter(base, jitter, r)` ヘルパー (BullMQ 式を忠実に再現、jitter は (0,1] にクランプ)。
- `worker.go` / `worker_options.go`
  - `Worker.backoffStrategy` / `Worker.rng` フィールド (rng 既定は `math/rand/v2`、テストで差し替え可)。
  - `WithBackoffStrategy(fn)` WorkerOption (BullMQ `settings.backoffStrategy` 相当)。
  - `computeRetryDelay`: built-in は jitter を重ね、custom/unknown は登録関数を呼ぶ。未登録 custom は即時 retry にフォールバックし foreign job で worker が wedge しない。
  - `parseBackoffOpt` で jitter 読み取り。
- `internal/proto/opts.go` / `queue.go`
  - `proto.Backoff.Jitter` 追加。`jitter > 0` のときのみ encode し、jitter 未使用 job の opts JSON を従来どおりに保つ。
- `README.md`: backoff 戦略一覧と Misskey `httpRelatedBackoff` 再現例を追記。

cap は wire に出さない (BullMQ に該当フィールドがなく foreign worker が無視するため)。built-in + jitter は `{type, delay, jitter}` で永続化され他言語ワーカーと共有可能。

## Testing

- `go build ./...` / `go vet ./...` / `gofmt -l` クリーン
- `go test . ./internal/...` 全 pass
- `go build -tags interop ./tests/...` (interop ビルド) OK
- 追加テスト (`backoff_test.go`, `parse_jobopts_test.go`, `internal/proto/opts_test` の該当 subtest):
  - `applyJitter` の範囲・境界 (決定的 rng で上下限、jitter クランプ)
  - `computeRetryDelay` 全分岐 (fixed / exp / jitter / custom / 未登録 custom / unknown / nil / attempt<1)
  - Misskey `httpRelatedBackoff` 相当 (`(2^n-1)*base`, 8h cap) を custom strategy で再現
  - proto encode の jitter (>0 で出力, ==0 で省略) + custom type
  - parse の jitter 読み取り + custom type

実行: `go test ./...` / interop は `go test -tags interop ./tests/interop/` (Redis 必要)

## Related Issue

Closes #66
mk-go 側 PR: shiroha-a/mk#1406 (これで TS の httpRelatedBackoff を完全再現できる)