### PR TITLE
release: v1.0.2 — CHANGELOG + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-06-01
+
+### Added
+
+- Custom and jittered retry backoff strategies for BullMQ parity. (#67)
+  - `FixedBackoffWithJitter` / `ExponentialBackoffWithJitter` apply
+    BullMQ's jitter fraction (`0..1`); the value is persisted in the
+    `opts.backoff` wire shape (`{type, delay, jitter}`) so foreign
+    BullMQ workers honour it.
+  - `CustomBackoff()` + `Worker.WithBackoffStrategy` expose BullMQ's
+    `settings.backoffStrategy` path: an arbitrary `func(attemptsMade int)
+    time.Duration` owns the formula, cap, and jitter. This lets mk-go
+    reproduce Misskey's `httpRelatedBackoff` (`(2^n-1)*base`, capped at
+    8h, plus 0-20% jitter) drop-in. (#66)
+
+### Fixed
+
+- (none)
+
 ## [1.0.1] - 2026-04-27
 
 ### Added

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ package mkq
 // runtime/debug.ReadBuildInfo so it stays meaningful in unit tests
 // and in users who vendor mkq via tooling that doesn't preserve
 // build info. Bump it on every release.
-const Version = "1.0.2-dev"
+const Version = "1.0.2"
 
 // versionTag is the value written to meta.version. BullMQ TS writes
 // `bullmq:<semver>`; mkq mirrors the convention with a `mkq:` prefix


### PR DESCRIPTION
## Summary

Cut the v1.0.2 release. Promotes the `1.0.2-dev` marker to `1.0.2` and finalises the CHANGELOG now that the custom / jittered backoff work (#66, #67) has landed on main.

## Key Changes

- `version.go`: `1.0.2-dev` → `1.0.2` (`Version` + `versionTag` = `mkq:1.0.2`).
- `CHANGELOG.md`: new `[1.0.2] - 2026-06-01` section documenting the backoff additions; `[Unreleased]` cleared.

## Release contents (1.0.2)

- Custom and jittered retry backoff strategies for BullMQ parity (#67, closes #66):
  - `FixedBackoffWithJitter` / `ExponentialBackoffWithJitter` (BullMQ jitter fraction, persisted in the `opts.backoff` wire shape).
  - `CustomBackoff()` + `Worker.WithBackoffStrategy` (BullMQ `settings.backoffStrategy` path) — lets mk-go reproduce Misskey's `httpRelatedBackoff` drop-in.

## Testing

- `go build ./...` / `go test . ./internal/...` pass on the release branch.
- No code changes beyond the version literal and CHANGELOG; the feature + tests already merged via #67.

## Post-merge

After merge, tag `v1.0.2` on main and bump `version.go` back to `1.0.3-dev` in a follow-up `chore:` commit (mirrors the post-v1.0.1 flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)