### PR TITLE
chore: bump Version to 1.0.3-dev (post-v1.0.2)

### DIFF
--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ package mkq
 // runtime/debug.ReadBuildInfo so it stays meaningful in unit tests
 // and in users who vendor mkq via tooling that doesn't preserve
 // build info. Bump it on every release.
-const Version = "1.0.2"
+const Version = "1.0.3-dev"
 
 // versionTag is the value written to meta.version. BullMQ TS writes
 // `bullmq:<semver>`; mkq mirrors the convention with a `mkq:` prefix


### PR DESCRIPTION
## Summary

Post-release housekeeping: now that **v1.0.2** is tagged on main, revert the version literal to a `-dev` marker so in-flight work builds under `1.0.3-dev`.

## Key Changes

- `version.go`: `1.0.2` → `1.0.3-dev` (`Version` + `versionTag` = `mkq:1.0.3-dev`).

## Testing

- `go build ./...` passes.

## Related

Mirrors the post-v1.0.1 / post-v1.0.0 flow. Follows the v1.0.2 release (#68, tag v1.0.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)