### PR TITLE
feat: public Pause/Resume/IsPaused API (BullMQ Queue.pause/resume parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Public pause/resume API for BullMQ `Queue.pause()` / `Queue.resume()`
+  parity. (#70)
+  - `Queue.Pause` sets the `meta.paused` flag and atomically moves the
+    `wait` list to `paused` (vendored `pause-7.lua`), so jobs already
+    queued are parked rather than dropped. Jobs enqueued while paused
+    also land in `paused` (no orphans); the pause is shared via Redis so
+    every worker process honours it.
+  - `Queue.Resume` clears the flag, returns parked jobs to `wait`, and
+    pokes the marker ZSET so blocking workers wake immediately.
+  - `Queue.IsPaused` reports the current state via `HEXISTS meta paused`.
+
 ## [1.0.2] - 2026-06-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ queue.RetryJob(ctx, jobID)
 queue.PromoteJob(ctx, jobID)
 queue.RemoveJob(ctx, jobID)
 queue.DrainPending(ctx, mkq.WithDrainDelayed(true))
+
+queue.Pause(ctx)             // stop handing jobs to workers (wait -> paused)
+queue.Resume(ctx)            // resume (paused -> wait, wakes blocking workers)
+paused, _ := queue.IsPaused(ctx)
 ```
 
 ### Job mutation from inside a handler
@@ -256,7 +260,8 @@ the asynq → mkq migration walkthrough.
 - **Inspector** (read): `Queue.Counts`, `Queue.ListJobs`,
   `Queue.Get`, `Client.Queues`.
 - **Inspector** (admin): `Queue.RemoveJob`, `Queue.DrainPending`,
-  `Queue.PromoteJob`, `Queue.RetryJob`.
+  `Queue.PromoteJob`, `Queue.RetryJob`, `Queue.Pause`, `Queue.Resume`,
+  `Queue.IsPaused`.
 - **Job mutation from handler**: `Job.UpdateProgress`,
   `Job.UpdateData`, `Job.Log`; out-of-band `Queue.UpdateJobProgress`,
   `Queue.UpdateJobData`, `Queue.AppendJobLog`.

--- a/inspector_admin.go
+++ b/inspector_admin.go
@@ -274,3 +274,77 @@ func (q *Queue[T]) RetryJob(ctx context.Context, jobID string, opts ...RetryOpti
 		return fmt.Errorf("mkq: reprocessJob returned error code %d", code)
 	}
 }
+
+// Pause stops the queue from handing jobs to workers, mirroring
+// BullMQ's Queue.pause(). It atomically sets the `meta.paused` flag and
+// renames the `wait` list onto `paused`, so any jobs already queued are
+// parked rather than dropped. Jobs enqueued while paused also land in
+// `paused` (addStandardJob honours the flag via getTargetQueueList), so
+// nothing is orphaned; Resume returns the whole set to `wait`.
+//
+// The pause is global to the queue and shared via Redis, so every
+// worker process bound to the same queue honours it (the gate lives in
+// moveToActive's Lua, not in any single client). In-flight jobs already
+// locked by a worker are allowed to finish — Pause only blocks new
+// fetches.
+//
+// Equivalent to BullMQ pause-7.lua with ARGV "paused". Idempotent:
+// pausing an already-paused queue is a no-op at the wire level.
+func (q *Queue[T]) Pause(ctx context.Context) error {
+	return q.pauseResume(ctx, q.keys.Wait(), q.keys.Paused(), "paused")
+}
+
+// Resume re-enables job processing on a paused queue, mirroring
+// BullMQ's Queue.resume(). It clears the `meta.paused` flag, renames the
+// `paused` list back onto `wait`, and pokes the marker ZSET so blocking
+// workers wake immediately instead of waiting out their BRPOPLPUSH
+// timeout.
+//
+// Equivalent to BullMQ pause-7.lua with ARGV "resumed". Idempotent:
+// resuming a queue that is not paused is a no-op at the wire level.
+func (q *Queue[T]) Resume(ctx context.Context) error {
+	return q.pauseResume(ctx, q.keys.Paused(), q.keys.Wait(), "resumed")
+}
+
+// pauseResume runs the vendored pause-7.lua. source/target are the
+// LIST keys to rename (wait->paused for pause, paused->wait for
+// resume); event is the BullMQ stream event ("paused" or "resumed")
+// that also selects the branch inside the Lua.
+func (q *Queue[T]) pauseResume(ctx context.Context, source, target, event string) error {
+	_, err := q.client.scripts.Run(
+		ctx,
+		lua.Pause,
+		// pause-7.lua KEYS:
+		//   1 source list, 2 target list, 3 meta, 4 prioritized,
+		//   5 events, 6 delayed, 7 marker
+		[]string{
+			source,
+			target,
+			q.keys.Meta(),
+			q.keys.Prioritized(),
+			q.keys.Events(),
+			q.keys.Delayed(),
+			q.keys.Marker(),
+		},
+		event,
+	)
+	// pause-7.lua はステータスコードを返さない (末尾は XADD)。返り値の
+	// 無い EVALSHA を go-redis は redis.Nil として surface するので成功
+	// 扱い。実エラー (NOSCRIPT 後の reload 失敗等) はそのまま伝播。
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return fmt.Errorf("mkq: %s: %w", event, err)
+	}
+	return nil
+}
+
+// IsPaused reports whether the queue is currently paused, mirroring
+// BullMQ's Queue.isPaused(). It checks for the `paused` field on the
+// `meta` HASH (HEXISTS) — an empty `paused` list and an unpaused queue
+// are distinct states, so the flag, not the list, is authoritative.
+func (q *Queue[T]) IsPaused(ctx context.Context) (bool, error) {
+	paused, err := q.client.rdb.HExists(ctx, q.keys.Meta(), "paused").Result()
+	if err != nil {
+		return false, fmt.Errorf("mkq: isPaused: %w", err)
+	}
+	return paused, nil
+}

--- a/internal/lua/loader.go
+++ b/internal/lua/loader.go
@@ -53,6 +53,7 @@ const (
 	Drain                 ScriptName = "drain-5"
 	Promote               ScriptName = "promote-9"
 	ReprocessJob          ScriptName = "reprocessJob-8"
+	Pause                 ScriptName = "pause-7"
 )
 
 // Scripter executes vendored Lua scripts via EVALSHA, with transparent
@@ -101,7 +102,7 @@ func NewScripter(ctx context.Context, client redis.Scripter, logger Logger) (*Sc
 		AddJobScheduler, UpdateJobScheduler,
 		UpdateProgress, UpdateData, AddLog,
 		GetCounts, GetRanges, GetMetrics,
-		RemoveJob, Drain, Promote, ReprocessJob,
+		RemoveJob, Drain, Promote, ReprocessJob, Pause,
 	} {
 		if _, err := s.load(ctx, name); err != nil {
 			return nil, fmt.Errorf("preload %s: %w", name, err)

--- a/internal/lua/scripts/UPSTREAM.md
+++ b/internal/lua/scripts/UPSTREAM.md
@@ -43,6 +43,7 @@ Entry points:
 - `promote-9.lua`
 - `reprocessJob-8.lua`
 - `getMetrics-2.lua`
+- `pause-7.lua`
 
 `includes/` — every script transitively reachable from the entry points
 above via `--- @include "..."` directives.

--- a/internal/lua/scripts/pause-7.lua
+++ b/internal/lua/scripts/pause-7.lua
@@ -1,0 +1,42 @@
+--[[
+  Pauses or resumes a queue globably.
+
+  Input:
+    KEYS[1] 'wait' or 'paused''
+    KEYS[2] 'paused' or 'wait'
+    KEYS[3] 'meta'
+    KEYS[4] 'prioritized'
+    KEYS[5] events stream key
+    KEYS[6] 'delayed'
+    KEYS|7] 'marker'
+
+    ARGV[1] 'paused' or 'resumed'
+
+  Event:
+    publish paused or resumed event.
+]]
+local rcall = redis.call
+
+-- Includes
+--- @include "includes/addDelayMarkerIfNeeded"
+
+local markerKey = KEYS[7]
+local hasJobs = rcall("EXISTS", KEYS[1]) == 1
+--TODO: check this logic to be reused when changing a delay
+if hasJobs then rcall("RENAME", KEYS[1], KEYS[2]) end
+
+if ARGV[1] == "paused" then
+    rcall("HSET", KEYS[3], "paused", 1)
+    rcall("DEL", markerKey)
+else
+    rcall("HDEL", KEYS[3], "paused")
+
+    if hasJobs or rcall("ZCARD", KEYS[4]) > 0 then
+        -- Add marker if there are waiting or priority jobs
+        rcall("ZADD", markerKey, 0, "0")
+    else
+        addDelayMarkerIfNeeded(markerKey, KEYS[6])
+    end
+end
+
+rcall("XADD", KEYS[5], "*", "event", ARGV[1]);

--- a/pause_test.go
+++ b/pause_test.go
@@ -1,0 +1,454 @@
+package mkq_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mkq"
+)
+
+// TestQueue_Pause_MovesWaitToPaused verifies the BullMQ pause semantics:
+// the meta.paused flag is set and every job already in wait is parked in
+// the paused list (atomic RENAME), so Counts.Paused / IsPaused agree.
+func TestQueue_Pause_MovesWaitToPaused(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var ids []string
+	for range 3 {
+		job, err := queue.Add(ctx, testPayload{Inbox: "to-park"})
+		require.NoError(t, err)
+		ids = append(ids, job.ID)
+	}
+
+	require.NoError(t, queue.Pause(ctx))
+
+	paused, err := queue.IsPaused(ctx)
+	require.NoError(t, err)
+	assert.True(t, paused, "IsPaused must report true after Pause")
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+
+	waitLen, err := rdb.LLen(ctx, base+"wait").Result()
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, waitLen, "wait list must be empty after Pause")
+
+	pausedMembers, err := rdb.LRange(ctx, base+"paused", 0, -1).Result()
+	require.NoError(t, err)
+	assert.ElementsMatch(t, ids, pausedMembers, "all jobs must be parked in paused")
+
+	flag, err := rdb.HGet(ctx, base+"meta", "paused").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "1", flag, "meta.paused must be set to 1")
+
+	// Pause must DEL the marker (BullMQ pause-7.lua) so idle blocking
+	// workers stop being woken to spin against the gate.
+	markerCard, err := rdb.ZCard(ctx, base+"marker").Result()
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, markerCard, "marker must be deleted by Pause")
+
+	counts, err := queue.Counts(ctx)
+	require.NoError(t, err)
+	assert.EqualValues(t, 3, counts.Paused, "Counts.Paused must reflect parked jobs")
+	assert.EqualValues(t, 0, counts.Wait, "Counts.Wait must be zero while paused")
+}
+
+// TestQueue_Resume_MovesPausedBackToWait verifies that Resume clears the
+// flag, returns parked jobs to wait, and pokes the marker ZSET so a
+// blocking worker wakes immediately.
+func TestQueue_Resume_MovesPausedBackToWait(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var ids []string
+	for range 3 {
+		job, err := queue.Add(ctx, testPayload{Inbox: "to-resume"})
+		require.NoError(t, err)
+		ids = append(ids, job.ID)
+	}
+	require.NoError(t, queue.Pause(ctx))
+	require.NoError(t, queue.Resume(ctx))
+
+	paused, err := queue.IsPaused(ctx)
+	require.NoError(t, err)
+	assert.False(t, paused, "IsPaused must report false after Resume")
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+
+	pausedLen, err := rdb.LLen(ctx, base+"paused").Result()
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, pausedLen, "paused list must be empty after Resume")
+
+	waitMembers, err := rdb.LRange(ctx, base+"wait", 0, -1).Result()
+	require.NoError(t, err)
+	assert.ElementsMatch(t, ids, waitMembers, "all jobs must be back in wait")
+
+	exists, err := rdb.HExists(ctx, base+"meta", "paused").Result()
+	require.NoError(t, err)
+	assert.False(t, exists, "meta.paused must be removed after Resume")
+
+	// Resume must add the base marker so blocking workers wake up.
+	markerScore, err := rdb.ZScore(ctx, base+"marker", "0").Result()
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, markerScore, "marker must hold the base entry after Resume")
+}
+
+// TestQueue_Add_DuringPause_GoesToPausedList is the orphan-safety
+// acceptance criterion: a job enqueued while the queue is paused must
+// land in the paused list (not wait), and Resume must return it to wait.
+func TestQueue_Add_DuringPause_GoesToPausedList(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, queue.Pause(ctx))
+
+	job, err := queue.Add(ctx, testPayload{Inbox: "enqueued-while-paused"})
+	require.NoError(t, err)
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+
+	pausedMembers, err := rdb.LRange(ctx, base+"paused", 0, -1).Result()
+	require.NoError(t, err)
+	assert.Equal(t, []string{job.ID}, pausedMembers, "job added during pause must go to paused")
+
+	waitLen, err := rdb.LLen(ctx, base+"wait").Result()
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, waitLen, "wait must stay empty for a job added during pause")
+
+	counts, err := queue.Counts(ctx)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, counts.Paused, "Counts.Paused must include the job added during pause")
+
+	require.NoError(t, queue.Resume(ctx))
+
+	waitMembers, err := rdb.LRange(ctx, base+"wait", 0, -1).Result()
+	require.NoError(t, err)
+	assert.Equal(t, []string{job.ID}, waitMembers, "job must return to wait after Resume")
+}
+
+// TestQueue_PauseResume_Idempotent confirms pause-7.lua's no-op
+// semantics: pausing an already-paused queue (or resuming an unpaused
+// one) is harmless and never errors.
+func TestQueue_PauseResume_Idempotent(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Resume on a never-paused queue is a no-op.
+	require.NoError(t, queue.Resume(ctx))
+	paused, err := queue.IsPaused(ctx)
+	require.NoError(t, err)
+	assert.False(t, paused)
+
+	require.NoError(t, queue.Pause(ctx))
+	require.NoError(t, queue.Pause(ctx), "double Pause must not error")
+	paused, err = queue.IsPaused(ctx)
+	require.NoError(t, err)
+	assert.True(t, paused)
+
+	require.NoError(t, queue.Resume(ctx))
+	require.NoError(t, queue.Resume(ctx), "double Resume must not error")
+	paused, err = queue.IsPaused(ctx)
+	require.NoError(t, err)
+	assert.False(t, paused)
+}
+
+// TestQueue_Pause_WorkerDoesNotFetch verifies the end-to-end gate: a job
+// parked while paused is not handed to a worker until Resume. The same
+// worker that idles through the pause must pick the job up promptly once
+// the queue resumes (marker poke).
+func TestQueue_Pause_WorkerDoesNotFetch(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, queue.Pause(ctx))
+
+	job, err := queue.Add(ctx, testPayload{Inbox: "gated"})
+	require.NoError(t, err)
+
+	processed := make(chan string, 1)
+	worker, err := mkq.Process(queue, func(_ context.Context, j *mkq.Job[testPayload]) (any, error) {
+		processed <- j.ID
+		return nil, nil
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		assert.NoError(t, worker.Stop(stopCtx))
+	}()
+
+	// The worker must NOT fetch the parked job while paused.
+	select {
+	case id := <-processed:
+		t.Fatalf("worker processed job %s while queue was paused", id)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	require.NoError(t, queue.Resume(ctx))
+
+	select {
+	case id := <-processed:
+		assert.Equal(t, job.ID, id, "worker must process the job after Resume")
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker did not process the job after Resume")
+	}
+}
+
+// TestQueue_Pause_PrioritizedNotFetched extends the pause gate to the
+// prioritized bucket. The moveToActive gate returns before the
+// prioritized->active move, so a prioritized job must not be dispatched
+// while paused — and it stays in the prioritized ZSET (Pause does not
+// rename prioritized into paused), so Counts.Paused excludes it.
+func TestQueue_Pause_PrioritizedNotFetched(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, queue.Pause(ctx))
+
+	job, err := queue.Add(ctx, testPayload{Inbox: "prio-gated"}, mkq.WithPriority(5))
+	require.NoError(t, err)
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+
+	// Prioritized job lands in the prioritized ZSET, not the paused list.
+	prioCard, err := rdb.ZCard(ctx, base+"prioritized").Result()
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, prioCard, "prioritized job must stay in the prioritized ZSET")
+	counts, err := queue.Counts(ctx)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, counts.Prioritized)
+	assert.EqualValues(t, 0, counts.Paused, "prioritized job is not counted as paused")
+
+	processed := make(chan string, 1)
+	worker, err := mkq.Process(queue, func(_ context.Context, j *mkq.Job[testPayload]) (any, error) {
+		processed <- j.ID
+		return nil, nil
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		assert.NoError(t, worker.Stop(stopCtx))
+	}()
+
+	// The prioritized job must NOT be fetched while paused.
+	select {
+	case id := <-processed:
+		t.Fatalf("worker processed prioritized job %s while paused", id)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	require.NoError(t, queue.Resume(ctx))
+
+	select {
+	case id := <-processed:
+		assert.Equal(t, job.ID, id, "prioritized job must process after Resume")
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker did not process the prioritized job after Resume")
+	}
+}
+
+// TestQueue_Pause_DelayedMaturesToPaused is the orphan-safety criterion
+// for delayed jobs. A delayed job whose timer fires while the queue is
+// paused must be promoted into the paused list (not wait), so it is not
+// dispatched until Resume. promoteDelayedJobs runs inside moveToActive
+// (driven by the idle worker) and honours the pause target, so the
+// matured job is parked, not handed out.
+func TestQueue_Pause_DelayedMaturesToPaused(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	require.NoError(t, queue.Pause(ctx))
+
+	processed := make(chan string, 1)
+	worker, err := mkq.Process(queue, func(_ context.Context, j *mkq.Job[testPayload]) (any, error) {
+		processed <- j.ID
+		return nil, nil
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		assert.NoError(t, worker.Stop(stopCtx))
+	}()
+
+	job, err := queue.Add(ctx, testPayload{Inbox: "delayed-gated"}, mkq.WithDelay(200*time.Millisecond))
+	require.NoError(t, err)
+
+	rdb := rawClient(t)
+	base := prefix + ":deliver:"
+
+	// Wait until the idle worker's moveToActive has promoted the matured
+	// delayed job out of the delayed ZSET.
+	waitFor(t, ctx, 50*time.Millisecond, func() bool {
+		n, _ := rdb.ZCard(ctx, base+"delayed").Result()
+		return n == 0
+	})
+
+	// It must have gone to paused, never to wait, and must not be processed.
+	pausedMembers, err := rdb.LRange(ctx, base+"paused", 0, -1).Result()
+	require.NoError(t, err)
+	assert.Contains(t, pausedMembers, job.ID, "matured delayed job must be parked in paused")
+	waitLen, err := rdb.LLen(ctx, base+"wait").Result()
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, waitLen, "matured delayed job must never leak into wait while paused")
+
+	select {
+	case id := <-processed:
+		t.Fatalf("worker processed delayed job %s while paused", id)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	require.NoError(t, queue.Resume(ctx))
+
+	select {
+	case id := <-processed:
+		assert.Equal(t, job.ID, id, "delayed job must process after Resume")
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker did not process the delayed job after Resume")
+	}
+}
+
+// TestQueue_Pause_ClusterHonorAcrossClients verifies the multi-process
+// acceptance criterion: a pause issued through one Client is honoured by
+// a worker created from a different Client against the same Redis. The
+// gate lives in moveToActive's Lua (shared meta.paused), so there is no
+// client-local pause state for a second process to miss.
+func TestQueue_Pause_ClusterHonorAcrossClients(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	cAdmin := newClient(t, prefix)
+	cWorker := newClient(t, prefix)
+
+	queueAdmin := mkq.Define[testPayload](cAdmin, "deliver")
+	queueWorker := mkq.Define[testPayload](cWorker, "deliver")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Pause through the admin Client before the worker Client enqueues.
+	require.NoError(t, queueAdmin.Pause(ctx))
+
+	job, err := queueWorker.Add(ctx, testPayload{Inbox: "cluster-gated"})
+	require.NoError(t, err)
+
+	processed := make(chan string, 1)
+	worker, err := mkq.Process(queueWorker, func(_ context.Context, j *mkq.Job[testPayload]) (any, error) {
+		processed <- j.ID
+		return nil, nil
+	}, mkq.WithIdlePollInterval(20*time.Millisecond))
+	require.NoError(t, err)
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		assert.NoError(t, worker.Stop(stopCtx))
+	}()
+
+	// The worker on cWorker must honour the pause set by cAdmin.
+	select {
+	case id := <-processed:
+		t.Fatalf("worker (cWorker) processed job %s despite pause set by cAdmin", id)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	// Resume through the admin Client; the worker Client must pick up.
+	require.NoError(t, queueAdmin.Resume(ctx))
+
+	select {
+	case id := <-processed:
+		assert.Equal(t, job.ID, id, "worker must process after admin Client resumes")
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker did not process after cross-Client Resume")
+	}
+}
+
+// TestQueue_PauseResume_EmitsEvents verifies the BullMQ QueueEvents wire
+// contract: Pause / Resume each XADD a "paused" / "resumed" event onto
+// the events stream. mkq has no dedicated event struct for these yet, so
+// they surface as RawEvent (forward-compatible), which is what
+// bull-board / Misskey QueueEvents consumers read.
+func TestQueue_PauseResume_EmitsEvents(t *testing.T) {
+	t.Parallel()
+	prefix := uniquePrefix(t)
+	c := newClient(t, prefix)
+	queue := mkq.Define[testPayload](c, "deliver")
+
+	qe := mkq.NewQueueEvents(queue)
+	events, _ := startSubscriber(t, qe)
+	time.Sleep(50 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, queue.Pause(ctx))
+	require.NoError(t, queue.Resume(ctx))
+
+	tctx, tcancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer tcancel()
+	got := drainUntil(t, tctx, events, func(xs []mkq.Event) bool {
+		var sawPaused, sawResumed bool
+		for _, ev := range xs {
+			if raw, ok := ev.(mkq.RawEvent); ok {
+				switch raw.Type {
+				case "paused":
+					sawPaused = true
+				case "resumed":
+					sawResumed = true
+				}
+			}
+		}
+		return sawPaused && sawResumed
+	})
+
+	var types []string
+	for _, ev := range got {
+		if raw, ok := ev.(mkq.RawEvent); ok {
+			types = append(types, raw.Type)
+		}
+	}
+	assert.Contains(t, types, "paused", "Pause must XADD a paused event")
+	assert.Contains(t, types, "resumed", "Resume must XADD a resumed event")
+}


### PR DESCRIPTION
## Summary

Adds the public Go API for pausing/resuming a queue, mirroring BullMQ's `Queue.pause()` / `Queue.resume()` / `Queue.isPaused()`. mkq already had the Lua-level pause machinery (`isQueuePaused`, `getTargetQueueList`, the `moveToActive` gate, `JobBucketPaused`, `Counts.Paused`); the only missing piece was a public way to set/clear the `meta.paused` flag. This wires that up so the mk-go admin dashboard can drive pause/resume (Misskey upstream PR 17436 parity).

## Key Changes

- **Vendor `pause-7.lua` verbatim** from the pinned BullMQ submodule (`0866f39`). It serves both pause and resume via `ARGV` (`"paused"` / `"resumed"`). Its includes (`addDelayMarkerIfNeeded`, `getNextDelayedTimestamp`) were already vendored and are byte-identical upstream. Registered as `lua.Pause` (`"pause-7"`) and added to the preload set; `UPSTREAM.md` updated.
- **`Queue.Pause`** — sets `meta.paused` and atomically renames `wait` → `paused`, so already-queued jobs are parked rather than dropped. Jobs enqueued while paused also land in `paused` (`addStandardJob` honours `getTargetQueueList`), so nothing is orphaned. The pause is shared via Redis, so every worker process honours it through the `moveToActive` gate — no client-local state.
- **`Queue.Resume`** — clears the flag, renames `paused` → `wait`, and pokes the marker ZSET so blocking workers wake immediately.
- **`Queue.IsPaused`** — `HEXISTS meta paused`.
- The vendored script returns no value, so `redis.Nil` is treated as success (same pattern as `DrainPending`).
- README + CHANGELOG updated.

### Acceptance criteria (issue #70)

All satisfied by existing Lua infra + verified by tests:
- pause中はworkerがfetchしない — `moveToActive` の `isPausedOrMaxed` gate が `wait`/`prioritized` 両方の fetch より前に return。
- enqueue-during-pause で orphan しない — `paused` list 行き、resume で `wait` 復帰。
- `Counts.Paused` / `JobBucketPaused` 整合。
- cluster で全 worker が共有 `meta.paused` を honor。

## Testing

`pause_test.go` (integration, 実Redis `127.0.0.1:6379`), 全9本:

- `TestQueue_Pause_MovesWaitToPaused` — wait→paused 移動 + `meta.paused=1` + marker DEL + `Counts.Paused`。
- `TestQueue_Resume_MovesPausedBackToWait` — paused→wait 戻し + flag 消滅 + marker poke。
- `TestQueue_Add_DuringPause_GoesToPausedList` — orphan-safety。
- `TestQueue_PauseResume_Idempotent` — 二重 Pause/Resume が no-op。
- `TestQueue_Pause_WorkerDoesNotFetch` — end-to-end gate。

敵対的レビューで判明したカバレッジの穴を埋める追加分:

- `TestQueue_Pause_PrioritizedNotFetched` — prioritized ジョブの gate + ZSET 残留。
- `TestQueue_Pause_DelayedMaturesToPaused` — pause中に満期になった delayed が `wait` に漏れず `paused` へ。
- `TestQueue_Pause_ClusterHonorAcrossClients` — 別 Client の Pause を別 Client 由来の worker が honor。
- `TestQueue_PauseResume_EmitsEvents` — QueueEvents stream に `paused`/`resumed` 発火。

実行方法:
\`\`\`
go test -run 'TestQueue_Pause|TestQueue_Resume|TestQueue_Add_DuringPause|TestQueue_PauseResume' ./...
go test ./...   # 全スイート
\`\`\`

`go test ./...` 全パス / `gofmt` clean / `go vet` clean / `script/sync-lua.sh` で divergence なし。3回連続実行でも安定。

## Adversarial review

3観点(BullMQ wire互換性 / 正しさ・並行性 / テスト品質)で敵対的レビュー実施。実装は wire互換(pinned commit と byte一致、KEYS/ARGV が `Scripts.pauseArgs` と完全一致)かつ correctness/concurrency バグなしと確認。テスト品質レビューで指摘された受け入れ条件カバレッジの穴(prioritized gate / delayed park / cluster honor / QueueEvents)を上記の追加テストで実証済み。

## Related Issue

Closes #70

## Other

- `paused`/`resumed` 専用 Event 型は未追加(現状 `RawEvent` で観測可能・wire互換成立)。型付けが必要なら follow-up。
- 利用側 (mk-go の `driver.Inspector` への wiring) は別PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)