### PR TITLE
fix(interop): clear Dependabot DoS alerts (qs, path-to-regexp)

### DIFF
--- a/tests/interop/node/package-lock.json
+++ b/tests/interop/node/package-lock.json
@@ -963,9 +963,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -988,12 +988,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"

--- a/tests/interop/node/package.json
+++ b/tests/interop/node/package.json
@@ -15,5 +15,9 @@
     "bullmq": "5.76.2",
     "express": "4.21.2",
     "ioredis": "5.10.1"
+  },
+  "overrides": {
+    "qs": "6.15.2",
+    "path-to-regexp": "0.1.13"
   }
 }


### PR DESCRIPTION
## Summary

Clears all 4 open Dependabot alerts. Every alert was a **transitive npm dep** of the interop test harness (`tests/interop/node/`, pulled via `express` 4.21.2 / `@bull-board/express`) — none ship in the Go module. All are DoS-class.

| # | Package | Severity | Advisory | Fix |
|---|---------|----------|----------|-----|
| 3 | path-to-regexp | high | GHSA-37ch-88jc-xwx2 (ReDoS via multiple route params) | 0.1.12 → **0.1.13** |
| 1 | qs | medium | GHSA-6rw7-vpxm-498p (bracket-notation arrayLimit bypass DoS) | 6.13.0 → **6.15.2** |
| 4 | qs | medium | GHSA-q8mj-m7cp-5q26 (null/undefined comma-format DoS) | 〃 |
| 2 | qs | low | GHSA-w7fw-mjwx-w883 (comma-parse arrayLimit bypass DoS) | 〃 |

## Key Changes

- Add npm `overrides` to `tests/interop/node/package.json` pinning `qs@6.15.2` (covers all three qs advisories) and `path-to-regexp@0.1.13` (security backport for the express 4.x `0.1.x` line). Overrides are required because both are transitive (`express` → `body-parser`/route compiler), not direct deps.
- Regenerate `package-lock.json`. Diff is limited to those two packages; `express`/`bullmq`/`ioredis`/bull-board pins are untouched, so the `lua-sync-verify` bullmq-pin check still holds.

## Risk

Test-only harness that runs local smoke tests against a local Redis — the express server (`bullboard.js`) is never exposed to untrusted input, so real-world exposure is negligible. The bumps are patch/minor and API-compatible; included purely to clear the alerts at low risk.

## Testing

- `npm ci` — clean install, lockfile consistent.
- `npm audit` — **found 0 vulnerabilities**.
- Runtime smoke: `express` boots and compiles a `:param` route (exercises path-to-regexp 0.1.13), `qs.parse` works; all three harness scripts (`worker.js` / `enqueuer.js` / `bullboard.js`) pass `node --check`.
- CI `interop` workflow uses `npm ci` against this lockfile.

## Related

Dependabot alerts #1–#4 (shiroha-a/mkq).

🤖 Generated with [Claude Code](https://claude.com/claude-code)