### PR TITLE
release: v1.0.3 — CHANGELOG + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-06-23
+
 ### Added
 
 - Public pause/resume API for BullMQ `Queue.pause()` / `Queue.resume()`

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ package mkq
 // runtime/debug.ReadBuildInfo so it stays meaningful in unit tests
 // and in users who vendor mkq via tooling that doesn't preserve
 // build info. Bump it on every release.
-const Version = "1.0.3-dev"
+const Version = "1.0.3"
 
 // versionTag is the value written to meta.version. BullMQ TS writes
 // `bullmq:<semver>`; mkq mirrors the convention with a `mkq:` prefix


### PR DESCRIPTION
## Summary

Cut the **v1.0.3** release. Promotes the `1.0.3-dev` marker to `1.0.3` and moves the public pause/resume API (#70 / #71) from `Unreleased` into a dated `[1.0.3]` CHANGELOG section.

## Key Changes

- `version.go`: `Version` `1.0.3-dev` → `1.0.3` (stamped into `meta.version` as `mkq:1.0.3` at `Queue.Define`).
- `CHANGELOG.md`: new `## [1.0.3] - 2026-06-23` section with the pause/resume `Added` entry; `## [Unreleased]` retained (empty) at the top.

### Release contents (since v1.0.2)

- **Public `Queue.Pause` / `Queue.Resume` / `Queue.IsPaused`** — BullMQ `Queue.pause()` / `resume()` / `isPaused()` parity (vendored `pause-7.lua`). (#70, #71)

Note: the interop test-harness dependency bumps (#72, `qs` / `path-to-regexp`) are test-only and not consumer-facing, so they are intentionally omitted from the user-facing CHANGELOG (consistent with prior releases not tracking internal/CI changes).

## Testing

- `go build ./...` clean.
- `go test ./...` pass (the `meta.version` test asserts the `mkq:` prefix, not the exact semver, so the bump is non-breaking).

## Post-merge steps (follow-ups)

1. Tag `v1.0.3` on `main` (matching `v1.0.0`–`v1.0.2`).
2. Reset `develop` to `main` (force-push) to clear the stale divergence.
3. Optional: post-release `1.0.4-dev` bump (matching the `#69` pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)